### PR TITLE
Remove changelog entry

### DIFF
--- a/Changelog-dev.md
+++ b/Changelog-dev.md
@@ -1,7 +1,6 @@
 ## Unreleased
 ### Changed
 - Updated to pc-nrfconnect-shared 4.18.0
-- Updated API call to send usage data, replacing `sendEvent` by `sendUsageData`
 
 ## Version 3.6.0
 ### Bugfixes


### PR DESCRIPTION
Because it does not describe a change that is visible to the app
developers.