### PR TITLE
Add hot reloading

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -578,6 +578,15 @@
                 "@babel/helper-plugin-utils": "^7.8.3"
             }
         },
+        "@babel/plugin-syntax-flow": {
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.12.1.tgz",
+            "integrity": "sha512-1lBLLmtxrwpm4VKmtVFselI/P3pX+G63fAtUUt6b2Nzgao77KNDwyuRt90Mj2/9pKobtt68FdvjfqohZjg/FCA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
         "@babel/plugin-syntax-import-meta": {
             "version": "7.10.4",
             "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
@@ -776,6 +785,16 @@
             "requires": {
                 "@babel/helper-builder-binary-assignment-operator-visitor": "^7.10.4",
                 "@babel/helper-plugin-utils": "^7.10.4"
+            }
+        },
+        "@babel/plugin-transform-flow-strip-types": {
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.12.1.tgz",
+            "integrity": "sha512-8hAtkmsQb36yMmEtk2JZ9JnVyDSnDOdlB+0nEGzIDLuK4yR3JcEjfuFPYkdEPSh8Id+rAMeBEn+X0iVEyho6Hg==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/plugin-syntax-flow": "^7.12.1"
             }
         },
         "@babel/plugin-transform-for-of": {
@@ -1219,6 +1238,16 @@
                 }
             }
         },
+        "@babel/preset-flow": {
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/preset-flow/-/preset-flow-7.12.1.tgz",
+            "integrity": "sha512-UAoyMdioAhM6H99qPoKvpHMzxmNVXno8GYU/7vZmGaHk6/KqfDYL1W0NxszVbJ2EP271b7e6Ox+Vk2A9QsB3Sw==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-plugin-utils": "^7.10.4",
+                "@babel/plugin-transform-flow-strip-types": "^7.12.1"
+            }
+        },
         "@babel/preset-modules": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/@babel/preset-modules/-/preset-modules-0.1.4.tgz",
@@ -1255,6 +1284,59 @@
             "requires": {
                 "@babel/helper-plugin-utils": "^7.10.4",
                 "@babel/plugin-transform-typescript": "^7.10.4"
+            }
+        },
+        "@babel/register": {
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.12.1.tgz",
+            "integrity": "sha512-XWcmseMIncOjoydKZnWvWi0/5CUCD+ZYKhRwgYlWOrA8fGZ/FjuLRpqtIhLOVD/fvR1b9DQHtZPn68VvhpYf+Q==",
+            "dev": true,
+            "requires": {
+                "find-cache-dir": "^2.0.0",
+                "lodash": "^4.17.19",
+                "make-dir": "^2.1.0",
+                "pirates": "^4.0.0",
+                "source-map-support": "^0.5.16"
+            },
+            "dependencies": {
+                "make-dir": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+                    "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+                    "dev": true,
+                    "requires": {
+                        "pify": "^4.0.1",
+                        "semver": "^5.6.0"
+                    }
+                },
+                "pify": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+                    "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+                    "dev": true
+                },
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                },
+                "source-map-support": {
+                    "version": "0.5.19",
+                    "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+                    "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+                    "dev": true,
+                    "requires": {
+                        "buffer-from": "^1.0.0",
+                        "source-map": "^0.6.0"
+                    }
+                }
             }
         },
         "@babel/runtime": {
@@ -2488,6 +2570,22 @@
             "resolved": "https://registry.npmjs.org/@mdi/font/-/font-3.7.95.tgz",
             "integrity": "sha512-JFQSv1GwhilTN6mj2SHu+YH+jZAIPn6sir/gGYoMSgyEM94nzlLGc7Ew21mnDEr0+W3LhFaInu8dqZFvNUx1bA=="
         },
+        "@mrmlnc/readdir-enhanced": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
+            "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
+            "dev": true,
+            "requires": {
+                "call-me-maybe": "^1.0.1",
+                "glob-to-regexp": "^0.3.0"
+            }
+        },
+        "@nodelib/fs.stat": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
+            "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
+            "dev": true
+        },
         "@popperjs/core": {
             "version": "2.5.3",
             "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.5.3.tgz",
@@ -3104,6 +3202,18 @@
                 "@babel/types": "^7.3.0"
             }
         },
+        "@types/cacheable-request": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.1.tgz",
+            "integrity": "sha512-ykFq2zmBGOCbpIXtoVbz4SKY5QriWPh3AjyU4G74RYbtt5yOc5OfaY75ftjg7mikMOla1CTGpX3lLbuJh8DTrQ==",
+            "dev": true,
+            "requires": {
+                "@types/http-cache-semantics": "*",
+                "@types/keyv": "*",
+                "@types/node": "*",
+                "@types/responselike": "*"
+            }
+        },
         "@types/debug": {
             "version": "4.1.5",
             "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.5.tgz",
@@ -3146,7 +3256,6 @@
             "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
             "integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
             "dev": true,
-            "optional": true,
             "requires": {
                 "@types/minimatch": "*",
                 "@types/node": "*"
@@ -3160,6 +3269,12 @@
             "requires": {
                 "@types/node": "*"
             }
+        },
+        "@types/http-cache-semantics": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.0.tgz",
+            "integrity": "sha512-c3Xy026kOF7QOTn00hbIllV1dLR9hG9NkSrLQgCVs8NF6sBU+VGWjD3wLPhmh1TYAc7ugCFsvHYMN4VcBN1U1A==",
+            "dev": true
         },
         "@types/istanbul-lib-coverage": {
             "version": "2.0.3",
@@ -3202,6 +3317,15 @@
             "integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
             "dev": true
         },
+        "@types/keyv": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.1.tgz",
+            "integrity": "sha512-MPtoySlAZQ37VoLaPcTHCu1RWJ4llDkULYZIzOYxlhxBqYPB0RsRlmMU0R6tahtFe27mIdkHV+551ZWV4PLmVw==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
+            }
+        },
         "@types/long": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
@@ -3211,8 +3335,7 @@
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
             "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
-            "dev": true,
-            "optional": true
+            "dev": true
         },
         "@types/node": {
             "version": "13.13.23",
@@ -3257,6 +3380,15 @@
             "requires": {
                 "@types/prop-types": "*",
                 "csstype": "^3.0.2"
+            }
+        },
+        "@types/responselike": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
+            "integrity": "sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==",
+            "dev": true,
+            "requires": {
+                "@types/node": "*"
             }
         },
         "@types/semver": {
@@ -3615,6 +3747,243 @@
                 "@xtuc/long": "4.2.2"
             }
         },
