### PR TITLE
Handle undefined serialport

### DIFF
--- a/Changelog-dev.md
+++ b/Changelog-dev.md
@@ -1,4 +1,7 @@
 ## Unreleased
+### Bugfixes
+- Fixed issue where undefined serialport attribute causes crash #521
+
 ### Changed
 - Updated to pc-nrfconnect-shared 4.18.0
 

--- a/src/legacy/portPath.js
+++ b/src/legacy/portPath.js
@@ -35,4 +35,4 @@
  */
 
 // Prefer to use the serialport 8 property or fall back to the serialport 7 property
-export default serialPort => serialPort.path || serialPort.comName;
+export default serialPort => serialPort?.path || serialPort?.comName;


### PR DESCRIPTION
This provides at least a step in the direction of fixing [NCP-3537](https://projecttools.nordicsemi.no/jira/browse/NCP-3537). Currently `serialport` is undefined, which causes the app to crash. But I don't know if this prevents any issues further in the process since I am unable to reproduce this issue locally.