### PR TITLE
Update pc-ble-driver-js to 2.7.2

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,4 +1,7 @@
 ## Version 3.4.2
+### Updates
+- Updated pc-ble-driver-js to 2.7.2 #452
+    See changes https://github.com/NordicSemiconductor/pc-ble-driver-js/releases/tag/v2.7.2
 ### Fixes
 - “Update all apps” sometimes showed an error message (even though it worked
   correctly). #451

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
         "mousetrap": "1.6.5",
         "mustache": "3.0.1",
         "nrf-device-setup": "0.6.7",
-        "pc-ble-driver-js": "2.7.1",
+        "pc-ble-driver-js": "2.7.2",
         "popper.js": "1.16.1",
         "react": "16.13.1",
         "react-dom": "16.13.1",


### PR DESCRIPTION
This PR updated pc-ble-driver-js to 2.7.2, for changes see: https://github.com/NordicSemiconductor/pc-ble-driver-js/releases/tag/v2.7.2