+        "@webpack-cli/generators": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/generators/-/generators-1.0.1.tgz",
+            "integrity": "sha512-MPaOezICviBfgYc+r8WBTkyM8gOe3qBR5t32roPqyhL4SJmN4f82ZYvVomLEx+YFBQ5uksCauSHAGoJNXinymg==",
+            "dev": true,
+            "requires": {
+                "@webpack-cli/utils": "^1.0.1",
+                "@webpack-cli/webpack-scaffold": "^1.0.1",
+                "colorette": "^1.2.1",
+                "log-symbols": "^4.0.0",
+                "mkdirp": "^1.0.4",
+                "yeoman-generator": "^4.12.0"
+            },
+            "dependencies": {
+                "mkdirp": {
+                    "version": "1.0.4",
+                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+                    "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+                    "dev": true
+                }
+            }
+        },
+        "@webpack-cli/info": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-1.0.1.tgz",
+            "integrity": "sha512-C6OJTxTLgTjBuNKLlseQ2HHjgEGTcgIFcrJd67K3pM2LcYJNWT6VFaPzk9Go0yTZ9km9awm8sq2hW3Hm32NBeQ==",
+            "dev": true,
+            "requires": {
+                "colorette": "^1.2.1",
+                "envinfo": "^7.5.0",
+                "prettyjson": "^1.2.1"
+            }
+        },
+        "@webpack-cli/init": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/init/-/init-1.0.1.tgz",
+            "integrity": "sha512-OmhDC1jjhhX13mNt+emTPR7u18nrAWKOk/nIAg8XRFdZU2VUBPJbOK3/6xmqXnWKByZVJClvaeUjvgVQBnQmZw==",
+            "dev": true,
+            "requires": {
+                "@webpack-cli/generators": "^1.0.1",
+                "@webpack-cli/utils": "^1.0.1"
+            }
+        },
+        "@webpack-cli/serve": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.0.1.tgz",
+            "integrity": "sha512-WGMaTMTK6NOe29Hw1WBEok9vGLfKg5C6jWzNOS/6HH1YadR+RL+TRWRcSyc81Dzulljhk/Ree9mrDM4Np9GGOQ==",
+            "dev": true
+        },
+        "@webpack-cli/utils": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/utils/-/utils-1.0.1.tgz",
+            "integrity": "sha512-G8UKA+B85/5X+pM85P0Knx43vwFS1W9WDseeif/15jbtDTib8jaNC+rD9SBvFcllmnqdfFXpkcrmWMW4A744dg==",
+            "dev": true,
+            "requires": {
+                "colorette": "^1.2.1",
+                "cross-spawn": "^7.0.3",
+                "enquirer": "^2.3.6",
+                "execa": "^4.0.0",
+                "findup-sync": "^4.0.0",
+                "global-modules": "^2.0.0",
+                "got": "^10.7.0",
+                "jscodeshift": "^0.7.0",
+                "p-each-series": "^2.1.0",
+                "yeoman-environment": "^2.8.1",
+                "yeoman-generator": "^4.7.2"
+            },
+            "dependencies": {
+                "@sindresorhus/is": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-2.1.1.tgz",
+                    "integrity": "sha512-/aPsuoj/1Dw/kzhkgz+ES6TxG0zfTMGLwuK2ZG00k/iJzYHTLCE8mVU8EPqEOp/lmxPoq1C1C9RYToRKb2KEfg==",
+                    "dev": true
+                },
+                "@szmarczak/http-timer": {
+                    "version": "4.0.5",
+                    "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.5.tgz",
+                    "integrity": "sha512-PyRA9sm1Yayuj5OIoJ1hGt2YISX45w9WcFbh6ddT0Z/0yaFxOtGLInr4jUfU1EAFVs0Yfyfev4RNwBlUaHdlDQ==",
+                    "dev": true,
+                    "requires": {
+                        "defer-to-connect": "^2.0.0"
+                    }
+                },
+                "cacheable-request": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.1.tgz",
+                    "integrity": "sha512-lt0mJ6YAnsrBErpTMWeu5kl/tg9xMAWjavYTN6VQXM1A/teBITuNcccXsCxF0tDQQJf9DfAaX5O4e0zp0KlfZw==",
+                    "dev": true,
+                    "requires": {
+                        "clone-response": "^1.0.2",
+                        "get-stream": "^5.1.0",
+                        "http-cache-semantics": "^4.0.0",
+                        "keyv": "^4.0.0",
+                        "lowercase-keys": "^2.0.0",
+                        "normalize-url": "^4.1.0",
+                        "responselike": "^2.0.0"
+                    }
+                },
+                "decompress-response": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-5.0.0.tgz",
+                    "integrity": "sha512-TLZWWybuxWgoW7Lykv+gq9xvzOsUjQ9tF09Tj6NSTYGMTCHNXzrPnD6Hi+TgZq19PyTAGH4Ll/NIM/eTGglnMw==",
+                    "dev": true,
+                    "requires": {
+                        "mimic-response": "^2.0.0"
+                    }
+                },
+                "defer-to-connect": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.0.tgz",
+                    "integrity": "sha512-bYL2d05vOSf1JEZNx5vSAtPuBMkX8K9EUutg7zlKvTqKXHt7RhWJFbmd7qakVuf13i+IkGmp6FwSsONOf6VYIg==",
+                    "dev": true
+                },
+                "execa": {
+                    "version": "4.0.3",
+                    "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.3.tgz",
+                    "integrity": "sha512-WFDXGHckXPWZX19t1kCsXzOpqX9LWYNqn4C+HqZlk/V0imTkzJZqf87ZBhvpHaftERYknpk0fjSylnXVlVgI0A==",
+                    "dev": true,
+                    "requires": {
+                        "cross-spawn": "^7.0.0",
+                        "get-stream": "^5.0.0",
+                        "human-signals": "^1.1.1",
+                        "is-stream": "^2.0.0",
+                        "merge-stream": "^2.0.0",
+                        "npm-run-path": "^4.0.0",
+                        "onetime": "^5.1.0",
+                        "signal-exit": "^3.0.2",
+                        "strip-final-newline": "^2.0.0"
+                    }
+                },
+                "get-stream": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+                    "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+                    "dev": true,
+                    "requires": {
+                        "pump": "^3.0.0"
+                    }
+                },
+                "got": {
+                    "version": "10.7.0",
+                    "resolved": "https://registry.npmjs.org/got/-/got-10.7.0.tgz",
+                    "integrity": "sha512-aWTDeNw9g+XqEZNcTjMMZSy7B7yE9toWOFYip7ofFTLleJhvZwUxxTxkTpKvF+p1SAA4VHmuEy7PiHTHyq8tJg==",
+                    "dev": true,
+                    "requires": {
+                        "@sindresorhus/is": "^2.0.0",
+                        "@szmarczak/http-timer": "^4.0.0",
+                        "@types/cacheable-request": "^6.0.1",
+                        "cacheable-lookup": "^2.0.0",
+                        "cacheable-request": "^7.0.1",
+                        "decompress-response": "^5.0.0",
+                        "duplexer3": "^0.1.4",
+                        "get-stream": "^5.0.0",
+                        "lowercase-keys": "^2.0.0",
+                        "mimic-response": "^2.1.0",
+                        "p-cancelable": "^2.0.0",
+                        "p-event": "^4.0.0",
+                        "responselike": "^2.0.0",
+                        "to-readable-stream": "^2.0.0",
+                        "type-fest": "^0.10.0"
+                    }
+                },
+                "is-stream": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+                    "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+                    "dev": true
+                },
+                "json-buffer": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+                    "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+                    "dev": true
+                },
+                "keyv": {
+                    "version": "4.0.3",
+                    "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.3.tgz",
+                    "integrity": "sha512-zdGa2TOpSZPq5mU6iowDARnMBZgtCqJ11dJROFi6tg6kTn4nuUdU09lFyLFSaHrWqpIJ+EBq4E8/Dc0Vx5vLdA==",
+                    "dev": true,
+                    "requires": {
+                        "json-buffer": "3.0.1"
+                    }
+                },
+                "lowercase-keys": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+                    "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+                    "dev": true
+                },
+                "npm-run-path": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+                    "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+                    "dev": true,
+                    "requires": {
+                        "path-key": "^3.0.0"
+                    }
+                },
+                "p-cancelable": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.0.0.tgz",
+                    "integrity": "sha512-wvPXDmbMmu2ksjkB4Z3nZWTSkJEb9lqVdMaCKpZUGJG9TMiNp9XcbG3fn9fPKjem04fJMJnXoyFPk2FmgiaiNg==",
+                    "dev": true
+                },
+                "responselike": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.0.tgz",
+                    "integrity": "sha512-xH48u3FTB9VsZw7R+vvgaKeLKzT6jOogbQhEe/jewwnZgzPcnyWui2Av6JpoYZF/91uueC+lqhWqeURw5/qhCw==",
+                    "dev": true,
+                    "requires": {
+                        "lowercase-keys": "^2.0.0"
+                    }
+                },
+                "to-readable-stream": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-2.1.0.tgz",
+                    "integrity": "sha512-o3Qa6DGg1CEXshSdvWNX2sN4QHqg03SPq7U6jPXRahlQdl5dK8oXjkU/2/sGrnOZKeGV1zLSO8qPwyKklPPE7w==",
+                    "dev": true
+                },
+                "type-fest": {
+                    "version": "0.10.0",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.10.0.tgz",
+                    "integrity": "sha512-EUV9jo4sffrwlg8s0zDhP0T2WD3pru5Xi0+HTE3zTUmBaZNhfkite9PdSJwdXLwPVW0jnAHT56pZHIOYckPEiw==",
+                    "dev": true
+                }
+            }
+        },
+        "@webpack-cli/webpack-scaffold": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@webpack-cli/webpack-scaffold/-/webpack-scaffold-1.0.1.tgz",
+            "integrity": "sha512-AfnpwDJv2hxwpaM6Ljz0eNa7ayHVviPNWN/76RjlFxMGfT0K7O6IWw2oDvikqko227DClV4xO/5CL1/tz0LGhw==",
+            "dev": true,
+            "requires": {
+                "jscodeshift": "^0.7.0",
+                "yeoman-generator": "^4.7.2"
+            }
+        },
         "@xtuc/ieee754": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -3626,6 +3995,16 @@
             "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
             "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
             "dev": true
+        },
+        "JSONStream": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
+            "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
+            "dev": true,
+            "requires": {
+                "jsonparse": "^1.2.0",
+                "through": ">=2.2.7 <3"
+            }
         },
         "abab": {
             "version": "2.0.5",
@@ -3743,6 +4122,12 @@
                     }
                 }
             }
+        },
+        "ansi-colors": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+            "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+            "dev": true
         },
         "ansi-escapes": {
             "version": "3.2.0",
@@ -4096,6 +4481,18 @@
             "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
             "dev": true
         },
+        "array-back": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.1.tgz",
+            "integrity": "sha512-Z/JnaVEXv+A9xabHzN43FiiiWEE7gPCRXMrVmRm00tWbjZRul1iHm7ECzlyNq1p4a4ATXz+G9FJ3GqGOkOV3fg==",
+            "dev": true
+        },
+        "array-differ": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-3.0.0.tgz",
+            "integrity": "sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==",
+            "dev": true
+        },
         "array-filter": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-1.0.0.tgz",
@@ -4139,6 +4536,21 @@
                     }
                 }
             }
+        },
+        "array-union": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+            "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+            "dev": true,
+            "requires": {
+                "array-uniq": "^1.0.1"
+            }
+        },
+        "array-uniq": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+            "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+            "dev": true
         },
         "array-unique": {
             "version": "0.3.2",
@@ -4320,6 +4732,12 @@
             "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
             "dev": true
         },
+        "ast-types": {
+            "version": "0.13.3",
+            "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.3.tgz",
+            "integrity": "sha512-XTZ7xGML849LkQP86sWdQzfhwbt3YwIO6MqbX9mUNYY98VKaaVZP7YNNm70IpwecbkkxmfC5IYAzOQ/2p29zRA==",
+            "dev": true
+        },
         "ast-types-flow": {
             "version": "0.0.7",
             "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
@@ -4393,6 +4811,12 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
             "integrity": "sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==",
+            "dev": true
+        },
+        "babel-core": {
+            "version": "7.0.0-bridge.0",
+            "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
+            "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==",
             "dev": true
         },
         "babel-eslint": {
@@ -4734,6 +5158,12 @@
             "version": "1.13.1",
             "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
             "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
+            "dev": true
+        },
+        "binaryextensions": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/binaryextensions/-/binaryextensions-2.3.0.tgz",
+            "integrity": "sha512-nAihlQsYGyc5Bwq6+EsubvANYGExeJKHDO3RjnvwU042fawQTQfM3Kxn7IHUXQOz4bzfwsGYYHGSvXyW4zOGLg==",
             "dev": true
         },
         "bindings": {
@@ -5385,6 +5815,33 @@
                 "unset-value": "^1.0.0"
             }
         },
+        "cacheable-lookup": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-2.0.1.tgz",
+            "integrity": "sha512-EMMbsiOTcdngM/K6gV/OxF2x0t07+vMOWxZNSCRQMjO2MY2nhZQ6OYhOOpyQrbhqsgtvKGI7hcq6xjnA92USjg==",
+            "dev": true,
+            "requires": {
+                "@types/keyv": "^3.1.1",
+                "keyv": "^4.0.0"
+            },
+            "dependencies": {
+                "json-buffer": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+                    "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+                    "dev": true
+                },
+                "keyv": {
+                    "version": "4.0.3",
+                    "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.3.tgz",
+                    "integrity": "sha512-zdGa2TOpSZPq5mU6iowDARnMBZgtCqJ11dJROFi6tg6kTn4nuUdU09lFyLFSaHrWqpIJ+EBq4E8/Dc0Vx5vLdA==",
+                    "dev": true,
+                    "requires": {
+                        "json-buffer": "3.0.1"
+                    }
+                }
+            }
+        },
         "cacheable-request": {
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
@@ -5416,6 +5873,12 @@
                     "dev": true
                 }
             }
+        },
+        "call-me-maybe": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz",
+            "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
+            "dev": true
         },
         "callsites": {
             "version": "3.1.0",
@@ -5469,6 +5932,12 @@
                     "dev": true
                 }
             }
+        },
+        "capture-stack-trace": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
+            "integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==",
+            "dev": true
         },
         "caseless": {
             "version": "0.12.0",
@@ -5763,6 +6232,23 @@
                 "restore-cursor": "^2.0.0"
             }
         },
+        "cli-table": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
+            "integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
+            "dev": true,
+            "requires": {
+                "colors": "1.0.3"
+            },
+            "dependencies": {
+                "colors": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+                    "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+                    "dev": true
+                }
+            }
+        },
         "cli-width": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
@@ -5811,6 +6297,18 @@
                 }
             }
         },
+        "clone": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+            "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
+            "dev": true
+        },
+        "clone-buffer": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
+            "integrity": "sha1-4+JbIHrE5wGvch4staFnksrD3Fg=",
+            "dev": true
+        },
         "clone-deep": {
             "version": "0.2.4",
             "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.2.4.tgz",
@@ -5838,6 +6336,55 @@
                     "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
                     "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
                     "dev": true
+                }
+            }
+        },
+        "clone-stats": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
+            "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
+            "dev": true
+        },
+        "cloneable-readable": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-1.1.3.tgz",
+            "integrity": "sha512-2EF8zTQOxYq70Y4XKtorQupqF0m49MBz2/yf5Bj+MHjvpG3Hy7sImifnqD6UA+TKYxeSV+u6qqQPawN5UvnpKQ==",
+            "dev": true,
+            "requires": {
+                "inherits": "^2.0.1",
+                "process-nextick-args": "^2.0.0",
+                "readable-stream": "^2.3.5"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "2.3.7",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "~5.1.0"
+                    }
                 }
             }
         },
