### PR TITLE
Set min-height: 0 on main window layout to prevent double scrollbar issue

### DIFF
--- a/resources/css/app.scss
+++ b/resources/css/app.scss
@@ -64,6 +64,7 @@ html, body, #webapp {
     display: flex;
     flex-flow: row;
     height: 100%;
+    min-height: 0;
 
     > div:nth-child(1) {
         flex: 1;


### PR DESCRIPTION
Issue with chromium, explained in more detailed here https://bugs.chromium.org/p/chromium/issues/detail?id=927066. Particularly comment #50 explains the reason this fix works.