### PR TITLE
Enhance removed sources handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
         "electron-devtools-installer": "2.2.4",
         "electron-is-dev": "1.1.0",
         "mini-css-extract-plugin": "0.8.0",
-        "pc-nrfconnect-shared": "github:NordicSemiconductor/pc-nrfconnect-shared#v4.0.0",
+        "pc-nrfconnect-shared": "github:NordicSemiconductor/pc-nrfconnect-shared#v4.1.0",
         "react-infinite": "github:NordicSemiconductor/react-infinite#react-15.5",
         "spectron": "7.0.0",
         "tar": "4.4.10",

--- a/src/launcher/actions/appsActions.js
+++ b/src/launcher/actions/appsActions.js
@@ -347,9 +347,13 @@ export function downloadLatestAppInfo(options = { rejectIfError: false }) {
                 dispatch(downloadLatestAppInfoErrorAction());
                 if (options.rejectIfError) {
                     throw error;
+                } else if (net.isResourceNotFound(error)) {
+                    dispatch(ErrorDialogActions.showDialog(
+                        `Unable to retrieve the source “${error.cause.name}” from ${error.cause.url}. \n\n`
+                        + 'This is usually caused by an outdated source file, which was removed from the server.',
+                    ));
                 } else {
-                    dispatch(ErrorDialogActions.showDialog('Unable to download '
-                        + `latest app info: ${error.message}`));
+                    dispatch(ErrorDialogActions.showDialog(`Unable to download latest app info: ${error.message}`));
                 }
             });
     };

--- a/src/launcher/actions/appsActions.js
+++ b/src/launcher/actions/appsActions.js
@@ -38,6 +38,9 @@ import { join } from 'path';
 import { ipcRenderer, remote } from 'electron';
 import { ErrorDialogActions } from 'pc-nrfconnect-shared';
 
+// eslint-disable-next-line import/no-cycle
+import { removeSource } from './settingsActions';
+
 const net = remote.require('../main/net');
 const fs = remote.require('fs');
 
@@ -350,7 +353,17 @@ export function downloadLatestAppInfo(options = { rejectIfError: false }) {
                 } else if (net.isResourceNotFound(error)) {
                     dispatch(ErrorDialogActions.showDialog(
                         `Unable to retrieve the source “${error.cause.name}” from ${error.cause.url}. \n\n`
-                        + 'This is usually caused by an outdated source file, which was removed from the server.',
+                        + 'This is usually caused by outdated app sources in the settings, '
+                        + 'where the sources files was removed from the server.',
+                        {
+                            'Remove source': () => {
+                                dispatch(removeSource(error.cause.name));
+                                dispatch(ErrorDialogActions.hideDialog());
+                            },
+                            Cancel: () => {
+                                dispatch(ErrorDialogActions.hideDialog());
+                            },
+                        },
                     ));
                 } else {
                     dispatch(ErrorDialogActions.showDialog(`Unable to download latest app info: ${error.message}`));

--- a/src/launcher/actions/appsActions.js
+++ b/src/launcher/actions/appsActions.js
@@ -38,9 +38,6 @@ import { join } from 'path';
 import { ipcRenderer, remote } from 'electron';
 import { ErrorDialogActions } from 'pc-nrfconnect-shared';
 
-// eslint-disable-next-line import/no-cycle
-import { removeSource } from './settingsActions';
-
 const net = remote.require('../main/net');
 const fs = remote.require('fs');
 
@@ -180,19 +177,19 @@ function upgradeOfficialAppErrorAction() {
     };
 }
 