@@ -6043,6 +6590,12 @@
                 "simple-swizzle": "^0.2.2"
             }
         },
+        "colorette": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
+            "integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==",
+            "dev": true
+        },
         "colornames": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/colornames/-/colornames-1.1.1.tgz",
@@ -6071,6 +6624,18 @@
             "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
             "requires": {
                 "delayed-stream": "~1.0.0"
+            }
+        },
+        "command-line-usage": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-6.1.0.tgz",
+            "integrity": "sha512-Ew1clU4pkUeo6AFVDFxCbnN7GIZfXl48HIOQeFQnkO3oOqvpI7wdqtLRwv9iOCZ/7A+z4csVZeiDdEcj8g6Wiw==",
+            "dev": true,
+            "requires": {
+                "array-back": "^4.0.0",
+                "chalk": "^2.4.2",
+                "table-layout": "^1.0.0",
+                "typical": "^5.2.0"
             }
         },
         "commander": {
@@ -6421,6 +6986,15 @@
                 }
             }
         },
+        "create-error-class": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+            "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+            "dev": true,
+            "requires": {
+                "capture-stack-trace": "^1.0.0"
+            }
+        },
         "create-hash": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
@@ -6762,6 +7336,12 @@
             "integrity": "sha512-JVrozIeElnj3QzfUIt8tB8YMluBJom4Vw9qTPpjGYQ9fYlB3D/rb6OordUxf3xeFB35LKWs0xqcO5U6ySvBtug==",
             "dev": true
         },
+        "dargs": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/dargs/-/dargs-6.1.0.tgz",
+            "integrity": "sha512-5dVBvpBLBnPwSsYXqfybFyehMmC/EenKEcf23AhCTgTf48JFBbmJKqoZBsERDnjL0FyiVTYWdFsRfTLHxLyKdQ==",
+            "dev": true
+        },
         "dashdash": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -6780,6 +7360,12 @@
                 "whatwg-mimetype": "^2.3.0",
                 "whatwg-url": "^8.0.0"
             }
+        },
+        "dateformat": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
+            "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
+            "dev": true
         },
         "debounce-fn": {
             "version": "3.0.1",
@@ -6920,6 +7506,12 @@
                 "minimalistic-assert": "^1.0.0"
             }
         },
+        "detect-file": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
+            "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
+            "dev": true
+        },
         "detect-libc": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
@@ -6955,6 +7547,12 @@
                 "kuler": "1.0.x"
             }
         },
+        "diff": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+            "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+            "dev": true
+        },
         "diff-sequences": {
             "version": "25.2.6",
             "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-25.2.6.tgz",
@@ -6977,6 +7575,33 @@
                     "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
                     "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
                     "dev": true
+                }
+            }
+        },
+        "dir-glob": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.0.0.tgz",
+            "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
+            "dev": true,
+            "requires": {
+                "arrify": "^1.0.1",
+                "path-type": "^3.0.0"
+            },
+            "dependencies": {
+                "arrify": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+                    "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+                    "dev": true
+                },
+                "path-type": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+                    "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+                    "dev": true,
+                    "requires": {
+                        "pify": "^3.0.0"
+                    }
                 }
             }
         },
@@ -7120,6 +7745,28 @@
             "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==",
             "dev": true
         },
+        "download-stats": {
+            "version": "0.3.4",
+            "resolved": "https://registry.npmjs.org/download-stats/-/download-stats-0.3.4.tgz",
+            "integrity": "sha512-ic2BigbyUWx7/CBbsfGjf71zUNZB4edBGC3oRliSzsoNmvyVx3Ycfp1w3vp2Y78Ee0eIIkjIEO5KzW0zThDGaA==",
+            "dev": true,
+            "requires": {
+                "JSONStream": "^1.2.1",
+                "lazy-cache": "^2.0.1",
+                "moment": "^2.15.1"
+            },
+            "dependencies": {
+                "lazy-cache": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
+                    "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
+                    "dev": true,
+                    "requires": {
+                        "set-getter": "^0.1.0"
+                    }
+                }
+            }
+        },
         "duplexer2": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
@@ -7214,6 +7861,16 @@
             "requires": {
                 "jsbn": "~0.1.0",
                 "safer-buffer": "^2.1.0"
+            }
+        },
+        "editions": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/editions/-/editions-2.3.1.tgz",
+            "integrity": "sha512-ptGvkwTvGdGfC0hfhKg0MT+TRLRKGtUiWGBInxOm5pz7ssADezahjCUaYuZ8Dr+C05FW0AECIIPt4WBxVINEhA==",
+            "dev": true,
+            "requires": {
+                "errlop": "^2.0.0",
+                "semver": "^6.3.0"
             }
         },
         "ejs": {
@@ -7788,6 +8445,15 @@
                 }
             }
         },
+        "enquirer": {
+            "version": "2.3.6",
+            "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+            "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+            "dev": true,
+            "requires": {
+                "ansi-colors": "^4.1.1"
+            }
+        },
         "entities": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
@@ -7802,6 +8468,12 @@
             "version": "0.0.6",
             "resolved": "https://registry.npmjs.org/env-variable/-/env-variable-0.0.6.tgz",
             "integrity": "sha512-bHz59NlBbtS0NhftmR8+ExBEekE7br0e01jw+kk0NDro7TtZzBYZ5ScGPs3OmwnpyfHTHOtr1Y6uedCdrIldtg==",
+            "dev": true
+        },
+        "envinfo": {
+            "version": "7.7.3",
+            "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.7.3.tgz",
+            "integrity": "sha512-46+j5QxbPWza0PB1i15nZx0xQ4I/EfQxg9J8Had3b408SV63nEtor2e+oiY63amTo9KTuh2a3XLObNwduxYwwA==",
             "dev": true
         },
         "enzyme": {
@@ -7901,6 +8573,12 @@
                 "react-is": "^16.12.0"
             }
         },
+        "errlop": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/errlop/-/errlop-2.2.0.tgz",
+            "integrity": "sha512-e64Qj9+4aZzjzzFpZC7p5kmm/ccCrbLhAJplhsDXQFs87XTsXwOpH4s1Io2s90Tau/8r2j9f4l/thhDevRjzxw==",
+            "dev": true
+        },
         "errno": {
             "version": "0.1.7",
             "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
@@ -7908,6 +8586,15 @@
             "dev": true,
             "requires": {
                 "prr": "~1.0.1"
+            }
+        },
+        "error": {
+            "version": "7.2.1",
+            "resolved": "https://registry.npmjs.org/error/-/error-7.2.1.tgz",
+            "integrity": "sha512-fo9HBvWnx3NGUKMvMwB/CBCMMrfEJgbDTVDEkPygA3Bdd3lM1OyCd+rbQ8BwnpF6GdVeOLDNmyL4N5Bg80ZvdA==",
+            "dev": true,
+            "requires": {
+                "string-template": "~0.2.1"
             }
         },
         "error-ex": {
@@ -8958,6 +9645,15 @@
             "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
             "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="
         },
+        "expand-tilde": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+            "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+            "dev": true,
+            "requires": {
+                "homedir-polyfill": "^1.0.1"
+            }
+        },
         "expect": {
             "version": "26.5.3",
             "resolved": "https://registry.npmjs.org/expect/-/expect-26.5.3.tgz",
@@ -9255,6 +9951,20 @@
             "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
             "dev": true
         },
+        "fast-glob": {
+            "version": "2.2.7",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.7.tgz",
+            "integrity": "sha512-g1KuQwHOZAmOZMuBtHdxDtju+T2RT8jgCC9aANsbpdiDDTSnjgfuVsIBNKbUeJI3oKMRExcfNDtJl4OhbffMsw==",
+            "dev": true,
+            "requires": {
+                "@mrmlnc/readdir-enhanced": "^2.2.1",
+                "@nodelib/fs.stat": "^1.1.2",
+                "glob-parent": "^3.1.0",
+                "is-glob": "^4.0.0",
+                "merge2": "^1.2.3",
+                "micromatch": "^3.1.10"
+            }
+        },
         "fast-json-stable-stringify": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -9456,6 +10166,104 @@
                 "semver-regex": "^2.0.0"
             }
         },
+        "findup-sync": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-4.0.0.tgz",
+            "integrity": "sha512-6jvvn/12IC4quLBL1KNokxC7wWTvYncaVUYSoxWw7YykPLuRrnv4qdHcSOywOI5RpkOVGeQRtWM8/q+G6W6qfQ==",
+            "dev": true,
+            "requires": {
+                "detect-file": "^1.0.0",
+                "is-glob": "^4.0.0",
+                "micromatch": "^4.0.2",
+                "resolve-dir": "^1.0.1"
+            },
+            "dependencies": {
+                "braces": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+                    "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+                    "dev": true,
+                    "requires": {
+                        "fill-range": "^7.0.1"
+                    }
+                },
+                "fill-range": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+                    "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+                    "dev": true,
+                    "requires": {
+                        "to-regex-range": "^5.0.1"
+                    }
+                },
+                "is-number": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+                    "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+                    "dev": true
+                },
+                "micromatch": {
+                    "version": "4.0.2",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+                    "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+                    "dev": true,
+                    "requires": {
+                        "braces": "^3.0.1",
+                        "picomatch": "^2.0.5"
+                    }
+                },
+                "to-regex-range": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+                    "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+                    "dev": true,
+                    "requires": {
+                        "is-number": "^7.0.0"
+                    }
+                }
+            }
+        },
+        "first-chunk-stream": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-2.0.0.tgz",
+            "integrity": "sha1-G97NuOCDwGZLkZRVgVd6Q6nzHXA=",
+            "dev": true,
+            "requires": {
+                "readable-stream": "^2.0.2"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "2.3.7",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                    "dev": true,
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "~5.1.0"
+                    }
+                }
+            }
+        },
         "flat-cache": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
@@ -9506,6 +10314,12 @@
             "requires": {
                 "rematrix": "0.2.2"
             }
+        },
+        "flow-parser": {
+            "version": "0.136.0",
+            "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.136.0.tgz",
+            "integrity": "sha512-PB2vYAqmz+dRikpx8TpNgRtBsyemP+7oQa0BcPZWnGABlJlB2WgJc/Lx0HeEPOUxDO/TxBbPaIHsffEIL9M6BQ==",
+            "dev": true
         },
         "flush-write-stream": {
             "version": "1.1.1",
@@ -9853,10 +10667,71 @@
                 "assert-plus": "^1.0.0"
             }
         },
