### PR TITLE
Automatically run tests before push

### DIFF
--- a/.huskyrc.json
+++ b/.huskyrc.json
@@ -1,0 +1,5 @@
+{
+    "hooks": {
+        "pre-push": "bash node_modules/pc-nrfconnect-shared/scripts/pre-push.sh"
+    }
+}


### PR DESCRIPTION
Remember that in a case of emergency you can do `git push --no-verify`
if you need to push even though tests might fail.