-function downloadLatestAppInfoAction() {
+export function downloadLatestAppInfoAction() {
     return {
         type: DOWNLOAD_LATEST_APP_INFO,
     };
 }
 
-function downloadLatestAppInfoSuccessAction() {
+export function downloadLatestAppInfoSuccessAction() {
     return {
         type: DOWNLOAD_LATEST_APP_INFO_SUCCESS,
     };
 }
 
-function downloadLatestAppInfoErrorAction() {
+export function downloadLatestAppInfoErrorAction() {
     return {
         type: DOWNLOAD_LATEST_APP_INFO_ERROR,
     };
@@ -334,40 +331,6 @@ export function loadOfficialApps(appName, appSource) {
                 dispatch(loadOfficialAppsError());
                 dispatch(ErrorDialogActions.showDialog('Unable to load apps: '
                     + `${error.message}`));
-            });
-    };
-}
-
-export function downloadLatestAppInfo(options = { rejectIfError: false }) {
-    return dispatch => {
-        dispatch(downloadLatestAppInfoAction());
-
-        return mainApps.downloadAppsJsonFiles()
-            .then(() => mainApps.generateUpdatesJsonFiles())
-            .then(() => dispatch(downloadLatestAppInfoSuccessAction()))
-            .then(() => dispatch(loadOfficialApps()))
-            .catch(error => {
-                dispatch(downloadLatestAppInfoErrorAction());
-                if (options.rejectIfError) {
-                    throw error;
-                } else if (net.isResourceNotFound(error)) {
-                    dispatch(ErrorDialogActions.showDialog(
-                        `Unable to retrieve the source “${error.cause.name}” from ${error.cause.url}. \n\n`
-                        + 'This is usually caused by outdated app sources in the settings, '
-                        + 'where the sources files was removed from the server.',
-                        {
-                            'Remove source': () => {
-                                dispatch(removeSource(error.cause.name));
-                                dispatch(ErrorDialogActions.hideDialog());
-                            },
-                            Cancel: () => {
-                                dispatch(ErrorDialogActions.hideDialog());
-                            },
-                        },
-                    ));
-                } else {
-                    dispatch(ErrorDialogActions.showDialog(`Unable to download latest app info: ${error.message}`));
-                }
             });
     };
 }

--- a/src/launcher/actions/settingsActions.js
+++ b/src/launcher/actions/settingsActions.js
@@ -37,9 +37,7 @@
 import { remote } from 'electron';
 import { ErrorDialogActions } from 'pc-nrfconnect-shared';
 
-// eslint-disable-next-line import/no-cycle
 import * as AppsActions from './appsActions';
-import * as AutoUpdateActions from './autoUpdateActions';
 
 const settings = remote.require('../main/settings');
 const mainApps = remote.require('../main/apps');
@@ -125,19 +123,6 @@ export function hideUpdateCheckCompleteDialog() {
     return {
         type: SETTINGS_UPDATE_CHECK_COMPLETE_DIALOG_HIDE,
     };
-}
-
-export function checkForUpdatesButtonClicked() {
-    return dispatch => (
-        dispatch(AppsActions.downloadLatestAppInfo({ rejectIfError: true }))
-            .then(() => {
-                dispatch(AutoUpdateActions.checkForCoreUpdates());
-                dispatch(showUpdateCheckCompleteDialog());
-            })
-            .catch(error => (
-                dispatch(ErrorDialogActions.showDialog(`Unable to check for updates: ${error.message}`))
-            ))
-    );
 }
 
 function addSourceAction(name, url) {

--- a/src/launcher/actions/settingsActions.js
+++ b/src/launcher/actions/settingsActions.js
@@ -37,6 +37,7 @@
 import { remote } from 'electron';
 import { ErrorDialogActions } from 'pc-nrfconnect-shared';
 
+// eslint-disable-next-line import/no-cycle
 import * as AppsActions from './appsActions';
 import * as AutoUpdateActions from './autoUpdateActions';
 

--- a/src/launcher/containers/SettingsContainer.js
+++ b/src/launcher/containers/SettingsContainer.js
@@ -37,6 +37,7 @@
 import { connect } from 'react-redux';
 import SettingsView from '../components/SettingsView';
 import * as SettingsActions from '../actions/settingsActions';
+import * as AutoUpdateActions from '../actions/autoUpdateActions';
 
 function isAppUpdateAvailable(officialApps) {
     return !!officialApps.find(app => app.latestVersion
@@ -66,7 +67,7 @@ function mapDispatchToProps(dispatch) {
             dispatch(SettingsActions.checkUpdatesAtStartupChanged(isEnabled))
         ),
         onTriggerUpdateCheck: () => (
-            dispatch(SettingsActions.checkForUpdatesButtonClicked())
+            dispatch(AutoUpdateActions.checkForUpdatesManually())
         ),
         onHideUpdateCheckCompleteDialog: () => (
             dispatch(SettingsActions.hideUpdateCheckCompleteDialog())

--- a/src/launcher/index.js
+++ b/src/launcher/index.js
@@ -63,7 +63,7 @@ const shouldCheckForUpdatesAtStartup = settings.get('shouldCheckForUpdatesAtStar
 
 function downloadLatestAppInfo() {
     if (shouldCheckForUpdatesAtStartup !== false && !config.isSkipUpdateApps()) {
-        return store.dispatch(AppsActions.downloadLatestAppInfo());
+        return store.dispatch(AutoUpdateActions.downloadLatestAppInfo());
     }
     return Promise.resolve();
 }

--- a/src/main/net.js
+++ b/src/main/net.js
@@ -161,9 +161,18 @@ function downloadToFile(url, filePath, enableProxyLogin) {
     });
 }
 
+/**
+ * Does this error mean, that a resource was not found on the server?
+ *
+ * @param {object} error An error caught when trying to retrieve something from a server.
+ * @returns {boolean} Whether this error means, that a resource was not found on the server.
+ */
+const isResourceNotFound = error => error.statusCode === 404;
+
 module.exports = {
     downloadToFile,
     downloadToStringIfChanged,
     downloadToJson,
+    isResourceNotFound,
     registerProxyLoginHandler,
 };


### PR DESCRIPTION
This fixes [NCP-2674](https://projecttools.nordicsemi.no/jira/browse/NCP-2674).

When the launchers gets a 404 for a source, it now displays this dialog, which explains the situation better and lets users directly remove the broken source:
![image](https://user-images.githubusercontent.com/260705/71360575-a3180480-2590-11ea-977b-9bb614045794.png)

For other error (e.g. when the user is offline), the old error message is still shown:
![image](https://user-images.githubusercontent.com/260705/71360693-f12d0800-2590-11ea-9905-eb096487e47c.png)

As you can see, even the latter case is slightly enhanced, because the URLs are now clickable.

The main change is done in the first two commits, the third was only needed to break a mostly harmless import cycle.