+        "gh-got": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/gh-got/-/gh-got-5.0.0.tgz",
+            "integrity": "sha1-7pW+NxBv2HSKlvjR20uuqJ4b+oo=",
+            "dev": true,
+            "requires": {
+                "got": "^6.2.0",
+                "is-plain-obj": "^1.1.0"
+            },
+            "dependencies": {
+                "get-stream": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+                    "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+                    "dev": true
+                },
+                "got": {
+                    "version": "6.7.1",
+                    "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+                    "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+                    "dev": true,
+                    "requires": {
+                        "create-error-class": "^3.0.0",
+                        "duplexer3": "^0.1.4",
+                        "get-stream": "^3.0.0",
+                        "is-redirect": "^1.0.0",
+                        "is-retry-allowed": "^1.0.0",
+                        "is-stream": "^1.0.0",
+                        "lowercase-keys": "^1.0.0",
+                        "safe-buffer": "^5.0.1",
+                        "timed-out": "^4.0.0",
+                        "unzip-response": "^2.0.1",
+                        "url-parse-lax": "^1.0.0"
+                    }
+                },
+                "prepend-http": {
+                    "version": "1.0.4",
+                    "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+                    "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+                    "dev": true
+                },
+                "url-parse-lax": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+                    "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+                    "dev": true,
+                    "requires": {
+                        "prepend-http": "^1.0.1"
+                    }
+                }
+            }
+        },
         "github-from-package": {
             "version": "0.0.0",
             "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
             "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
+        },
+        "github-username": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/github-username/-/github-username-3.0.0.tgz",
+            "integrity": "sha1-CnciGbMTB0NCnyRW0L3T21Xc57E=",
+            "dev": true,
+            "requires": {
+                "gh-got": "^5.0.0"
+            }
         },
         "glob": {
             "version": "5.0.15",
@@ -9890,6 +10765,12 @@
                     }
                 }
             }
+        },
+        "glob-to-regexp": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
+            "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=",
+            "dev": true
         },
         "global-agent": {
             "version": "2.1.12",
@@ -9932,6 +10813,47 @@
                 "ini": "^1.3.5"
             }
         },
+        "global-modules": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
+            "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
+            "dev": true,
+            "requires": {
+                "global-prefix": "^3.0.0"
+            },
+            "dependencies": {
+                "global-prefix": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
+                    "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
+                    "dev": true,
+                    "requires": {
+                        "ini": "^1.3.5",
+                        "kind-of": "^6.0.2",
+                        "which": "^1.3.1"
+                    }
+                },
+                "kind-of": {
+                    "version": "6.0.3",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+                    "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+                    "dev": true
+                }
+            }
+        },
+        "global-prefix": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+            "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
+            "dev": true,
+            "requires": {
+                "expand-tilde": "^2.0.2",
+                "homedir-polyfill": "^1.0.1",
+                "ini": "^1.3.4",
+                "is-windows": "^1.0.1",
+                "which": "^1.2.14"
+            }
+        },
         "global-tunnel-ng": {
             "version": "2.7.1",
             "resolved": "https://registry.npmjs.org/global-tunnel-ng/-/global-tunnel-ng-2.7.1.tgz",
@@ -9959,6 +10881,49 @@
             "optional": true,
             "requires": {
                 "define-properties": "^1.1.3"
+            }
+        },
+        "globby": {
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-8.0.2.tgz",
+            "integrity": "sha512-yTzMmKygLp8RUpG1Ymu2VXPSJQZjNAZPD4ywgYEaG7e4tBJeUQBO8OpXrf1RCNcEs5alsoJYPAMiIHP0cmeC7w==",
+            "dev": true,
+            "requires": {
+                "array-union": "^1.0.1",
+                "dir-glob": "2.0.0",
+                "fast-glob": "^2.0.2",
+                "glob": "^7.1.2",
+                "ignore": "^3.3.5",
+                "pify": "^3.0.0",
+                "slash": "^1.0.0"
+            },
+            "dependencies": {
+                "glob": {
+                    "version": "7.1.6",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+                    "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                },
+                "ignore": {
+                    "version": "3.3.10",
+                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+                    "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
+                    "dev": true
+                },
+                "slash": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+                    "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+                    "dev": true
+                }
             }
         },
         "globule": {
@@ -10039,6 +11004,15 @@
             "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
             "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
             "dev": true
+        },
+        "grouped-queue": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/grouped-queue/-/grouped-queue-1.1.0.tgz",
+            "integrity": "sha512-rZOFKfCqLhsu5VqjBjEWiwrYqJR07KxIkH4mLZlNlGDfntbb4FbMyGFP14TlvRPrU9S3Hnn/sgxbC5ZeN0no3Q==",
+            "dev": true,
+            "requires": {
+                "lodash": "^4.17.15"
+            }
         },
         "growly": {
             "version": "1.3.0",
@@ -10197,6 +11171,15 @@
             "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
             "requires": {
                 "react-is": "^16.7.0"
+            }
+        },
+        "homedir-polyfill": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+            "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
+            "dev": true,
+            "requires": {
+                "parse-passwd": "^1.0.0"
             }
         },
         "hosted-git-info": {
@@ -10616,6 +11599,12 @@
                 }
             }
         },
+        "interpret": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/interpret/-/interpret-2.2.0.tgz",
+            "integrity": "sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==",
+            "dev": true
+        },
         "invariant": {
             "version": "2.2.4",
             "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
@@ -10867,12 +11856,33 @@
             "integrity": "sha1-DFLlS8yjkbssSUsh6GJtczbG45c=",
             "dev": true
         },
+        "is-redirect": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+            "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
+            "dev": true
+        },
         "is-regex": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
             "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
             "requires": {
                 "has-symbols": "^1.0.1"
+            }
+        },
+        "is-retry-allowed": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
+            "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
+            "dev": true
+        },
+        "is-scoped": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-scoped/-/is-scoped-1.0.0.tgz",
+            "integrity": "sha1-RJypgpnnEwOCViieyytUDcQ3yzA=",
+            "dev": true,
+            "requires": {
+                "scoped-regex": "^1.0.0"
             }
         },
         "is-stream": {
@@ -11075,6 +12085,17 @@
             "requires": {
                 "html-escaper": "^2.0.0",
                 "istanbul-lib-report": "^3.0.0"
+            }
+        },
+        "istextorbinary": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.6.0.tgz",
+            "integrity": "sha512-+XRlFseT8B3L9KyjxxLjfXSLMuErKDsd8DBNrsaxoViABMEZlOSCstwmw0qpoFX3+U6yWU1yhLudAe6/lETGGA==",
+            "dev": true,
+            "requires": {
+                "binaryextensions": "^2.1.2",
+                "editions": "^2.2.0",
+                "textextensions": "^2.5.0"
             }
         },
         "jake": {
@@ -13856,6 +14877,45 @@
             "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
             "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
         },
+        "jscodeshift": {
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/jscodeshift/-/jscodeshift-0.7.1.tgz",
+            "integrity": "sha512-YMkZSyoc8zg5woZL23cmWlnFLPH/mHilonGA7Qbzs7H6M4v4PH0Qsn4jeDyw+CHhVoAnm9UxQyB0Yw1OT+mktA==",
+            "dev": true,
+            "requires": {
+                "@babel/core": "^7.1.6",
+                "@babel/parser": "^7.1.6",
+                "@babel/plugin-proposal-class-properties": "^7.1.0",
+                "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
+                "@babel/preset-env": "^7.1.6",
+                "@babel/preset-flow": "^7.0.0",
+                "@babel/preset-typescript": "^7.1.0",
+                "@babel/register": "^7.0.0",
+                "babel-core": "^7.0.0-bridge.0",
+                "colors": "^1.1.2",
+                "flow-parser": "0.*",
+                "graceful-fs": "^4.1.11",
+                "micromatch": "^3.1.10",
+                "neo-async": "^2.5.0",
+                "node-dir": "^0.1.17",
+                "recast": "^0.18.1",
+                "temp": "^0.8.1",
+                "write-file-atomic": "^2.3.0"
+            },
+            "dependencies": {
+                "write-file-atomic": {
+                    "version": "2.4.3",
+                    "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+                    "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.11",
+                        "imurmurhash": "^0.1.4",
+                        "signal-exit": "^3.0.2"
+                    }
+                }
+            }
+        },
         "jsdom": {
             "version": "16.4.0",
             "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.4.0.tgz",
@@ -13989,6 +15049,12 @@
             "version": "0.0.0",
             "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
             "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+        },
+        "jsonparse": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+            "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
+            "dev": true
         },
         "jsprim": {
             "version": "1.4.1",
@@ -14326,6 +15392,66 @@
             "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
             "dev": true
         },
+        "log-symbols": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
+            "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
+            "dev": true,
+            "requires": {
+                "chalk": "^4.0.0"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                    "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                }
+            }
+        },
         "logform": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/logform/-/logform-2.2.0.tgz",
@@ -14492,6 +15618,186 @@
             "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.4.tgz",
             "integrity": "sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==",
             "dev": true
