### PR TITLE
Notarize macOS build (#419)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *~
 .DS_Store
 .idea
+.env
 build/nrfjprog
 build/JLink*
 dist

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,9 +16,9 @@ jobs:
   strategy:
     matrix:
       linux:
-        IMAGE_NAME: 'ubuntu-16.04'
+        IMAGE_NAME: 'ubuntu-18.04'
       macOS:
-        IMAGE_NAME: 'macos-10.13'
+        IMAGE_NAME: 'macos-10.15'
       win32:
         IMAGE_NAME: 'vs2017-win2016'
         ARCH: 'ia32'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -94,7 +94,11 @@ jobs:
   - bash: |
       export CSC_LINK=$(Agent.TempDirectory)/NORDIC_SIGNING_CERTIFICATE.p12
       export CSC_KEY_PASSWORD=$(NORDIC_SIGNING_CERTIFICATE_PASSWORD_P12)
-      npx build -p never
+      export APPLEID=$(WAYLAND_APPLE_ID)
+      export APPLEIDPASS=$(WAYLAND_APPLE_ID_PASS)
+      rm -f node_modules/pc-nrfjprog-js/nrfjprog/._*
+      rm -f node_modules/pc-nrfjprog-js/build/Release/._*
+      npx electron-builder -p never
     condition: and(ne(variables['Build.Reason'], 'PullRequest'), contains(variables['IMAGE_NAME'], 'mac'))
     displayName: 'Release on macOS'
   - bash: |

--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+  </dict>
+</plist>
+

--- a/build/notarize.js
+++ b/build/notarize.js
@@ -1,0 +1,15 @@
+require('dotenv').config();
+const { notarize } = require('electron-notarize');
+const pkgJson = require('../package.json');
+
+exports.default = async ({ electronPlatformName, appOutDir }) => (
+  (electronPlatformName === 'darwin')
+  ? await notarize({
+    appBundleId: pkgJson.build.appId,
+    appPath: `${appOutDir}/${pkgJson.build.productName}.app`,
+    appleId: process.env.APPLEID,
+    appleIdPassword: process.env.APPLEIDPASS,
+  })
+  : undefined
+);
+

--- a/package.json
+++ b/package.json
@@ -26,14 +26,15 @@
         "clean-release": "rimraf release",
         "clean-modules": "rimraf \"node_modules/!(rimraf|.bin)\"",
         "get-jlink": "get-jlink -o build",
-        "pack": "npm run build && build -p never",
-        "release": "build -p always"
+        "pack": "npm run build && electron-builder -p never",
+        "release": "electron-builder -p always"
     },
     "author": "Nordic Semiconductor ASA",
     "license": "Proprietary",
     "build": {
         "appId": "com.nordicsemi.nrfconnect",
         "productName": "nRF Connect",
+        "npmRebuild": false,
         "publish": [
             "github"
         ],
@@ -67,9 +68,14 @@
             ],
             "category": "Development"
         },
+        "afterSign": "build/notarize.js",
         "mac": {
             "category": "public.app-category.developer-tools",
             "artifactName": "${name}-${version}-${os}.${ext}",
+            "hardenedRuntime": true,
+            "gatekeeperAssess": false,
+            "entitlements": "build/entitlements.mac.plist",
+            "entitlementsInherit": "build/entitlements.mac.plist",
             "extraFiles": [
                 {
                     "from": "node_modules/pc-nrfjprog-js/nrfjprog",
@@ -79,7 +85,8 @@
             ]
         },
         "dmg": {
-            "artifactName": "${name}-${version}.${ext}"
+            "artifactName": "${name}-${version}.${ext}",
+            "sign": false
         },
         "win": {
             "target": [
@@ -104,8 +111,9 @@
         "asar": "2.0.1",
         "bootstrap": "4.3.1",
         "electron": "5.0.6",
-        "electron-builder": "20.44.4",
+        "electron-builder": "22.4.1",
         "electron-is-dev": "1.1.0",
+        "electron-notarize": "0.2.1",
         "mini-css-extract-plugin": "0.8.0",
         "moment": "2.24.0",
         "mousetrap": "1.6.3",


### PR DESCRIPTION
In case we need to release any updates to 3.3 this cherry-picked change should let us correctly build on  CI.