### PR TITLE
Show app version in title bar

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 ## Unreleased
 ### Updates
-- Links to product page added for PPK2 and updated for nRF5340 DK.
+- Show app version in title bar (before only the version of the launcher was shown)
+- Links to product page added for PPK2 and updated for nRF5340 DK
 ### Bugfixes
 - macOS: When clicking on URLs in log entries the web site was not opened
 

--- a/src/main/windows.js
+++ b/src/main/windows.js
@@ -102,7 +102,7 @@ function openAppWindow(app) {
     const appWindow = browser.createWindow({
         title: `nRF Connect v${config.getVersion()} - ${
             app.displayName || app.name
-        }`,
+        } v${app.currentVersion}`,
         url: `file://${config.getElectronResourcesDir()}/app.html?appPath=${
             app.path
         }`,


### PR DESCRIPTION
Before only the version of the launcher was shown.

Checked that this also works in old app: 
![image](https://user-images.githubusercontent.com/260705/107038513-ed703b00-67bc-11eb-8d7c-429000593d4b.png) 

as well as in the PPK app which does modify it's title: 
![image](https://user-images.githubusercontent.com/260705/107038536-f5c87600-67bc-11eb-985c-7b7f6e0fa22a.png)