+        },
+        "mem-fs": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/mem-fs/-/mem-fs-1.2.0.tgz",
+            "integrity": "sha512-b8g0jWKdl8pM0LqAPdK9i8ERL7nYrzmJfRhxMiWH2uYdfYnb7uXnmwVb0ZGe7xyEl4lj+nLIU3yf4zPUT+XsVQ==",
+            "dev": true,
+            "requires": {
+                "through2": "^3.0.0",
+                "vinyl": "^2.0.1",
+                "vinyl-file": "^3.0.0"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "3.6.0",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.2.1",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+                    "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+                    "dev": true
+                },
+                "string_decoder": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+                    "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "~5.2.0"
+                    }
+                },
+                "through2": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
+                    "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "^2.0.4",
+                        "readable-stream": "2 || 3"
+                    }
+                }
+            }
+        },
+        "mem-fs-editor": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/mem-fs-editor/-/mem-fs-editor-6.0.0.tgz",
+            "integrity": "sha512-e0WfJAMm8Gv1mP5fEq/Blzy6Lt1VbLg7gNnZmZak7nhrBTibs+c6nQ4SKs/ZyJYHS1mFgDJeopsLAv7Ow0FMFg==",
+            "dev": true,
+            "requires": {
+                "commondir": "^1.0.1",
+                "deep-extend": "^0.6.0",
+                "ejs": "^2.6.1",
+                "glob": "^7.1.4",
+                "globby": "^9.2.0",
+                "isbinaryfile": "^4.0.0",
+                "mkdirp": "^0.5.0",
+                "multimatch": "^4.0.0",
+                "rimraf": "^2.6.3",
+                "through2": "^3.0.1",
+                "vinyl": "^2.2.0"
+            },
+            "dependencies": {
+                "dir-glob": {
+                    "version": "2.2.2",
+                    "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.2.tgz",
+                    "integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
+                    "dev": true,
+                    "requires": {
+                        "path-type": "^3.0.0"
+                    }
+                },
+                "ejs": {
+                    "version": "2.7.4",
+                    "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.7.4.tgz",
+                    "integrity": "sha512-7vmuyh5+kuUyJKePhQfRQBhXV5Ce+RnaeeQArKu1EAMpL3WbgMt5WG6uQZpEVvYSSsxMXRKOewtDk9RaTKXRlA==",
+                    "dev": true
+                },
+                "glob": {
+                    "version": "7.1.6",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+                    "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                },
+                "globby": {
+                    "version": "9.2.0",
+                    "resolved": "https://registry.npmjs.org/globby/-/globby-9.2.0.tgz",
+                    "integrity": "sha512-ollPHROa5mcxDEkwg6bPt3QbEf4pDQSNtd6JPL1YvOvAo/7/0VAm9TccUeoTmarjPw4pfUthSCqcyfNB1I3ZSg==",
+                    "dev": true,
+                    "requires": {
+                        "@types/glob": "^7.1.1",
+                        "array-union": "^1.0.2",
+                        "dir-glob": "^2.2.2",
+                        "fast-glob": "^2.2.6",
+                        "glob": "^7.1.3",
+                        "ignore": "^4.0.3",
+                        "pify": "^4.0.1",
+                        "slash": "^2.0.0"
+                    }
+                },
+                "path-type": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+                    "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+                    "dev": true,
+                    "requires": {
+                        "pify": "^3.0.0"
+                    },
+                    "dependencies": {
+                        "pify": {
+                            "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+                            "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+                            "dev": true
+                        }
+                    }
+                },
+                "pify": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+                    "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "3.6.0",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.2.1",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+                    "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+                    "dev": true
+                },
+                "slash": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+                    "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+                    "dev": true
+                },
+                "string_decoder": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+                    "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "~5.2.0"
+                    }
+                },
+                "through2": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
+                    "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "^2.0.4",
+                        "readable-stream": "2 || 3"
+                    }
+                }
+            }
         },
         "memory-fs": {
             "version": "0.4.1",
@@ -14700,6 +16006,12 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
             "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+            "dev": true
+        },
+        "merge2": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+            "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
             "dev": true
         },
         "micromatch": {
@@ -15006,6 +16318,27 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
             "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
+        "multimatch": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-4.0.0.tgz",
+            "integrity": "sha512-lDmx79y1z6i7RNx0ZGCPq1bzJ6ZoDDKbvh7jxr9SJcWLkShMzXrHbYVpTdnhNM5MXpDUxCQ4DgqVttVXlBgiBQ==",
+            "dev": true,
+            "requires": {
+                "@types/minimatch": "^3.0.3",
+                "array-differ": "^3.0.0",
+                "array-union": "^2.1.0",
+                "arrify": "^2.0.1",
+                "minimatch": "^3.0.4"
+            },
+            "dependencies": {
+                "array-union": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+                    "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+                    "dev": true
+                }
+            }
+        },
         "mustache": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.0.1.tgz",
@@ -15146,6 +16479,15 @@
                     "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
                     "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
                 }
+            }
+        },
+        "node-dir": {
+            "version": "0.1.17",
+            "resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.17.tgz",
+            "integrity": "sha1-X1Zl2TNRM1yqvvjxxVRRbPXx5OU=",
+            "dev": true,
+            "requires": {
+                "minimatch": "^3.0.2"
             }
         },
         "node-fetch": {
@@ -15497,6 +16839,48 @@
             "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
             "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
             "dev": true
+        },
+        "npm-api": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/npm-api/-/npm-api-1.0.0.tgz",
+            "integrity": "sha512-gtJhIhGq07g9H5sIAB9TZzTySW8MYtcYqg+e+J+5q1GmDsDLLVfyvVBL1VklzjtRsElph11GUtLBS191RDOJxQ==",
+            "dev": true,
+            "requires": {
+                "JSONStream": "^1.3.5",
+                "clone-deep": "^4.0.1",
+                "download-stats": "^0.3.4",
+                "moment": "^2.24.0",
+                "paged-request": "^2.0.1",
+                "request": "^2.88.0"
+            },
+            "dependencies": {
+                "clone-deep": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
+                    "integrity": "sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==",
+                    "dev": true,
+                    "requires": {
+                        "is-plain-object": "^2.0.4",
+                        "kind-of": "^6.0.2",
+                        "shallow-clone": "^3.0.0"
+                    }
+                },
+                "kind-of": {
+                    "version": "6.0.3",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+                    "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+                    "dev": true
+                },
+                "shallow-clone": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-3.0.1.tgz",
+                    "integrity": "sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^6.0.2"
+                    }
+                }
+            }
         },
         "npm-bundled": {
             "version": "1.1.1",
@@ -15976,6 +17360,15 @@
             "integrity": "sha512-ZuRs1miPT4HrjFa+9fRfOFXxGJfORgelKV9f9nNOWw2gl6gVsRaVDOQP0+MI0G0wGKns1Yacsu0GjOFbTK0JFQ==",
             "dev": true
         },
+        "p-event": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/p-event/-/p-event-4.2.0.tgz",
+            "integrity": "sha512-KXatOjCRXXkSePPb1Nbi0p0m+gQAwdlbhi4wQKJPI1HsMQS9g+Sqp2o+QHziPr7eYJyOZet836KoHEVM1mwOrQ==",
+            "dev": true,
+            "requires": {
+                "p-timeout": "^3.1.0"
+            }
+        },
         "p-finally": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -15998,6 +17391,15 @@
                 "p-limit": "^2.0.0"
             }
         },
+        "p-timeout": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+            "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+            "dev": true,
+            "requires": {
+                "p-finally": "^1.0.0"
+            }
+        },
         "p-try": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
@@ -16013,6 +17415,33 @@
                 "registry-auth-token": "^4.0.0",
                 "registry-url": "^5.0.0",
                 "semver": "^6.2.0"
+            }
+        },
+        "paged-request": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/paged-request/-/paged-request-2.0.1.tgz",
+            "integrity": "sha512-C0bB/PFk9rQskD1YEiz7uuchzqKDQGgdsEHN1ahify0UUWzgmMK4NDG9fhlQg2waogmNFwEvEeHfMRvJySpdVw==",
+            "dev": true,
+            "requires": {
+                "axios": "^0.18.0"
+            },
+            "dependencies": {
+                "axios": {
+                    "version": "0.18.1",
+                    "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
+                    "integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
+                    "dev": true,
+                    "requires": {
+                        "follow-redirects": "1.5.10",
+                        "is-buffer": "^2.0.2"
+                    }
+                },
+                "is-buffer": {
+                    "version": "2.0.4",
+                    "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+                    "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+                    "dev": true
+                }
             }
         },
         "pako": {
@@ -16117,6 +17546,12 @@
                 "json-parse-even-better-errors": "^2.3.0",
                 "lines-and-columns": "^1.1.6"
             }
+        },
+        "parse-passwd": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+            "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
+            "dev": true
         },
         "parse5": {
             "version": "3.0.3",
@@ -16767,8 +18202,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
             "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-            "dev": true,
-            "optional": true
+            "dev": true
         },
         "pinkie": {
             "version": "2.0.4",
@@ -17124,10 +18558,26 @@
                 }
             }
         },
+        "prettyjson": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/prettyjson/-/prettyjson-1.2.1.tgz",
+            "integrity": "sha1-/P+rQdGcq0365eV15kJGYZsS0ok=",
+            "dev": true,
+            "requires": {
+                "colors": "^1.1.2",
+                "minimist": "^1.2.0"
+            }
+        },
         "prettysize": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/prettysize/-/prettysize-2.0.0.tgz",
             "integrity": "sha512-VVtxR7sOh0VsG8o06Ttq5TrI1aiZKmC+ClSn4eBPaNf4SHr5lzbYW+kYGX3HocBL/MfpVrRfFZ9V3vCbLaiplg==",
+            "dev": true
+        },
+        "private": {
+            "version": "0.1.8",
+            "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
+            "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
             "dev": true
         },
         "process": {
@@ -17562,6 +19012,11 @@
                 "react-is": "^16.9.0"
             }
         },
+        "react-refresh": {
+            "version": "0.8.3",
+            "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.8.3.tgz",
+            "integrity": "sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg=="
+        },
         "react-test-renderer": {
             "version": "16.13.1",
             "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.13.1.tgz",
@@ -17584,6 +19039,24 @@
                 "dom-helpers": "^5.0.1",
                 "loose-envify": "^1.4.0",
                 "prop-types": "^15.6.2"
+            }
+        },
+        "read-chunk": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/read-chunk/-/read-chunk-3.2.0.tgz",
+            "integrity": "sha512-CEjy9LCzhmD7nUpJ1oVOE6s/hBkejlcJEgLQHVnQznOSilOPb+kpKktlLfFDK3/WP43+F80xkUTM2VOkYoSYvQ==",
+            "dev": true,
+            "requires": {
+                "pify": "^4.0.1",
+                "with-open-file": "^0.1.6"
+            },
+            "dependencies": {
+                "pify": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+                    "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+                    "dev": true
+                }
             }
         },
         "read-config-file": {
@@ -17736,6 +19209,35 @@
                 }
             }
         },
+        "recast": {
+            "version": "0.18.10",
+            "resolved": "https://registry.npmjs.org/recast/-/recast-0.18.10.tgz",
+            "integrity": "sha512-XNvYvkfdAN9QewbrxeTOjgINkdY/odTgTS56ZNEWL9Ml0weT4T3sFtvnTuF+Gxyu46ANcRm1ntrF6F5LAJPAaQ==",
+            "dev": true,
+            "requires": {
+                "ast-types": "0.13.3",
+                "esprima": "~4.0.0",
+                "private": "^0.1.8",
+                "source-map": "~0.6.1"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                    "dev": true
+                }
+            }
+        },
+        "rechoir": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.7.0.tgz",
+            "integrity": "sha512-ADsDEH2bvbjltXEP+hTIAmeFekTFK0V2BTxMkok6qILyAJEXV0AFfoWcAq4yfll5VdIMd/RVXq0lR+wQi5ZU3Q==",
+            "dev": true,
+            "requires": {
+                "resolve": "^1.9.0"
+            }
+        },
         "redent": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -17745,6 +19247,12 @@
                 "indent-string": "^4.0.0",
                 "strip-indent": "^3.0.0"
             }
+        },
+        "reduce-flatten": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/reduce-flatten/-/reduce-flatten-2.0.0.tgz",
+            "integrity": "sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w==",
+            "dev": true
         },
         "redux": {
             "version": "4.0.5",
@@ -18080,6 +19588,29 @@
                 }
             }
         },
+        "resolve-dir": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+            "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
+            "dev": true,
+            "requires": {
+                "expand-tilde": "^2.0.0",
+                "global-modules": "^1.0.0"
+            },
+            "dependencies": {
+                "global-modules": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+                    "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+                    "dev": true,
+                    "requires": {
+                        "global-prefix": "^1.0.1",
+                        "is-windows": "^1.0.1",
+                        "resolve-dir": "^1.0.0"
+                    }
+                }
+            }
+        },
         "resolve-from": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -18401,6 +19932,12 @@
                 "ajv-keywords": "^3.1.0"
             }
         },
