### PR TITLE
Fix dropdown toggle alignment

### DIFF
--- a/resources/css/launcher.scss
+++ b/resources/css/launcher.scss
@@ -247,3 +247,8 @@ body {
     overflow-y: scroll;
     height: 40vh;
 }
+
+.dropdown-toggle:empty::after {
+    position: relative;
+    top: 2px;
+}


### PR DESCRIPTION
The arrows in the dropdown buttons were a wee bit misaligned; this PR corrects that.

Before:
<img width="53" alt="Screenshot 2020-10-21 at 09 39 36" src="https://user-images.githubusercontent.com/4018892/96695581-198cbb00-138a-11eb-933a-60b0589f82ba.png">

After:
<img width="57" alt="Screenshot 2020-10-21 at 09 39 23" src="https://user-images.githubusercontent.com/4018892/96695601-201b3280-138a-11eb-8f0a-982c9a0b34b9.png">

