### PR TITLE
Added workaround to prevent errors when proxy authentication is required

### DIFF
--- a/src/main/net.js
+++ b/src/main/net.js
@@ -76,6 +76,8 @@ function downloadToBuffer(url, enableProxyLogin, headers = {}) {
                     `Unable to download ${url}. Got status code ${statusCode}`
                 );
                 error.statusCode = statusCode;
+                // https://github.com/electron/electron/issues/24948
+                response.on('error', () => {});
                 reject(error);
                 return;
             }


### PR DESCRIPTION
If proxy authentication is required, electron will show error dialog as described in https://github.com/electron/electron/issues/24948. This is a workaround until the issue has been fixed.