+        "scoped-regex": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/scoped-regex/-/scoped-regex-1.0.0.tgz",
+            "integrity": "sha1-o0a7Gs1CB65wvXwMfKnlZra63bg=",
+            "dev": true
+        },
         "semver": {
             "version": "6.3.0",
             "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -18501,6 +20038,15 @@
             "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
             "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
         },
+        "set-getter": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/set-getter/-/set-getter-0.1.0.tgz",
+            "integrity": "sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=",
+            "dev": true,
+            "requires": {
+                "to-object-path": "^0.3.0"
+            }
+        },
         "set-immediate-shim": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
@@ -18595,6 +20141,48 @@
             "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
             "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
             "dev": true
+        },
+        "shelljs": {
+            "version": "0.8.4",
+            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
+            "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
+            "dev": true,
+            "requires": {
+                "glob": "^7.0.0",
+                "interpret": "^1.0.0",
+                "rechoir": "^0.6.2"
+            },
+            "dependencies": {
+                "glob": {
+                    "version": "7.1.6",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+                    "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                },
+                "interpret": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
+                    "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
+                    "dev": true
+                },
+                "rechoir": {
+                    "version": "0.6.2",
+                    "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+                    "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+                    "dev": true,
+                    "requires": {
+                        "resolve": "^1.1.6"
+                    }
+                }
+            }
         },
         "shellwords": {
             "version": "0.1.1",
@@ -19206,6 +20794,12 @@
                 }
             }
         },
+        "string-template": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
+            "integrity": "sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0=",
+            "dev": true
+        },
         "string-width": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -19353,6 +20947,36 @@
             "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
             "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
             "dev": true
+        },
+        "strip-bom-buf": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom-buf/-/strip-bom-buf-1.0.0.tgz",
+            "integrity": "sha1-HLRar1dTD0yvhsf3UXnSyaUd1XI=",
+            "dev": true,
+            "requires": {
+                "is-utf8": "^0.2.1"
+            }
+        },
+        "strip-bom-stream": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-2.0.0.tgz",
+            "integrity": "sha1-+H217yYT9paKpUWr/h7HKLaoKco=",
+            "dev": true,
+            "requires": {
+                "first-chunk-stream": "^2.0.0",
+                "strip-bom": "^2.0.0"
+            },
+            "dependencies": {
+                "strip-bom": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+                    "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+                    "dev": true,
+                    "requires": {
+                        "is-utf8": "^0.2.0"
+                    }
+                }
+            }
         },
         "strip-eof": {
             "version": "1.0.0",
@@ -19565,6 +21189,18 @@
                 }
             }
         },
+        "table-layout": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-1.0.1.tgz",
+            "integrity": "sha512-dEquqYNJiGwY7iPfZ3wbXDI944iqanTSchrACLL2nOB+1r+h1Nzu2eH+DuPPvWvm5Ry7iAPeFlgEtP5bIp5U7Q==",
+            "dev": true,
+            "requires": {
+                "array-back": "^4.0.1",
+                "deep-extend": "~0.6.0",
+                "typical": "^5.2.0",
+                "wordwrapjs": "^4.0.0"
+            }
+        },
         "tapable": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
@@ -19761,6 +21397,40 @@
                 }
             }
         },
+        "temp": {
+            "version": "0.8.4",
+            "resolved": "https://registry.npmjs.org/temp/-/temp-0.8.4.tgz",
+            "integrity": "sha512-s0ZZzd0BzYv5tLSptZooSjK8oj6C+c19p7Vqta9+6NPOf7r+fxq0cJe6/oN4LTC79sy5NY8ucOJNgwsKCSbfqg==",
+            "dev": true,
+            "requires": {
+                "rimraf": "~2.6.2"
+            },
+            "dependencies": {
+                "glob": {
+                    "version": "7.1.6",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+                    "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                },
+                "rimraf": {
+                    "version": "2.6.3",
+                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+                    "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+                    "dev": true,
+                    "requires": {
+                        "glob": "^7.1.3"
+                    }
+                }
+            }
+        },
         "temp-file": {
             "version": "3.3.7",
             "resolved": "https://registry.npmjs.org/temp-file/-/temp-file-3.3.7.tgz",
@@ -19931,6 +21601,12 @@
             "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
             "dev": true
         },
+        "textextensions": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/textextensions/-/textextensions-2.6.0.tgz",
+            "integrity": "sha512-49WtAWS+tcsy93dRt6P0P3AMD2m5PvXRhuEA0kaXos5ZLlujtYmpmFsB+QvWUSxE1ZsstmYXfQ7L40+EcQgpAQ==",
+            "dev": true
+        },
         "throat": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/throat/-/throat-5.0.0.tgz",
@@ -19956,6 +21632,12 @@
                 "readable-stream": ">=1.0.33-1 <1.1.0-0",
                 "xtend": ">=4.0.0 <4.1.0-0"
             }
+        },
+        "timed-out": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+            "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
+            "dev": true
         },
         "timers-browserify": {
             "version": "2.0.11",
@@ -20209,6 +21891,12 @@
             "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
             "dev": true
         },
+        "typical": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/typical/-/typical-5.2.0.tgz",
+            "integrity": "sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==",
+            "dev": true
+        },
         "ua-parser-js": {
             "version": "0.7.22",
             "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.22.tgz",
@@ -20424,6 +22112,12 @@
                 }
             }
         },
+        "untildify": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/untildify/-/untildify-3.0.3.tgz",
+            "integrity": "sha512-iSk/J8efr8uPT/Z4eSUywnqyrQU7DSdMfdqK4iWEaUVVmcP5JcnpRqmVMwcwcnmI1ATFNgC5V90u09tBynNFKA==",
+            "dev": true
+        },
         "unzip-crx-3": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/unzip-crx-3/-/unzip-crx-3-0.2.0.tgz",
@@ -20434,6 +22128,12 @@
                 "mkdirp": "^0.5.1",
                 "yaku": "^0.16.6"
             }
+        },
+        "unzip-response": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-2.0.1.tgz",
+            "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
+            "dev": true
         },
         "unzipper": {
             "version": "0.8.14",
@@ -20812,6 +22512,41 @@
                 "unist-util-stringify-position": "^1.1.1"
             }
         },
+        "vinyl": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.1.tgz",
+            "integrity": "sha512-LII3bXRFBZLlezoG5FfZVcXflZgWP/4dCwKtxd5ky9+LOtM4CS3bIRQsmR1KMnMW07jpE8fqR2lcxPZ+8sJIcw==",
+            "dev": true,
+            "requires": {
+                "clone": "^2.1.1",
+                "clone-buffer": "^1.0.0",
+                "clone-stats": "^1.0.0",
+                "cloneable-readable": "^1.0.0",
+                "remove-trailing-separator": "^1.0.1",
+                "replace-ext": "^1.0.0"
+            }
+        },
+        "vinyl-file": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/vinyl-file/-/vinyl-file-3.0.0.tgz",
+            "integrity": "sha1-sQTZ5ECf+jJfqt1SBkLQo7SIs2U=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "^4.1.2",
+                "pify": "^2.3.0",
+                "strip-bom-buf": "^1.0.0",
+                "strip-bom-stream": "^2.0.0",
+                "vinyl": "^2.0.1"
+            },
+            "dependencies": {
+                "pify": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+                    "dev": true
+                }
+            }
+        },
         "vm-browserify": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
@@ -21178,6 +22913,101 @@
                 }
             }
         },
+        "webpack-cli": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.0.0.tgz",
+            "integrity": "sha512-c5NOm8jDp3qWa+Q4pDZTcT5IwPcPXdjU1ejN9e7LojHQN02sjNr4tzLrt5pwkY+zN8pQL40m14JsbC2Dh+ZJ/w==",
+            "dev": true,
+            "requires": {
+                "@webpack-cli/info": "^1.0.1",
+                "@webpack-cli/init": "^1.0.1",
+                "@webpack-cli/serve": "^1.0.1",
+                "ansi-escapes": "^4.3.1",
+                "colorette": "^1.2.1",
+                "command-line-usage": "^6.1.0",
+                "commander": "^6.0.0",
+                "enquirer": "^2.3.4",
+                "execa": "^4.0.0",
+                "import-local": "^3.0.2",
+                "interpret": "^2.0.0",
+                "rechoir": "^0.7.0",
+                "v8-compile-cache": "^2.1.0",
+                "webpack-merge": "^4.2.2"
+            },
+            "dependencies": {
+                "ansi-escapes": {
+                    "version": "4.3.1",
+                    "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
+                    "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
+                    "dev": true,
+                    "requires": {
+                        "type-fest": "^0.11.0"
+                    }
+                },
+                "commander": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-6.1.0.tgz",
+                    "integrity": "sha512-wl7PNrYWd2y5mp1OK/LhTlv8Ff4kQJQRXXAvF+uU/TPNiVJUxZLRYGj/B0y/lPGAVcSbJqH2Za/cvHmrPMC8mA==",
+                    "dev": true
+                },
+                "execa": {
+                    "version": "4.0.3",
+                    "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.3.tgz",
+                    "integrity": "sha512-WFDXGHckXPWZX19t1kCsXzOpqX9LWYNqn4C+HqZlk/V0imTkzJZqf87ZBhvpHaftERYknpk0fjSylnXVlVgI0A==",
+                    "dev": true,
+                    "requires": {
+                        "cross-spawn": "^7.0.0",
+                        "get-stream": "^5.0.0",
+                        "human-signals": "^1.1.1",
+                        "is-stream": "^2.0.0",
+                        "merge-stream": "^2.0.0",
+                        "npm-run-path": "^4.0.0",
+                        "onetime": "^5.1.0",
+                        "signal-exit": "^3.0.2",
+                        "strip-final-newline": "^2.0.0"
+                    }
+                },
+                "get-stream": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+                    "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+                    "dev": true,
+                    "requires": {
+                        "pump": "^3.0.0"
+                    }
+                },
+                "is-stream": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+                    "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+                    "dev": true
+                },
+                "npm-run-path": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+                    "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+                    "dev": true,
+                    "requires": {
+                        "path-key": "^3.0.0"
+                    }
+                },
+                "type-fest": {
+                    "version": "0.11.0",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
+                    "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
+                    "dev": true
+                }
+            }
+        },
+        "webpack-merge": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-4.2.2.tgz",
+            "integrity": "sha512-TUE1UGoTX2Cd42j3krGYqObZbOD+xF7u28WB7tfUordytSjbWTIjK/8V0amkBfTYN4/pB/GIDlJZZ657BGG19g==",
+            "dev": true,
+            "requires": {
+                "lodash": "^4.17.15"
+            }
+        },
         "webpack-sources": {
             "version": "1.4.3",
             "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
@@ -21414,6 +23244,25 @@
                 }
             }
         },
+        "with-open-file": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/with-open-file/-/with-open-file-0.1.7.tgz",
+            "integrity": "sha512-ecJS2/oHtESJ1t3ZfMI3B7KIDKyfN0O16miWxdn30zdh66Yd3LsRFebXZXq6GU4xfxLf6nVxp9kIqElb5fqczA==",
+            "dev": true,
+            "requires": {
+                "p-finally": "^1.0.0",
+                "p-try": "^2.1.0",
+                "pify": "^4.0.1"
+            },
+            "dependencies": {
+                "pify": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+                    "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+                    "dev": true
+                }
+            }
+        },
         "word-wrap": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -21425,6 +23274,16 @@
             "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
             "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
             "dev": true
