### PR TITLE
Fix “Update all apps”

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+## Version 3.4.2
+### Fixes
+- “Update all apps” sometimes showed an error message (even though it worked
+  correctly). #451
+
 ## Version 3.4.1
 ### Updates
 - Updated to pc-nrfjprog-js v1.7.3, including bundled nrfjprog v10.9.0 and JLink 6.80a

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nrfconnect",
-    "version": "3.4.1",
+    "version": "3.4.2",
     "description": "nRF Connect for PC",
     "repository": {
         "type": "git",

--- a/src/main/apps.js
+++ b/src/main/apps.js
@@ -239,7 +239,7 @@ function installLocalAppArchive(tgzFilePath) {
         .then(isInstalled => {
             if (!isInstalled) {
                 return fileUtil.mkdir(appPath)
-                    .then(() => fileUtil.extractNpmPackage(tgzFilePath, appPath))
+                    .then(() => fileUtil.extractNpmPackage(appName, tgzFilePath, appPath))
                     .then(() => fileUtil.deleteFile(tgzFilePath));
             }
             return Promise.resolve();
@@ -490,7 +490,11 @@ function removeOfficialApp(name, source) {
             + `to remove app directory ${appPath}. The directory does not `
             + 'have node_modules in its path.'));
     }
-    return fs.remove(appPath);
+
+    const tmpDir = fileUtil.getTmpFilename(name);
+
+    return fs.move(appPath, tmpDir)
+        .then(() => fs.remove(tmpDir));
 }
 
 /**
@@ -513,7 +517,7 @@ function installOfficialApp(name, version, source) {
                     }
                     return Promise.resolve();
                 })
-                .then(() => fileUtil.extractNpmPackage(tgzFilePath, appPath))
+                .then(() => fileUtil.extractNpmPackage(name, tgzFilePath, appPath))
                 .then(() => fileUtil.deleteFile(tgzFilePath));
         });
 }

--- a/src/main/fileUtil.js
+++ b/src/main/fileUtil.js
@@ -288,7 +288,6 @@ function createJsonFileIfNotExists(filePath, jsonData) {
 }
 
 module.exports = {
-    readFile,
     readJsonFile,
     listDirectories,
     listFiles,


### PR DESCRIPTION
Fixes the bug [NCP-3115](https://projecttools.nordicsemi.no/jira/browse/NCP-3115).

When users press “Update all apps” sometimes an error message “Unable to load apps” was shown (even though it worked correctly). 

This was caused by a race condition: When one app was completely upgraded it reloaded the state of all apps but another one was possible in the middle of being upgraded, which could lead to it's app folder being transiently in an inconsistent state. E.g. while deleting the old version, the `package.json` was already gone but the folder still existed.

To fix this, when removing the old version of the app, the app folder is first moved to different, temporary folder and the contents are removed there. When installing the new version it is done the other way around: The downloaded app is first unpacked to a temporary folder and afterwards the whole folder is moved to the final destination.

This PR bumps the version up to 3.4.2, but from my point of view this small fix alone does not yet justify doing a release. We can wait for the next thing that should also be released.

This change also makes it possible, that we could allow users to start multiple installs, upgrades or removals in parallel, but I will do that change in a different PR. Currently the UI state can be slightly broken in that regard anyhow: After users click on “Update all apps” all install/upgrade/remove buttons are temporarily disabled but as soon as the first upgrade is finished all buttons (including “Update all apps”) are enabled again.