### PR TITLE
Add dedicated plugin reducer

### DIFF
--- a/lib/reducers/index.js
+++ b/lib/reducers/index.js
@@ -1,6 +1,6 @@
 import { combineReducers } from 'redux';
 import core from './coreReducer';
-import { pluginReducer as plugin } from '../util/plugins';
+import plugin from './pluginReducer';
 
 export default combineReducers({
     core,

--- a/lib/reducers/pluginReducer.js
+++ b/lib/reducers/pluginReducer.js
@@ -1,0 +1,44 @@
+/* Copyright (c) 2016, Nordic Semiconductor ASA
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ *   2. Redistributions in binary form, except as embedded into a Nordic
+ *   Semiconductor ASA integrated circuit in a product or a software update for
+ *   such product, must reproduce the above copyright notice, this list of
+ *   conditions and the following disclaimer in the documentation and/or other
+ *   materials provided with the distribution.
+ *
+ *   3. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ *   4. This software, with or without modification, must only be used with a
+ *   Nordic Semiconductor ASA integrated circuit.
+ *
+ *   5. Any software provided in binary form under this license must not be
+ *   reverse engineered, decompiled, modified and/or disassembled.
+ *
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+ * GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import { decorateReducer } from '../util/plugins';
+
+const reducer = (state = {}) => state;
+
+export default decorateReducer(reducer, 'Plugin');

--- a/lib/util/plugins.js
+++ b/lib/util/plugins.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { connect as reduxConnect } from 'react-redux';
-import { Record } from 'immutable';
 import path from 'path';
 import { getPluginLocalDir, listDirectories, loadModule } from './fileUtil';
 
@@ -17,14 +16,6 @@ function loadPlugin(name) {
 
 function setPlugin(pluginObj) {
     plugin = pluginObj;
-}
-
-function pluginReducer(state = Record({}), action) {
-    // TODO: Use reducer from plugin
-    switch (action.type) {
-        default:
-            return state;
-    }
 }
 
 function getDecorated(parent, name) {
@@ -127,11 +118,10 @@ function connect(coreMapStateFn, coreMapDispatchFn, mergeProps, options = {}) {
     );
 }
 
-export {
+export default {
     getAvailablePlugins,
     loadPlugin,
     setPlugin,
-    pluginReducer,
     decorateReducer,
     decorate,
     connect,


### PR DESCRIPTION
The core comes with its own reducers, such as `adapterReducer`, `logReducer`, and `navMenuReducer`, scoped below `core` in state. Plugins get their own section of the state below `plugin`:

```
{
    core: {
        adapter: {},
        log: {},
        navMenu: {},
    },
    plugin: {
        /* plugin state */
    },
}
```

The application comes with a `pluginReducer` that returns an empty object by default. Plugins can decorate this and build their own state hierarchy, f.ex:

```
import { combineReducers } from 'redux';
import discovery from './reducers/discoveryReducer';
import advertising from './reducers/advertisingReducer';

const plugin = {
    reducePlugin: combineReducers({
        discovery: discoveryReducer,
        advertising: advertisingReducer,
    }),
};
```

Or, if the plugin is very simple, the state can be added directly on `state.plugin`:

```
const plugin = {
    reducePlugin: (state, action) => {
        switch (action.type) {
            case 'FOO_ACTION':
                return Object.assign({}, state, {
                    fooValue: action.value,
                });
            default:
                return state;
        }
    },
};
```

Plugins have full control over the state below `state.plugin`. Some may want to use Immutable.js, while other may not. However, the reducers below `state.core` use Immutable records, so if plugins want to decorate those, they have to use the Immutable API.