+        },
+        "wordwrapjs": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-4.0.0.tgz",
+            "integrity": "sha512-Svqw723a3R34KvsMgpjFBYCgNOSdcW3mQFK4wIfhGQhtaFVOJmdYoXgi63ne3dTlWgatVcUc7t4HtQ/+bUVIzQ==",
+            "dev": true,
+            "requires": {
+                "reduce-flatten": "^2.0.0",
+                "typical": "^5.0.0"
+            }
         },
         "worker-farm": {
             "version": "1.7.0",
@@ -21736,6 +23595,567 @@
             "requires": {
                 "buffer-crc32": "~0.2.3",
                 "fd-slicer": "~1.1.0"
+            }
+        },
+        "yeoman-environment": {
+            "version": "2.10.3",
+            "resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-2.10.3.tgz",
+            "integrity": "sha512-pLIhhU9z/G+kjOXmJ2bPFm3nejfbH+f1fjYRSOteEXDBrv1EoJE/e+kuHixSXfCYfTkxjYsvRaDX+1QykLCnpQ==",
+            "dev": true,
+            "requires": {
+                "chalk": "^2.4.1",
+                "debug": "^3.1.0",
+                "diff": "^3.5.0",
+                "escape-string-regexp": "^1.0.2",
+                "execa": "^4.0.0",
+                "globby": "^8.0.1",
+                "grouped-queue": "^1.1.0",
+                "inquirer": "^7.1.0",
+                "is-scoped": "^1.0.0",
+                "lodash": "^4.17.10",
+                "log-symbols": "^2.2.0",
+                "mem-fs": "^1.1.0",
+                "mem-fs-editor": "^6.0.0",
+                "npm-api": "^1.0.0",
+                "semver": "^7.1.3",
+                "strip-ansi": "^4.0.0",
+                "text-table": "^0.2.0",
+                "untildify": "^3.0.3",
+                "yeoman-generator": "^4.8.2"
+            },
+            "dependencies": {
+                "ansi-escapes": {
+                    "version": "4.3.1",
+                    "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.1.tgz",
+                    "integrity": "sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==",
+                    "dev": true,
+                    "requires": {
+                        "type-fest": "^0.11.0"
+                    }
+                },
+                "ansi-regex": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+                    "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+                    "dev": true
+                },
+                "ansi-styles": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+                    "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^2.0.1"
+                    }
+                },
+                "cli-cursor": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+                    "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+                    "dev": true,
+                    "requires": {
+                        "restore-cursor": "^3.1.0"
+                    }
+                },
+                "cli-width": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-3.0.0.tgz",
+                    "integrity": "sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==",
+                    "dev": true
+                },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
+                "execa": {
+                    "version": "4.0.3",
+                    "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.3.tgz",
+                    "integrity": "sha512-WFDXGHckXPWZX19t1kCsXzOpqX9LWYNqn4C+HqZlk/V0imTkzJZqf87ZBhvpHaftERYknpk0fjSylnXVlVgI0A==",
+                    "dev": true,
+                    "requires": {
+                        "cross-spawn": "^7.0.0",
+                        "get-stream": "^5.0.0",
+                        "human-signals": "^1.1.1",
+                        "is-stream": "^2.0.0",
+                        "merge-stream": "^2.0.0",
+                        "npm-run-path": "^4.0.0",
+                        "onetime": "^5.1.0",
+                        "signal-exit": "^3.0.2",
+                        "strip-final-newline": "^2.0.0"
+                    }
+                },
+                "figures": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
+                    "integrity": "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==",
+                    "dev": true,
+                    "requires": {
+                        "escape-string-regexp": "^1.0.5"
+                    }
+                },
+                "get-stream": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+                    "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+                    "dev": true,
+                    "requires": {
+                        "pump": "^3.0.0"
+                    }
+                },
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+                    "dev": true
+                },
+                "inquirer": {
+                    "version": "7.3.3",
+                    "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz",
+                    "integrity": "sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-escapes": "^4.2.1",
+                        "chalk": "^4.1.0",
+                        "cli-cursor": "^3.1.0",
+                        "cli-width": "^3.0.0",
+                        "external-editor": "^3.0.3",
+                        "figures": "^3.0.0",
+                        "lodash": "^4.17.19",
+                        "mute-stream": "0.0.8",
+                        "run-async": "^2.4.0",
+                        "rxjs": "^6.6.0",
+                        "string-width": "^4.1.0",
+                        "strip-ansi": "^6.0.0",
+                        "through": "^2.3.6"
+                    },
+                    "dependencies": {
+                        "chalk": {
+                            "version": "4.1.0",
+                            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+                            "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+                            "dev": true,
+                            "requires": {
+                                "ansi-styles": "^4.1.0",
+                                "supports-color": "^7.1.0"
+                            }
+                        },
+                        "strip-ansi": {
+                            "version": "6.0.0",
+                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+                            "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+                            "dev": true,
+                            "requires": {
+                                "ansi-regex": "^5.0.0"
+                            }
+                        }
+                    }
+                },
+                "is-fullwidth-code-point": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+                    "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+                    "dev": true
+                },
+                "is-stream": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+                    "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+                    "dev": true
+                },
+                "log-symbols": {
+                    "version": "2.2.0",
+                    "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+                    "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^2.0.1"
+                    }
+                },
+                "mute-stream": {
+                    "version": "0.0.8",
+                    "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
+                    "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+                    "dev": true
+                },
+                "npm-run-path": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+                    "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+                    "dev": true,
+                    "requires": {
+                        "path-key": "^3.0.0"
+                    }
+                },
+                "restore-cursor": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+                    "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+                    "dev": true,
+                    "requires": {
+                        "onetime": "^5.1.0",
+                        "signal-exit": "^3.0.2"
+                    }
+                },
+                "semver": {
+                    "version": "7.3.2",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+                    "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+                    "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+                    "dev": true,
+                    "requires": {
+                        "emoji-regex": "^8.0.0",
+                        "is-fullwidth-code-point": "^3.0.0",
+                        "strip-ansi": "^6.0.0"
+                    },
+                    "dependencies": {
+                        "strip-ansi": {
+                            "version": "6.0.0",
+                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+                            "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+                            "dev": true,
+                            "requires": {
+                                "ansi-regex": "^5.0.0"
+                            }
+                        }
+                    }
+                },
+                "strip-ansi": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "^3.0.0"
+                    },
+                    "dependencies": {
+                        "ansi-regex": {
+                            "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                            "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                            "dev": true
+                        }
+                    }
+                },
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
+                },
+                "type-fest": {
+                    "version": "0.11.0",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.11.0.tgz",
+                    "integrity": "sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==",
+                    "dev": true
+                }
+            }
+        },
+        "yeoman-generator": {
+            "version": "4.12.0",
+            "resolved": "https://registry.npmjs.org/yeoman-generator/-/yeoman-generator-4.12.0.tgz",
+            "integrity": "sha512-lozwklVQHwUXMM1o8BgxEB8F5BB7vkHW4pjAo1Zt5sJ7FOlWhd6DJ4ZxJ2OK0w+gNYkY/ocPMkUV7DTz/uqEEg==",
+            "dev": true,
+            "requires": {
+                "async": "^2.6.2",
+                "chalk": "^2.4.2",
+                "cli-table": "^0.3.1",
+                "cross-spawn": "^6.0.5",
+                "dargs": "^6.1.0",
+                "dateformat": "^3.0.3",
+                "debug": "^4.1.1",
+                "diff": "^4.0.1",
+                "error": "^7.0.2",
+                "find-up": "^3.0.0",
+                "github-username": "^3.0.0",
+                "grouped-queue": "^1.1.0",
+                "istextorbinary": "^2.5.1",
+                "lodash": "^4.17.11",
+                "make-dir": "^3.0.0",
+                "mem-fs-editor": "^7.0.1",
+                "minimist": "^1.2.5",
+                "pretty-bytes": "^5.2.0",
+                "read-chunk": "^3.2.0",
+                "read-pkg-up": "^5.0.0",
+                "rimraf": "^2.6.3",
+                "run-async": "^2.0.0",
+                "semver": "^7.2.1",
+                "shelljs": "^0.8.3",
+                "text-table": "^0.2.0",
+                "through2": "^3.0.1",
+                "yeoman-environment": "^2.9.5"
+            },
+            "dependencies": {
+                "async": {
+                    "version": "2.6.3",
+                    "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+                    "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+                    "dev": true,
+                    "requires": {
+                        "lodash": "^4.17.14"
+                    }
+                },
+                "cross-spawn": {
+                    "version": "6.0.5",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+                    "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+                    "dev": true,
+                    "requires": {
+                        "nice-try": "^1.0.4",
+                        "path-key": "^2.0.1",
+                        "semver": "^5.5.0",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
+                    },
+                    "dependencies": {
+                        "semver": {
+                            "version": "5.7.1",
+                            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+                            "dev": true
+                        }
+                    }
+                },
+                "debug": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+                    "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.1.2"
+                    }
+                },
+                "diff": {
+                    "version": "4.0.2",
+                    "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+                    "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+                    "dev": true
+                },
+                "dir-glob": {
+                    "version": "2.2.2",
+                    "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.2.tgz",
+                    "integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
+                    "dev": true,
+                    "requires": {
+                        "path-type": "^3.0.0"
+                    }
+                },
+                "glob": {
+                    "version": "7.1.6",
+                    "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+                    "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+                    "dev": true,
+                    "requires": {
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                    }
+                },
+                "globby": {
+                    "version": "9.2.0",
+                    "resolved": "https://registry.npmjs.org/globby/-/globby-9.2.0.tgz",
+                    "integrity": "sha512-ollPHROa5mcxDEkwg6bPt3QbEf4pDQSNtd6JPL1YvOvAo/7/0VAm9TccUeoTmarjPw4pfUthSCqcyfNB1I3ZSg==",
+                    "dev": true,
+                    "requires": {
+                        "@types/glob": "^7.1.1",
+                        "array-union": "^1.0.2",
+                        "dir-glob": "^2.2.2",
+                        "fast-glob": "^2.2.6",
+                        "glob": "^7.1.3",
+                        "ignore": "^4.0.3",
+                        "pify": "^4.0.1",
+                        "slash": "^2.0.0"
+                    }
+                },
+                "mem-fs-editor": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/mem-fs-editor/-/mem-fs-editor-7.0.1.tgz",
+                    "integrity": "sha512-eD8r4/d2ayp9HHIgBPHB6Ds0ggA8F9cf9HxcNtbqrwqJXfIDrOSMG5K4fV3+Ib3B+HIdrWqkeDDDvrO7i9EbvQ==",
+                    "dev": true,
+                    "requires": {
+                        "commondir": "^1.0.1",
+                        "deep-extend": "^0.6.0",
+                        "ejs": "^3.0.1",
+                        "glob": "^7.1.4",
+                        "globby": "^9.2.0",
+                        "isbinaryfile": "^4.0.0",
+                        "mkdirp": "^1.0.0",
+                        "multimatch": "^4.0.0",
+                        "rimraf": "^3.0.0",
+                        "through2": "^3.0.1",
+                        "vinyl": "^2.2.0"
+                    },
+                    "dependencies": {
+                        "rimraf": {
+                            "version": "3.0.2",
+                            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+                            "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+                            "dev": true,
+                            "requires": {
+                                "glob": "^7.1.3"
+                            }
+                        }
+                    }
+                },
+                "mkdirp": {
+                    "version": "1.0.4",
+                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+                    "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+                    "dev": true
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                },
+                "path-key": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+                    "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+                    "dev": true
+                },
+                "path-type": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+                    "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+                    "dev": true,
+                    "requires": {
+                        "pify": "^3.0.0"
+                    },
+                    "dependencies": {
+                        "pify": {
+                            "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+                            "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+                            "dev": true
+                        }
+                    }
+                },
+                "pify": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+                    "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+                    "dev": true
+                },
+                "pretty-bytes": {
+                    "version": "5.4.1",
+                    "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.4.1.tgz",
+                    "integrity": "sha512-s1Iam6Gwz3JI5Hweaz4GoCD1WUNUIyzePFy5+Js2hjwGVt2Z79wNN+ZKOZ2vB6C+Xs6njyB84Z1IthQg8d9LxA==",
+                    "dev": true
+                },
+                "read-pkg": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+                    "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+                    "dev": true,
+                    "requires": {
+                        "@types/normalize-package-data": "^2.4.0",
+                        "normalize-package-data": "^2.5.0",
+                        "parse-json": "^5.0.0",
+                        "type-fest": "^0.6.0"
+                    }
+                },
+                "read-pkg-up": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-5.0.0.tgz",
+                    "integrity": "sha512-XBQjqOBtTzyol2CpsQOw8LHV0XbDZVG7xMMjmXAJomlVY03WOBRmYgDJETlvcg0H63AJvPRwT7GFi5rvOzUOKg==",
+                    "dev": true,
+                    "requires": {
+                        "find-up": "^3.0.0",
+                        "read-pkg": "^5.0.0"
+                    }
+                },
+                "readable-stream": {
+                    "version": "3.6.0",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.2.1",
+                    "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+                    "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+                    "dev": true
+                },
+                "semver": {
+                    "version": "7.3.2",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+                    "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+                    "dev": true
+                },
+                "shebang-command": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+                    "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+                    "dev": true,
+                    "requires": {
+                        "shebang-regex": "^1.0.0"
+                    }
+                },
+                "shebang-regex": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+                    "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+                    "dev": true
+                },
+                "slash": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+                    "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+                    "dev": true
+                },
+                "string_decoder": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+                    "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "~5.2.0"
+                    }
+                },
+                "through2": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
+                    "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "^2.0.4",
+                        "readable-stream": "2 || 3"
+                    }
+                },
+                "type-fest": {
+                    "version": "0.6.0",
+                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+                    "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+                    "dev": true
+                }
             }
         },
         "zip-stream": {

--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
         "pc-nrfconnect-shared": "github:NordicSemiconductor/pc-nrfconnect-shared#v4.10.4",
         "spectron": "7.0.0",
         "tar": "6.0.2",
+        "webpack-cli": "^4.0.0",
         "xvfb-maybe": "0.2.1"
     },
     "dependencies": {
@@ -148,6 +149,7 @@
         "react-dom": "16.13.1",
         "react-markdown": "4.3.1",
         "react-redux": "7.2.0",
+        "react-refresh": "^0.8.3",
         "roboto-fontface": "0.10.0",
         "shasum": "1.0.2",
         "targz": "1.0.1",

--- a/resources/launcher-dev.html
+++ b/resources/launcher-dev.html
@@ -6,6 +6,6 @@
 </head>
 <body>
 <div id='webapp'></div>
-<script src="http://localhost:8080/launcher-bundle.js"></script>
+<script src="http://localhost:5004/launcher-bundle.js"></script>
 </body>
 </html>

--- a/resources/launcher-dev.html
+++ b/resources/launcher-dev.html
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset='UTF-8'/>
-    <link rel='stylesheet' type='text/css' href='../dist/launcher.css'>
+    <link rel='stylesheet' type='text/css' href='http://localhost:5004/launcher.css'>
 </head>
 <body>
 <div id='webapp'></div>

--- a/resources/launcher-dev.html
+++ b/resources/launcher-dev.html
@@ -6,6 +6,6 @@
 </head>
 <body>
 <div id='webapp'></div>
-<script src="../dist/launcher-bundle.js"></script>
+<script src="http://localhost:8080/launcher-bundle.js"></script>
 </body>
 </html>

--- a/resources/launcher.html
+++ b/resources/launcher.html
@@ -6,7 +6,7 @@
 </head>
 <body>
 <div id='webapp'></div>
-
-<script src="../dist/launcher-bundle.js"></script>
+<!-- <script src="../dist/launcher-bundle.js"></script> -->
+<script src="http://localhost:8080/launcher-bundle.js"></script>
 </body>
 </html>

--- a/src/launcher/index.js
+++ b/src/launcher/index.js
@@ -53,6 +53,8 @@ import * as ProxyActions from './actions/proxyActions';
 import * as UsageDataActions from './actions/usageDataActions';
 import '../../resources/css/launcher.scss';
 
+module.hot.accept();
+
 const config = remote.require('../main/config');
 const settings = remote.require('../main/settings');
 const net = remote.require('../main/net');

--- a/src/main/windows.js
+++ b/src/main/windows.js
@@ -37,6 +37,7 @@
 'use strict';
 
 const electron = require('electron');
+const isDev = require('electron-is-dev');
 const path = require('path');
 const browser = require('./browser');
 const config = require('./config');
@@ -58,9 +59,11 @@ function openLauncherWindow() {
     if (launcherWindow) {
         launcherWindow.show();
     } else {
+        const launcherTemplate = isDev ? 'launcher-dev.html' : 'launcher.html';
+
         launcherWindow = browser.createWindow({
             title: `nRF Connect v${config.getVersion()}`,
-            url: `file://${config.getElectronResourcesDir()}/launcher.html`,
+            url: `file://${config.getElectronResourcesDir()}/${launcherTemplate}`,
             icon: getDefaultIconPath(),
             width: 760,
             height: 500,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -43,7 +43,7 @@ module.exports = {
         contentBase: path.join(__dirname, '/dist/'),
         inline: true,
         stats: { colors: true },
-        port: 8080
+        port: 8080,
     },
     module: {
         rules: [
@@ -61,8 +61,8 @@ module.exports = {
                     {
                         loader: require.resolve('eslint-loader'),
                         options: {
-                            emitWarning: true
-                        }
+                            emitWarning: true,
+                        },
                     },
                 ],
                 exclude: /node_modules\/(?!pc-nrfconnect-shared\/)/,
@@ -92,6 +92,7 @@ module.exports = {
         symlinks: false,
     },
     plugins: [
+        new webpack.HotModuleReplacementPlugin(),
         isDev && new ReactRefreshWebpackPlugin(),
         new webpack.DefinePlugin({
             'process.env.NODE_ENV': JSON.stringify(nodeEnv),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,9 +1,11 @@
 const webpack = require('webpack');
 const path = require('path');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin');
 
 const nodeEnv = process.env.NODE_ENV || 'development';
 const isProd = nodeEnv === 'production';
+const isDev = !isProd;
 
 function createExternals() {
     // Some libraries, e.g. those with native addons, cannot be bundled
@@ -16,6 +18,7 @@ function createExternals() {
         'nrf-device-setup',
         'osx-temperature-sensor',
     ];
+
     return libs.reduce(
         (prev, lib) => Object.assign(prev, { [lib]: `commonjs ${lib}` }),
         {}
@@ -34,6 +37,11 @@ module.exports = {
         path: path.resolve('dist'),
         publicPath: '../dist/',
         filename: '[name]-bundle.js',
+    },
+    devServer: {
+        hot: true,
+        publicPath: '../dist/',
+        stats: { colors: true },
     },
     module: {
         rules: [
@@ -79,6 +87,8 @@ module.exports = {
         symlinks: false,
     },
     plugins: [
+        new webpack.HotModuleReplacementPlugin(),
+        isDev && new ReactRefreshWebpackPlugin(),
         new webpack.DefinePlugin({
             'process.env.NODE_ENV': JSON.stringify(nodeEnv),
         }),
@@ -90,7 +100,8 @@ module.exports = {
                 name === 'app' ? 'legacy.css' : '[name].css',
             chunkFilename: '[id].css',
         }),
-    ],
+    ].filter(Boolean),
+    watch: true,
     externals: createExternals(),
     target: 'electron-renderer',
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,13 +35,15 @@ module.exports = {
     },
     output: {
         path: path.resolve('dist'),
-        publicPath: '../dist/',
+        publicPath: isDev ? 'http://localhost:8080/' : '../dist/',
         filename: '[name]-bundle.js',
     },
     devServer: {
         hot: true,
-        publicPath: '../dist/',
+        contentBase: path.join(__dirname, '/dist/'),
+        inline: true,
         stats: { colors: true },
+        port: 8080
     },
     module: {
         rules: [
@@ -58,6 +60,9 @@ module.exports = {
                     },
                     {
                         loader: require.resolve('eslint-loader'),
+                        options: {
+                            emitWarning: true
+                        }
                     },
                 ],
                 exclude: /node_modules\/(?!pc-nrfconnect-shared\/)/,
@@ -87,7 +92,6 @@ module.exports = {
         symlinks: false,
     },
     plugins: [
-        new webpack.HotModuleReplacementPlugin(),
         isDev && new ReactRefreshWebpackPlugin(),
         new webpack.DefinePlugin({
             'process.env.NODE_ENV': JSON.stringify(nodeEnv),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,7 +35,7 @@ module.exports = {
     },
     output: {
         path: path.resolve('dist'),
-        publicPath: isDev ? 'http://localhost:8080/' : '../dist/',
+        publicPath: isDev ? 'http://localhost:5004/' : '../dist/',
         filename: '[name]-bundle.js',
     },
     devServer: {
@@ -43,7 +43,7 @@ module.exports = {
         contentBase: path.join(__dirname, '/dist/'),
         inline: true,
         stats: { colors: true },
-        port: 8080,
+        port: 5004,
     },
     module: {
         rules: [


### PR DESCRIPTION
Adds hot reloading for developing the launcher, in tandem with the PR for shared.

By and large this was a case of adding a couple of hot-reload dependencies and fiddling with the configuration long enough to get them to work and play nice with our setup.

The biggest change is the introduction of a new `launcher-dev.html` file, which will be loaded whenever the launcher is run in development mode. This is necessary in order to link to a different script file, namely the one hosted by `webpack-dev-server` instead of one on the local filesystem.