### PR TITLE
Fix: No engine warning for available apps

### DIFF
--- a/src/launcher/components/AppIcon.jsx
+++ b/src/launcher/components/AppIcon.jsx
@@ -64,6 +64,7 @@ function renderNotice(app) {
 
 const AppIcon = ({ app }) => {
     const { engineVersion, iconPath } = app;
+    const installed = !!app.currentVersion;
     const primaryColorNeedsUpdate = engineVersion && semver.lt(semver.minVersion(engineVersion), '3.2.0');
     return (
         <div
@@ -80,7 +81,7 @@ const AppIcon = ({ app }) => {
                 alt=""
                 draggable={false}
             />
-            {renderNotice(app)}
+            {installed && renderNotice(app)}
         </div>
     );
 };
@@ -88,6 +89,7 @@ const AppIcon = ({ app }) => {
 AppIcon.propTypes = {
     app: PropTypes.shape({
         iconPath: PropTypes.string,
+        currentVersion: PropTypes.string,
         engineVersion: PropTypes.string,
         isSupportedEngine: PropTypes.bool,
         url: PropTypes.string,

--- a/src/launcher/components/__tests__/__snapshots__/AppManagementView-test.jsx.snap
+++ b/src/launcher/components/__tests__/__snapshots__/AppManagementView-test.jsx.snap
@@ -54,15 +54,6 @@ Array [
             draggable={false}
             src=""
           />
-          <div>
-            <span
-              className="alert-icon-bg"
-            />
-            <span
-              className="mdi mdi-alert"
-              title="The app does not specify which nRF Connect version(s) it supports"
-            />
-          </div>
         </div>
       </div>
       <div
@@ -463,15 +454,6 @@ Array [
             draggable={false}
             src=""
           />
-          <div>
-            <span
-              className="alert-icon-bg"
-            />
-            <span
-              className="mdi mdi-alert"
-              title="The app does not specify which nRF Connect version(s) it supports"
-            />
-          </div>
         </div>
       </div>
       <div
@@ -555,15 +537,6 @@ Array [
             draggable={false}
             src=""
           />
-          <div>
-            <span
-              className="alert-icon-bg"
-            />
-            <span
-              className="mdi mdi-alert"
-              title="The app does not specify which nRF Connect version(s) it supports"
-            />
-          </div>
         </div>
       </div>
       <div
@@ -647,15 +620,6 @@ Array [
             draggable={false}
             src=""
           />
-          <div>
-            <span
-              className="alert-icon-bg"
-            />
-            <span
-              className="mdi mdi-alert"
-              title="The app does not specify which nRF Connect version(s) it supports"
-            />
-          </div>
         </div>
       </div>
       <div
@@ -806,15 +770,6 @@ Array [
             draggable={false}
             src=""
           />
-          <div>
-            <span
-              className="alert-icon-bg"
-            />
-            <span
-              className="mdi mdi-alert"
-              title="The app does not specify which nRF Connect version(s) it supports"
-            />
-          </div>
         </div>
       </div>
       <div

--- a/test-e2e/launcher/engineVersionCheck.test.js
+++ b/test-e2e/launcher/engineVersionCheck.test.js
@@ -38,6 +38,21 @@ import setupTestApp from '../setupTestApp';
 import launchFirstApp from '../launchFirstApp';
 
 describe('checks the version of the engine against what the app declares', () => {
+    describe('an official app that is only available', () => {
+        const app = setupTestApp({
+            appsRootDir: 'launcher/fixtures/one-official-app-not-installed/.nrfconnect-apps',
+        });
+
+        it('shows no warning in the app list', async () => {
+            await app.client.waitForVisible('.list-group-item');
+
+            await expect(app.client.isVisible('span[title="The app does not specify which nRF Connect version(s) it supports'))
+                .resolves.toBe(false);
+            await expect(app.client.isVisible('span[title*="The app only supports nRF Connect'))
+                .resolves.toBe(false);
+        });
+    });
+
     describe('local app with unsupported engine', () => {
         const app = setupTestApp({
             appsRootDir: 'launcher/fixtures/one-local-app-unsupported-engine/.nrfconnect-apps',


### PR DESCRIPTION
4af1267993 introduced a regression: Now all apps that are available online (but not yet installed) did show a warning about a missing engine version.