### PR TITLE
Allow custom device

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
         "electron-updater": "4.0.14",
         "fs-extra": "8.1.0",
         "mustache": "3.0.1",
-        "nrf-device-setup": "0.6.2",
+        "nrf-device-setup": "0.6.3",
         "pc-ble-driver-js": "2.6.2",
         "react-markdown": "4.1.0",
         "roboto-fontface": "0.10.0",


### PR DESCRIPTION
This PR is to avoid deselecting device when error occurs during device setup. It allows apps to use custom device even though there is no firmware provided for such devices in the apps.