### PR TITLE
Fix/display source as app

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
         "electron-notarize": "0.3.0",
         "mini-css-extract-plugin": "0.9.0",
         "pc-nrfconnect-build": "git+https://github.com/NordicPlayground/pc-nrfconnect-build.git#semver:0.3.0",
-        "pc-nrfconnect-shared": "github:NordicSemiconductor/pc-nrfconnect-shared#v4.9.7",
+        "pc-nrfconnect-shared": "github:NordicSemiconductor/pc-nrfconnect-shared#v4.9.8",
         "spectron": "7.0.0",
         "tar": "6.0.2",
         "xvfb-maybe": "0.2.1"

--- a/src/main/apps.js
+++ b/src/main/apps.js
@@ -458,7 +458,9 @@ function decorateWithLatestVersion(officialApp, availableUpdates) {
  */
 function officialAppsObjToArray(officialAppsObj, source) {
     const names = Object.keys(officialAppsObj);
-    return names.map(name => ({ name, source, ...officialAppsObj[name] }));
+    return names
+        .map(name => ({ name, source, ...officialAppsObj[name] }))
+        .filter(app => app.name && app.name !== '_source');
 }
 
 /**


### PR DESCRIPTION
This PR is to fix that `_source` displayed as an app in Linux.
And also update shared to v4.9.8 to enhance the logic which IP is used to generate the client id for usage statistics.