### PR TITLE
Move Filter and Search to the left side

### DIFF
--- a/src/launcher/components/AppManagementFilter.jsx
+++ b/src/launcher/components/AppManagementFilter.jsx
@@ -158,19 +158,6 @@ const AppManagementFilter = ({
     setAppManagementSource,
 }) => (
     <div className="filterbox mb-3 w-100 d-inline-flex">
-        { upgradeableApps.size > 0 && (
-            <Button
-                variant="outline-secondary"
-                onClick={() => upgradeableApps.forEach(
-                    ({ name, latestVersion, source }) => (
-                        onUpgrade(name, latestVersion, source)
-                    ),
-                )}
-            >
-                Update all apps
-            </Button>
-        )}
-        <div className="flex-fill" />
         <FilterDropdown
             sources={sources}
             show={show}
@@ -183,6 +170,19 @@ const AppManagementFilter = ({
             value={filter}
             onChange={({ target }) => setAppManagementFilter(target.value)}
         />
+        <div className="flex-fill" />
+        { upgradeableApps.size > 0 && (
+            <Button
+                variant="outline-secondary"
+                onClick={() => upgradeableApps.forEach(
+                    ({ name, latestVersion, source }) => (
+                        onUpgrade(name, latestVersion, source)
+                    ),
+                )}
+            >
+                Update all apps
+            </Button>
+        )}
     </div>
 );
 


### PR DESCRIPTION
This PR moves the Filter and Search components to the left, the Update All Apps button to the right side.

<img width="763" alt="Screenshot 2020-04-20 at 09 27 53" src="https://user-images.githubusercontent.com/26139379/79725979-59df8380-82ea-11ea-83c9-d9ee73e02caa.png">
