### PR TITLE
Fix: Missing release notes after app update

### DIFF
--- a/Changelog-dev.md
+++ b/Changelog-dev.md
@@ -1,6 +1,8 @@
 ## Version 3.6.1
 ### Updates
 - Small visual enhancements to apps using the new design
+### Bugfixes
+- After updating an app, the other apps showed no release notes anymore #502
 
 ## Version 3.6.0
 ### Updates

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,8 @@
 ## Version 3.6.1
 ### Updates
 - Small visual enhancements to apps using the new design
+### Bugfixes
+- After updating an app, the other apps showed no release notes anymore #502
 
 ## Version 3.6.0
 ### Updates

--- a/src/launcher/actions/appsActions.js
+++ b/src/launcher/actions/appsActions.js
@@ -98,10 +98,11 @@ function loadOfficialAppsAction() {
     };
 }
 
-function loadOfficialAppsSuccess(apps) {
+function loadOfficialAppsSuccess(apps, appToUpdate) {
     return {
         type: LOAD_OFFICIAL_APPS_SUCCESS,
         apps,
+        appToUpdate,
     };
 }
 
@@ -314,7 +315,12 @@ export function loadOfficialApps(appName, appSource) {
         return mainApps
             .getOfficialApps()
             .then(apps => {
-                dispatch(loadOfficialAppsSuccess(apps));
+                dispatch(
+                    loadOfficialAppsSuccess(
+                        apps,
+                        appName && { name: appName, source: appSource }
+                    )
+                );
                 apps.filter(({ path }) => !path).forEach(
                     ({ source, name, url }) => {
                         const iconPath = join(

--- a/src/launcher/reducers/appsReducer.js
+++ b/src/launcher/reducers/appsReducer.js
@@ -71,6 +71,20 @@ function setOfficialApps(state, apps) {
         .set('officialApps', List(immutableApps));
 }
 
+function setOfficialApp(state, loadedApps, appToUpdate) {
+    const findAppToUpdate = app =>
+        app.source === appToUpdate.source && app.name === appToUpdate.name;
+
+    return state
+        .set('isLoadingOfficialApps', false)
+        .update('officialApps', existingApps =>
+            existingApps.set(
+                existingApps.findKey(findAppToUpdate),
+                getImmutableApp(loadedApps.find(findAppToUpdate))
+            )
+        );
+}
+
 function showConfirmLaunchDialog(state, text, app) {
     return state
         .set('confirmLaunchText', text)
@@ -118,7 +132,9 @@ const reducer = (state = initialState, action) => {
         case AppsActions.LOAD_LOCAL_APPS_SUCCESS:
             return setLocalApps(state, action.apps);
         case AppsActions.LOAD_OFFICIAL_APPS_SUCCESS:
-            return setOfficialApps(state, action.apps);
+            return action.appToUpdate
+                ? setOfficialApp(state, action.apps, action.appToUpdate)
+                : setOfficialApps(state, action.apps);
         case AppsActions.LOAD_LOCAL_APPS_ERROR:
             return state.set('isLoadingLocalApps', false);
         case AppsActions.LOAD_OFFICIAL_APPS_ERROR:


### PR DESCRIPTION
After updating an app the others were not showing release notes anymore.

This was caused by this: After we update an app, we reload the data for all online available apps (the function is called `getOfficialApps` but it really loads from all sources). This causes existing data about the apps to be wiped, including the release notes. But as an optimisation we reload only the release notes about the just updated app, so the other apps are then left without release notes.

This fix does not wipe the existing data about all apps, only data about the just updated app is overwritten with the online data about it, thus the release notes from other apps are not removed anymore.

This is a bit of a quick fix. I think there are better ways to solve it but they would take more changes which do not seem appropriate so short before we want to release the launcher. So I will do them separately against `master` after we released 3.6.1.

Since we want to get this into 3.6.1 quickly, I assume it is correct to make this PR against the branch `release/3.6`. If it rather should go into `master`, then let us change the base branch of the PR.