### PR TITLE
Temporary dialog API patch

### DIFF
--- a/Changelog-dev.md
+++ b/Changelog-dev.md
@@ -1,6 +1,7 @@
 ## Unreleased
 ### Features
 - Send system report
+- Temporary fix to hide electron dialog api change for apps not yet requiring 3.6+ engine #485
 
 ## Version 3.5.0
 ### Features

--- a/src/app/module-loader.js
+++ b/src/app/module-loader.js
@@ -96,3 +96,29 @@ const bleDriverJs = require('pc-ble-driver-js');
 
 const bleDriver = bleDriverJs.api ? bleDriverJs.api : bleDriverJs;
 hostedModules['pc-ble-driver-js'] = bleDriver;
+
+// Temporary workaround. To be removed after all the related apps are updated.
+// Electron dialog api change breaks the behaviour of show[Open|Save]Dialog() calls.
+// Update apps by either calling the synchronous version or to expect
+// a Promise return value.
+const { remote } = hostedModules['electron'];
+
+remote.dialog.showSaveDialog = (...args) => {
+    const lastArg = args[args.length - 1];
+    const result = remote.dialog.showSaveDialogSync(...args);
+    if (typeof lastArg === 'function') {
+        const callback = lastArg;
+        callback(result);
+    }
+    return result;
+};
+
+remote.dialog.showOpenDialog = (...args) => {
+    const lastArg = args[args.length - 1];
+    const result = remote.dialog.showOpenDialogSync(...args);
+    if (typeof lastArg === 'function') {
+        const callback = lastArg;
+        callback(result);
+    }
+    return result;
+};


### PR DESCRIPTION
This PR patches electron's dialog api for apps which are not yet updated.
Should an app use _showSaveDialog()_ or _showOpenDialog()_ must expect a Promise return.
This will be the case as soon as the app updates required nrfconnect engine version to 3.6+ in package.json, until that the app will see a patched api which should behave as in the old api.
