### PR TITLE
Make port of the hot reload server configurable

### DIFF
--- a/resources/launcher-dev.html
+++ b/resources/launcher-dev.html
@@ -1,11 +1,23 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <meta charset='UTF-8'/>
-    <link rel='stylesheet' type='text/css' href='http://localhost:5004/launcher.css'>
+    <meta charset="UTF-8"/>
 </head>
 <body>
-<div id='webapp'></div>
-<script src="http://localhost:5004/launcher-bundle.js"></script>
+<div id="webapp"></div>
+<script>
+    const port = process.env.PORT || 5004;
+    const devServer = `http://localhost:${process.env.PORT}`;
+
+    const css = document.createElement('link');
+    css.setAttribute('rel', 'stylesheet');
+    css.setAttribute('type', 'text/css');
+    css.setAttribute('href', `${devServer}/launcher.css`);
+    document.querySelector('head').appendChild(css);
+
+    const javascript = document.createElement('script');
+    javascript.setAttribute('src', `${devServer}/launcher-bundle.js`);
+    document.querySelector('body').appendChild(javascript);
+</script>
 </body>
 </html>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,7 +35,9 @@ module.exports = {
     },
     output: {
         path: path.resolve('dist'),
-        publicPath: isDev ? 'http://localhost:5004/' : '../dist/',
+        publicPath: isDev
+            ? `http://localhost:${process.env.PORT || 5004}/`
+            : '../dist/',
         filename: '[name]-bundle.js',
     },
     devServer: {
@@ -43,7 +45,7 @@ module.exports = {
         contentBase: path.join(__dirname, '/dist/'),
         inline: true,
         stats: { colors: true },
-        port: 5004,
+        port: process.env.PORT || 5004,
     },
     module: {
         rules: [


### PR DESCRIPTION
With this one can start the compilation e.g. with

    PORT=5432 npm run dev

and the app with

    PORT=5432 npm run app

This will also require a change to `shared`, where https://github.com/NordicSemiconductor/pc-nrfconnect-shared/blob/6d887d0e1c6dd1744f6ed3f2c6c26efc95551180/scripts/build.js#L85 has to be replaced by 

```js
const port = process.env.PORT || 5004;
```