### PR TITLE
Upgrade serialport

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
         "electron-updater": "4.0.14",
         "fs-extra": "8.1.0",
         "mustache": "3.0.1",
-        "nrf-device-setup": "0.6.3",
+        "nrf-device-setup": "0.6.5",
         "pc-ble-driver-js": "2.6.2",
         "react-markdown": "4.1.0",
         "roboto-fontface": "0.10.0",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
     "main": "src/main",
     "scripts": {
         "start": "echo 'please run `npm run dev` in one tab and then `npm run app` in another one'",
-        "postinstall": "npm run get-jlink && npm run fix-serialport",
-        "fix-serialport": "cp ./serialport-prebuild-installrc ./node_modules/@serialport/bindings/.prebuild-installrc && electron-builder install-app-deps",
+        "postinstall": "npm run get-jlink",
         "app": "electron .",
         "dev": "nrfconnect-scripts build-watch",
         "webpack": "nrfconnect-scripts build-dev",

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
         "electron-updater": "4.0.14",
         "fs-extra": "8.1.0",
         "mustache": "3.0.1",
-        "nrf-device-setup": "0.6.5",
+        "nrf-device-setup": "0.6.6",
         "pc-ble-driver-js": "2.6.2",
         "react-markdown": "4.1.0",
         "roboto-fontface": "0.10.0",

--- a/serialport-prebuild-installrc
+++ b/serialport-prebuild-installrc
@@ -1,3 +1,0 @@
-tag-prefix=@serialport/bindings@
-verbose=true
-compile=true

--- a/src/app/module-loader.js
+++ b/src/app/module-loader.js
@@ -52,8 +52,30 @@ Module._load = function load(modulePath) { // eslint-disable-line no-underscore-
     return originalLoad.apply(this, arguments); // eslint-disable-line prefer-rest-params
 };
 
+
+const SerialPort = require('serialport');
+
+let hasShownDeprecatedPropertyWarning = false;
+const mayShowWarningAboutDeprecatedProperty = () => {
+    if (!hasShownDeprecatedPropertyWarning) {
+        console.warn('Using the property "comName" has been deprecated. You should now use "path". The property will be removed in the next major release.');
+    }
+    hasShownDeprecatedPropertyWarning = true;
+};
+const ducktapeComName = port => ({
+    ...port,
+    get comName() {
+        mayShowWarningAboutDeprecatedProperty();
+        return port.path;
+    },
+});
+
+const originalSerialPortList = SerialPort.list;
+SerialPort.list = () => originalSerialPortList().then(ports => ports.map(ducktapeComName));
+
 /* eslint-disable dot-notation */
 // Disable dot-notation in this file, to keep the syntax below more consistent
+hostedModules['serialport'] = SerialPort;
 
 hostedModules['electron'] = require('electron');
 hostedModules['nrf-device-setup'] = require('nrf-device-setup');
@@ -65,7 +87,6 @@ hostedModules['react-redux'] = require('react-redux');
 hostedModules['react'] = require('react');
 hostedModules['redux-devtools-extension'] = require('redux-devtools-extension');
 hostedModules['redux-thunk'] = require('redux-thunk');
-hostedModules['serialport'] = require('serialport');
 hostedModules['usb'] = require('usb');
 
 const bleDriverJs = require('pc-ble-driver-js');

--- a/src/legacy/api/jlink/index.js
+++ b/src/legacy/api/jlink/index.js
@@ -36,6 +36,7 @@
 
 import SerialPort from 'serialport';
 import JlinkFacade from './jlinkFacade';
+import portPath from '../../portPath';
 
 const SEGGER_VENDOR_ID = '1366';
 
@@ -48,7 +49,7 @@ const SEGGER_VENDOR_ID = '1366';
  */
 function getSeggerComNames(ports) {
     return ports.filter(port => port.vendorId === SEGGER_VENDOR_ID)
-        .map(port => port.comName);
+        .map(port => port.path);
 }
 
 function getPortsWithSerialNumberOnWindows(ports, onWarning) {
@@ -60,7 +61,7 @@ function getPortsWithSerialNumberOnWindows(ports, onWarning) {
         facade.getSerialNumberMap(seggerComNames)
             .then(map => {
                 map.forEach((serialNumber, comName) => {
-                    const port = decoratedPorts.find(p => p.comName === comName);
+                    const port = decoratedPorts.find(p => portPath(p) === comName);
                     port.serialNumber = serialNumber;
                 });
                 resolve(decoratedPorts);
@@ -95,12 +96,12 @@ export function decorateWithSerialNumber(ports, onWarning = () => {}) {
  * Try to open and close the given serial port to see if it is available. This
  * is needed to identify if a SEGGER J-Link device is in a bad state.
  *
- * @param {string} comName The COM name to check.
+ * @param {string} path The system path of the serial port you want to check.
  * @returns {Promise} Promise that resolves if available, and rejects if not.
  */
-export function isPortAvailable(comName) {
+export function isPortAvailable(path) {
     return new Promise((resolve, reject) => {
-        const serialPort = new SerialPort(comName, { autoOpen: false });
+        const serialPort = new SerialPort(path, { autoOpen: false });
         serialPort.open(openErr => {
             if (openErr) {
                 reject(openErr);

--- a/src/legacy/app/actions/serialPortActions.js
+++ b/src/legacy/app/actions/serialPortActions.js
@@ -37,6 +37,7 @@
 import SerialPort from 'serialport';
 import { logger } from 'pc-nrfconnect-shared';
 import { isPortAvailable, decorateWithSerialNumber } from '../../api/jlink';
+import portPath from '../../portPath';
 
 /**
  * Indicates that loading all available serial ports has been requested. This action is
@@ -112,7 +113,7 @@ function selectorToggleExpandedAction() {
     };
 }
 
-function selectPortAction(port) {
+export function selectPortAction(port) {
     return {
         type: SERIAL_PORT_SELECTED,
         port,
@@ -122,15 +123,12 @@ function selectPortAction(port) {
 export function loadPorts() {
     return dispatch => {
         dispatch(loadPortsAction());
-        SerialPort.list((err, ports) => {
-            if (err) {
-                dispatch(loadPortsErrorAction(err.message));
-            } else {
-                decorateWithSerialNumber(ports)
-                    .then(finalPorts => dispatch(loadPortsSuccessAction(finalPorts)))
-                    .catch(error => loadPortsErrorAction(error.message));
-            }
-        });
+
+        SerialPort
+            .list()
+            .then(decorateWithSerialNumber)
+            .then(finalPorts => dispatch(loadPortsSuccessAction(finalPorts)))
+            .catch(error => loadPortsErrorAction(error.message));
     };
 }
 
@@ -146,7 +144,7 @@ export function toggleSelectorExpanded() {
 
 export function selectPort(port) {
     return dispatch => {
-        isPortAvailable(port.comName)
+        isPortAvailable(portPath(port))
             .then(() => dispatch(selectPortAction(port)))
             .catch(error => {
                 logger.error('Unable to open the port. Please power cycle the device and try again.');

--- a/src/legacy/app/components/DeviceSelector.jsx
+++ b/src/legacy/app/components/DeviceSelector.jsx
@@ -40,6 +40,7 @@ import Dropdown from 'react-bootstrap/Dropdown';
 import { Iterable } from 'immutable';
 
 import HotkeyedDropdown from '../../components/HotkeyedDropdown';
+import portPath from '../../portPath';
 
 // Stateless, templating-only component. Used only from ../containers/DeviceSelectorContainer
 export default class DeviceSelector extends React.Component {
@@ -53,7 +54,7 @@ export default class DeviceSelector extends React.Component {
     static mapSerialPortsToListItems(device) {
         return Object.keys(device)
             .filter(key => key.startsWith('serialport'))
-            .map(key => <li key={device[key].comName}>Serial port: {device[key].comName}</li>);
+            .map(key => <li key={key}>Serial port: {portPath(device[key])}</li>);
     }
 
     componentDidMount() {

--- a/src/legacy/app/components/FirmwareDialog.jsx
+++ b/src/legacy/app/components/FirmwareDialog.jsx
@@ -37,6 +37,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+import portPath from '../../portPath';
 import ConfirmationDialog from '../../components/ConfirmationDialog';
 
 const FirmwareDialog = ({
@@ -49,7 +50,7 @@ const FirmwareDialog = ({
 }) => {
     if (isVisible) {
         const textToUse = text || 'Would you like to program the development kit'
-            + ` on ${port.comName} (${port.serialNumber})`
+            + ` on ${portPath(port)} (${port.serialNumber})`
             + ' with the required firmware?';
         return (
             <ConfirmationDialog
@@ -71,6 +72,7 @@ FirmwareDialog.propTypes = {
     isInProgress: PropTypes.bool,
     port: PropTypes.shape({
         comName: PropTypes.string,
+        path: PropTypes.string,
         serialNumber: PropTypes.number,
     }),
     text: PropTypes.string,

--- a/src/legacy/app/components/SerialPortSelector.jsx
+++ b/src/legacy/app/components/SerialPortSelector.jsx
@@ -39,6 +39,7 @@ import PropTypes from 'prop-types';
 import Dropdown from 'react-bootstrap/Dropdown';
 import { Iterable } from 'immutable';
 
+import portPath from '../../portPath';
 import HotkeyedDropdown from '../../components/HotkeyedDropdown';
 
 const SEGGER_VENDOR_IDS = new Set(['0x1366', '1366']);
@@ -62,12 +63,12 @@ class SerialPortSelector extends React.Component {
                 .filter(filter)
                 .map(port => (
                     <Dropdown.Item
-                        key={port.comName}
+                        key={portPath(port)}
                         className={menuItemCssClass}
-                        eventKey={port.comName}
+                        eventKey={portPath(port)}
                         onSelect={() => onSelect(port)}
                     >
-                        <div>{port.comName}</div>
+                        <div>{portPath(port)}</div>
                         <div style={{ fontSize: 'small' }}>{port.serialNumber || ''}</div>
                     </Dropdown.Item>
                 ));

--- a/src/legacy/app/components/__tests__/DeviceSelector-test.jsx
+++ b/src/legacy/app/components/__tests__/DeviceSelector-test.jsx
@@ -71,10 +71,10 @@ describe('DeviceSelector', () => {
                     {
                         serialNumber: '123456789',
                         serialport: {
-                            comName: '/dev/ttyACM0',
+                            path: '/dev/ttyACM0',
                         },
                         'serialport.1': {
-                            comName: '/dev/ttyACM1',
+                            path: '/dev/ttyACM1',
                         },
                         usb: {
                             manufacturer: 'Nordic Semiconductor',

--- a/src/legacy/app/components/__tests__/FirmwareDialog-test.jsx
+++ b/src/legacy/app/components/__tests__/FirmwareDialog-test.jsx
@@ -59,7 +59,7 @@ describe('FirmwareDialog', () => {
             <FirmwareDialog
                 isVisible
                 port={{
-                    comName: '/dev/tty1',
+                    path: '/dev/tty1',
                     serialNumber: 1337,
                 }}
                 onCancel={() => {}}

--- a/src/legacy/app/components/__tests__/SerialPortSelector-test.jsx
+++ b/src/legacy/app/components/__tests__/SerialPortSelector-test.jsx
@@ -73,11 +73,11 @@ describe('SerialPortSelector', () => {
             <SerialPortSelector
                 ports={[
                     {
-                        comName: '/dev/tty0',
+                        path: '/dev/tty0',
                         serialNumber: '123456',
                         vendorId: SEGGER_VENDOR_ID,
                     }, {
-                        comName: '/dev/tty1',
+                        path: '/dev/tty1',
                         serialNumber: '456789',
                         vendorId: SEGGER_VENDOR_ID,
                     },
@@ -95,11 +95,11 @@ describe('SerialPortSelector', () => {
             <SerialPortSelector
                 ports={[
                     {
-                        comName: '/dev/tty0',
+                        path: '/dev/tty0',
                         serialNumber: '123456',
                         vendorId: '0x1234',
                     }, {
-                        comName: '/dev/tty1',
+                        path: '/dev/tty1',
                         serialNumber: '456789',
                         vendorId: SEGGER_VENDOR_ID,
                     },
@@ -117,11 +117,11 @@ describe('SerialPortSelector', () => {
             <SerialPortSelector
                 ports={[
                     {
-                        comName: '/dev/tty0',
+                        path: '/dev/tty0',
                         serialNumber: '123456',
                         vendorId: '0x1234',
                     }, {
-                        comName: '/dev/tty1',
+                        path: '/dev/tty1',
                         serialNumber: '456789',
                         vendorId: SEGGER_VENDOR_ID,
                     },
@@ -140,11 +140,11 @@ describe('SerialPortSelector', () => {
             <SerialPortSelector
                 ports={[
                     {
-                        comName: '/dev/tty0',
+                        path: '/dev/tty0',
                         serialNumber: '123456',
                         vendorId: SEGGER_VENDOR_ID,
                     }, {
-                        comName: '/dev/tty1',
+                        path: '/dev/tty1',
                         serialNumber: '456789',
                         vendorId: SEGGER_VENDOR_ID,
                     },
@@ -163,7 +163,7 @@ describe('SerialPortSelector', () => {
             <SerialPortSelector
                 ports={[
                     {
-                        comName: '/dev/tty0',
+                        path: '/dev/tty0',
                         serialNumber: '123456',
                         vendorId: SEGGER_VENDOR_ID,
                     },
@@ -182,7 +182,7 @@ describe('SerialPortSelector', () => {
             <SerialPortSelector
                 ports={[
                     {
-                        comName: '/dev/tty0',
+                        path: '/dev/tty0',
                         serialNumber: '123456',
                         vendorId: SEGGER_VENDOR_ID,
                     },

--- a/src/legacy/app/reducers/__tests__/firmwareDialogReducer-test.js
+++ b/src/legacy/app/reducers/__tests__/firmwareDialogReducer-test.js
@@ -47,6 +47,7 @@ describe('firmwareDialogReducer', () => {
     it('should be visible and have a port object after show action has been dispatched', () => {
         const port = {
             comName: '/dev/tty1',
+            path: '/dev/tty1',
             manufacturer: null,
             productId: null,
             serialNumber: null,
@@ -68,7 +69,7 @@ describe('firmwareDialogReducer', () => {
     });
 
     it('should be hidden, with no port, and not in progress after hide action has been dispatched', () => {
-        const port = { comName: '/dev/tty1' };
+        const port = { path: '/dev/tty1' };
         const firstState = reducer(initialState, {
             type: FirmwareDialogActions.FIRMWARE_DIALOG_SHOW,
             port,

--- a/src/legacy/app/reducers/__tests__/serialPortReducer-test.js
+++ b/src/legacy/app/reducers/__tests__/serialPortReducer-test.js
@@ -69,7 +69,7 @@ describe('serialPortReducer', () => {
 
     it('should add port metadata to state when loading ports has succeeded', () => {
         const seggerPort = {
-            comName: '/dev/tty1',
+            path: '/dev/tty1',
             vendorId: SEGGER_VENDOR_ID,
             manufacturer: 'SEGGER',
             serialNumber: 'SEGGER_J-Link_000680551615',
@@ -83,6 +83,7 @@ describe('serialPortReducer', () => {
 
         expect(state.ports.first().toJS()).toEqual({
             comName: '/dev/tty1',
+            path: '/dev/tty1',
             vendorId: SEGGER_VENDOR_ID,
             manufacturer: 'SEGGER',
             serialNumber: 680551615,
@@ -106,12 +107,7 @@ describe('serialPortReducer', () => {
     });
 
     it('should set selected port comPort when port has been selected', () => {
-        const state = reducer(initialState, {
-            type: SerialPortActions.SERIAL_PORT_SELECTED,
-            port: {
-                comName: '/dev/tty1',
-            },
-        });
+        const state = reducer(initialState, SerialPortActions.selectPortAction({ path: '/dev/tty1' }));
         expect(state.selectedPort).toEqual('/dev/tty1');
     });
 

--- a/src/legacy/app/reducers/serialPortReducer.js
+++ b/src/legacy/app/reducers/serialPortReducer.js
@@ -80,7 +80,7 @@ function toggleSelectorExpanded(state) {
 }
 
 function setSelectedPort(state, port) {
-    return state.set('selectedPort', port.comName);
+    return state.set('selectedPort', port.path);
 }
 
 function clearSelectedPort(state) {

--- a/src/legacy/portPath.js
+++ b/src/legacy/portPath.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2015 - 2017, Nordic Semiconductor ASA
+/* Copyright (c) 2015 - 2019, Nordic Semiconductor ASA
  *
  * All rights reserved.
  *
@@ -34,50 +34,5 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { Record } from 'immutable';
-import portPath from '../../portPath';
-
-const ImmutableSerialPort = Record({
-    comName: null,
-    path: null,
-    serialNumber: null,
-    manufacturer: null,
-    vendorId: null,
-    productId: null,
-});
-
-const ImmutableDevice = Record({
-    comName: null,
-    path: null,
-    busNumber: null,
-    deviceAddress: null,
-    serialNumber: null,
-    manufacturer: null,
-    product: null,
-    vendorId: null,
-    productId: null,
-});
-
-function getImmutableSerialPort(serialPort) {
-    return new ImmutableSerialPort({
-        comName: portPath(serialPort),
-        path: portPath(serialPort),
-        serialNumber: serialPort.serialNumber,
-        vendorId: serialPort.vendorId,
-        productId: serialPort.productId,
-        manufacturer: serialPort.manufacturer,
-    });
-}
-
-function getImmutableDevice(device) {
-    return new ImmutableDevice({
-        ...device,
-        comName: portPath(device),
-        path: portPath(device),
-    });
-}
-
-export {
-    getImmutableSerialPort,
-    getImmutableDevice,
-};
+// Prefer to use the serialport 8 property or fall back to the serialport 7 property
+export default serialPort => serialPort.path || serialPort.comName;


### PR DESCRIPTION
Part of [NCP-2996](https://projecttools.nordicsemi.no/jira/browse/NCP-2996).

The main change of the upgraded nrf-device-setup dependency is that it brings in serialport 8, from which two changes are especially relevant for us:
- `SerialPort.list` does not take a callback anymore but instead you now always have to use the returned Promise.
- The property `comName` on ports is deprecated (though still supported) and one should use the property `path` instead.