### PR TITLE
Add Error Boundary to the launcher itself.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -79,12 +79,12 @@
             }
         },
         "@babel/generator": {
-            "version": "7.14.1",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.1.tgz",
-            "integrity": "sha512-TMGhsXMXCP/O1WtQmZjpEYDhCYC9vFhayWZPJSZCGkPJgUqX0rF0wwtrYvnzVxIjcF80tkUertXVk5cwqi5cAQ==",
+            "version": "7.14.3",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.3.tgz",
+            "integrity": "sha512-bn0S6flG/j0xtQdz3hsjJ624h3W0r3llttBMfyHX3YrZ/KtLYr15bjA0FXkgW7FpvrDuTuElXeVjiKlYRpnOFA==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.14.1",
+                "@babel/types": "^7.14.2",
                 "jsesc": "^2.5.1",
                 "source-map": "^0.5.0"
             },
@@ -129,23 +129,23 @@
             }
         },
         "@babel/helper-create-class-features-plugin": {
-            "version": "7.14.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.14.1.tgz",
-            "integrity": "sha512-r8rsUahG4ywm0QpGcCrLaUSOuNAISR3IZCg4Fx05Ozq31aCUrQsTLH6KPxy0N5ULoQ4Sn9qjNdGNtbPWAC6hYg==",
+            "version": "7.14.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.14.3.tgz",
+            "integrity": "sha512-BnEfi5+6J2Lte9LeiL6TxLWdIlEv9Woacc1qXzXBgbikcOzMRM2Oya5XGg/f/ngotv1ej2A/b+3iJH8wbS1+lQ==",
             "dev": true,
             "requires": {
                 "@babel/helper-annotate-as-pure": "^7.12.13",
-                "@babel/helper-function-name": "^7.12.13",
+                "@babel/helper-function-name": "^7.14.2",
                 "@babel/helper-member-expression-to-functions": "^7.13.12",
                 "@babel/helper-optimise-call-expression": "^7.12.13",
-                "@babel/helper-replace-supers": "^7.13.12",
+                "@babel/helper-replace-supers": "^7.14.3",
                 "@babel/helper-split-export-declaration": "^7.12.13"
             }
         },
         "@babel/helper-create-regexp-features-plugin": {
-            "version": "7.12.17",
-            "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.12.17.tgz",
-            "integrity": "sha512-p2VGmBu9oefLZ2nQpgnEnG0ZlRPvL8gAGvPUMQwUdaE8k49rOMuZpOwdQoy5qJf6K8jL3bcAMhVUlHAjIgJHUg==",
+            "version": "7.14.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.14.3.tgz",
+            "integrity": "sha512-JIB2+XJrb7v3zceV2XzDhGIB902CmKGSpSl4q2C6agU9SNLG/2V1RtFRGPG1Ajh9STj3+q6zJMOC+N/pp2P9DA==",
             "dev": true,
             "requires": {
                 "@babel/helper-annotate-as-pure": "^7.12.13",
@@ -153,9 +153,9 @@
             }
         },
         "@babel/helper-define-polyfill-provider": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.2.0.tgz",
-            "integrity": "sha512-JT8tHuFjKBo8NnaUbblz7mIu1nnvUDiHVjXXkulZULyidvo/7P6TY7+YqpV37IfF+KUFxmlK04elKtGKXaiVgw==",
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.2.3.tgz",
+            "integrity": "sha512-RH3QDAfRMzj7+0Nqu5oqgO5q9mFtQEVvCRsi8qCEfzLR9p2BHfn5FzhSB2oj1fF7I2+DcTORkYaQ6aTR9Cofew==",
             "dev": true,
             "requires": {
                 "@babel/helper-compilation-targets": "^7.13.0",
@@ -195,14 +195,14 @@
             }
         },
         "@babel/helper-function-name": {
-            "version": "7.12.13",
-            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
-            "integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
+            "version": "7.14.2",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.2.tgz",
+            "integrity": "sha512-NYZlkZRydxw+YT56IlhIcS8PAhb+FEUiOzuhFTfqDyPmzAhRge6ua0dQYT/Uh0t/EDHq05/i+e5M2d4XvjgarQ==",
             "dev": true,
             "requires": {
                 "@babel/helper-get-function-arity": "^7.12.13",
                 "@babel/template": "^7.12.13",
-                "@babel/types": "^7.12.13"
+                "@babel/types": "^7.14.2"
             }
         },
         "@babel/helper-get-function-arity": {
@@ -243,9 +243,9 @@
             }
         },
         "@babel/helper-module-transforms": {
-            "version": "7.14.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.14.0.tgz",
-            "integrity": "sha512-L40t9bxIuGOfpIGA3HNkJhU9qYrf4y5A5LUSw7rGMSn+pcG8dfJ0g6Zval6YJGd2nEjI7oP00fRdnhLKndx6bw==",
+            "version": "7.14.2",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.14.2.tgz",
+            "integrity": "sha512-OznJUda/soKXv0XhpvzGWDnml4Qnwp16GN+D/kZIdLsWoHj05kyu8Rm5kXmMef+rVJZ0+4pSGLkeixdqNUATDA==",
             "dev": true,
             "requires": {
                 "@babel/helper-module-imports": "^7.13.12",
@@ -254,8 +254,8 @@
                 "@babel/helper-split-export-declaration": "^7.12.13",
                 "@babel/helper-validator-identifier": "^7.14.0",
                 "@babel/template": "^7.12.13",
-                "@babel/traverse": "^7.14.0",
-                "@babel/types": "^7.14.0"
+                "@babel/traverse": "^7.14.2",
+                "@babel/types": "^7.14.2"
             }
         },
         "@babel/helper-optimise-call-expression": {
@@ -285,15 +285,15 @@
             }
         },
         "@babel/helper-replace-supers": {
-            "version": "7.13.12",
-            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.13.12.tgz",
-            "integrity": "sha512-Gz1eiX+4yDO8mT+heB94aLVNCL+rbuT2xy4YfyNqu8F+OI6vMvJK891qGBTqL9Uc8wxEvRW92Id6G7sDen3fFw==",
+            "version": "7.14.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.14.3.tgz",
+            "integrity": "sha512-Rlh8qEWZSTfdz+tgNV/N4gz1a0TMNwCUcENhMjHTHKp3LseYH5Jha0NSlyTQWMnjbYcwFt+bqAMqSLHVXkQ6UA==",
             "dev": true,
             "requires": {
                 "@babel/helper-member-expression-to-functions": "^7.13.12",
                 "@babel/helper-optimise-call-expression": "^7.12.13",
-                "@babel/traverse": "^7.13.0",
-                "@babel/types": "^7.13.12"
+                "@babel/traverse": "^7.14.2",
+                "@babel/types": "^7.14.2"
             }
         },
         "@babel/helper-simple-access": {
@@ -370,9 +370,9 @@
             }
         },
         "@babel/parser": {
-            "version": "7.14.1",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.1.tgz",
-            "integrity": "sha512-muUGEKu8E/ftMTPlNp+mc6zL3E9zKWmF5sDHZ5MSsoTP9Wyz64AhEf9kD08xYJ7w6Hdcu8H550ircnPyWSIF0Q==",
+            "version": "7.14.3",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.3.tgz",
+            "integrity": "sha512-7MpZDIfI7sUC5zWo2+foJ50CSI5lcqDehZ0lVgIhSi4bFEk94fLAKlF3Q0nzSQQ+ca0lm+O6G9ztKVBeu8PMRQ==",
             "dev": true
         },
         "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
@@ -387,9 +387,9 @@
             }
         },
         "@babel/plugin-proposal-async-generator-functions": {
-            "version": "7.13.15",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.13.15.tgz",
-            "integrity": "sha512-VapibkWzFeoa6ubXy/NgV5U2U4MVnUlvnx6wo1XhlsaTrLYWE0UFpDQsVrmn22q5CzeloqJ8gEMHSKxuee6ZdA==",
+            "version": "7.14.2",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.14.2.tgz",
+            "integrity": "sha512-b1AM4F6fwck4N8ItZ/AtC4FP/cqZqmKRQ4FaTDutwSYyjuhtvsGEMLK4N/ztV/ImP40BjIDyMgBQAeAMsQYVFQ==",
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.13.0",
@@ -408,19 +408,20 @@
             }
         },
         "@babel/plugin-proposal-class-static-block": {
-            "version": "7.13.11",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-static-block/-/plugin-proposal-class-static-block-7.13.11.tgz",
-            "integrity": "sha512-fJTdFI4bfnMjvxJyNuaf8i9mVcZ0UhetaGEUHaHV9KEnibLugJkZAtXikR8KcYj+NYmI4DZMS8yQAyg+hvfSqg==",
+            "version": "7.14.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-static-block/-/plugin-proposal-class-static-block-7.14.3.tgz",
+            "integrity": "sha512-HEjzp5q+lWSjAgJtSluFDrGGosmwTgKwCXdDQZvhKsRlwv3YdkUEqxNrrjesJd+B9E9zvr1PVPVBvhYZ9msjvQ==",
             "dev": true,
             "requires": {
+                "@babel/helper-create-class-features-plugin": "^7.14.3",
                 "@babel/helper-plugin-utils": "^7.13.0",
                 "@babel/plugin-syntax-class-static-block": "^7.12.13"
             }
         },
         "@babel/plugin-proposal-dynamic-import": {
-            "version": "7.13.8",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.13.8.tgz",
-            "integrity": "sha512-ONWKj0H6+wIRCkZi9zSbZtE/r73uOhMVHh256ys0UzfM7I3d4n+spZNWjOnJv2gzopumP2Wxi186vI8N0Y2JyQ==",
+            "version": "7.14.2",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.14.2.tgz",
+            "integrity": "sha512-oxVQZIWFh91vuNEMKltqNsKLFWkOIyJc95k2Gv9lWVyDfPUQGSSlbDEgWuJUU1afGE9WwlzpucMZ3yDRHIItkA==",
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.13.0",
@@ -428,19 +429,19 @@
             }
         },
         "@babel/plugin-proposal-export-namespace-from": {
-            "version": "7.12.13",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.12.13.tgz",
-            "integrity": "sha512-INAgtFo4OnLN3Y/j0VwAgw3HDXcDtX+C/erMvWzuV9v71r7urb6iyMXu7eM9IgLr1ElLlOkaHjJ0SbCmdOQ3Iw==",
+            "version": "7.14.2",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.14.2.tgz",
+            "integrity": "sha512-sRxW3z3Zp3pFfLAgVEvzTFutTXax837oOatUIvSG9o5gRj9mKwm3br1Se5f4QalTQs9x4AzlA/HrCWbQIHASUQ==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.12.13",
+                "@babel/helper-plugin-utils": "^7.13.0",
                 "@babel/plugin-syntax-export-namespace-from": "^7.8.3"
             }
         },
         "@babel/plugin-proposal-json-strings": {
-            "version": "7.13.8",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.13.8.tgz",
-            "integrity": "sha512-w4zOPKUFPX1mgvTmL/fcEqy34hrQ1CRcGxdphBc6snDnnqJ47EZDIyop6IwXzAC8G916hsIuXB2ZMBCExC5k7Q==",
+            "version": "7.14.2",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.14.2.tgz",
+            "integrity": "sha512-w2DtsfXBBJddJacXMBhElGEYqCZQqN99Se1qeYn8DVLB33owlrlLftIbMzn5nz1OITfDVknXF433tBrLEAOEjA==",
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.13.0",
@@ -448,9 +449,9 @@
             }
         },
         "@babel/plugin-proposal-logical-assignment-operators": {
-            "version": "7.13.8",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.13.8.tgz",
-            "integrity": "sha512-aul6znYB4N4HGweImqKn59Su9RS8lbUIqxtXTOcAGtNIDczoEFv+l1EhmX8rUBp3G1jMjKJm8m0jXVp63ZpS4A==",
+            "version": "7.14.2",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.14.2.tgz",
+            "integrity": "sha512-1JAZtUrqYyGsS7IDmFeaem+/LJqujfLZ2weLR9ugB0ufUPjzf8cguyVT1g5im7f7RXxuLq1xUxEzvm68uYRtGg==",
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.13.0",
@@ -468,12 +469,12 @@
             }
         },
         "@babel/plugin-proposal-numeric-separator": {
-            "version": "7.12.13",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.12.13.tgz",
-            "integrity": "sha512-O1jFia9R8BUCl3ZGB7eitaAPu62TXJRHn7rh+ojNERCFyqRwJMTmhz+tJ+k0CwI6CLjX/ee4qW74FSqlq9I35w==",
+            "version": "7.14.2",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.14.2.tgz",
+            "integrity": "sha512-DcTQY9syxu9BpU3Uo94fjCB3LN9/hgPS8oUL7KrSW3bA2ePrKZZPJcc5y0hoJAM9dft3pGfErtEUvxXQcfLxUg==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.12.13",
+                "@babel/helper-plugin-utils": "^7.13.0",
                 "@babel/plugin-syntax-numeric-separator": "^7.10.4"
             }
         },
@@ -489,9 +490,9 @@
             }
         },
         "@babel/plugin-proposal-optional-catch-binding": {
-            "version": "7.13.8",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.13.8.tgz",
-            "integrity": "sha512-0wS/4DUF1CuTmGo+NiaHfHcVSeSLj5S3e6RivPTg/2k3wOv3jO35tZ6/ZWsQhQMvdgI7CwphjQa/ccarLymHVA==",
+            "version": "7.14.2",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.14.2.tgz",
+            "integrity": "sha512-XtkJsmJtBaUbOxZsNk0Fvrv8eiqgneug0A6aqLFZ4TSkar2L5dSXWcnUKHgmjJt49pyB/6ZHvkr3dPgl9MOWRQ==",
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.13.0",
@@ -499,9 +500,9 @@
             }
         },
         "@babel/plugin-proposal-optional-chaining": {
-            "version": "7.13.12",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.13.12.tgz",
-            "integrity": "sha512-fcEdKOkIB7Tf4IxrgEVeFC4zeJSTr78no9wTdBuZZbqF64kzllU0ybo2zrzm7gUQfxGhBgq4E39oRs8Zx/RMYQ==",
+            "version": "7.14.2",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.14.2.tgz",
+            "integrity": "sha512-qQByMRPwMZJainfig10BoaDldx/+VDtNcrA7qdNaEOAj6VXud+gfrkA8j4CRAU5HjnWREXqIpSpH30qZX1xivA==",
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.13.0",
@@ -733,25 +734,25 @@
             }
         },
         "@babel/plugin-transform-block-scoping": {
-            "version": "7.14.1",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.14.1.tgz",
-            "integrity": "sha512-2mQXd0zBrwfp0O1moWIhPpEeTKDvxyHcnma3JATVP1l+CctWBuot6OJG8LQ4DnBj4ZZPSmlb/fm4mu47EOAnVA==",
+            "version": "7.14.2",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.14.2.tgz",
+            "integrity": "sha512-neZZcP19NugZZqNwMTH+KoBjx5WyvESPSIOQb4JHpfd+zPfqcH65RMu5xJju5+6q/Y2VzYrleQTr+b6METyyxg==",
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.13.0"
             }
         },
         "@babel/plugin-transform-classes": {
-            "version": "7.13.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.13.0.tgz",
-            "integrity": "sha512-9BtHCPUARyVH1oXGcSJD3YpsqRLROJx5ZNP6tN5vnk17N0SVf9WCtf8Nuh1CFmgByKKAIMstitKduoCmsaDK5g==",
+            "version": "7.14.2",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.14.2.tgz",
+            "integrity": "sha512-7oafAVcucHquA/VZCsXv/gmuiHeYd64UJyyTYU+MPfNu0KeNlxw06IeENBO8bJjXVbolu+j1MM5aKQtH1OMCNg==",
             "dev": true,
             "requires": {
                 "@babel/helper-annotate-as-pure": "^7.12.13",
-                "@babel/helper-function-name": "^7.12.13",
+                "@babel/helper-function-name": "^7.14.2",
                 "@babel/helper-optimise-call-expression": "^7.12.13",
                 "@babel/helper-plugin-utils": "^7.13.0",
-                "@babel/helper-replace-supers": "^7.13.0",
+                "@babel/helper-replace-supers": "^7.13.12",
                 "@babel/helper-split-export-declaration": "^7.12.13",
                 "globals": "^11.1.0"
             }
@@ -841,12 +842,12 @@
             }
         },
         "@babel/plugin-transform-modules-amd": {
-            "version": "7.14.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.14.0.tgz",
-            "integrity": "sha512-CF4c5LX4LQ03LebQxJ5JZes2OYjzBuk1TdiF7cG7d5dK4lAdw9NZmaxq5K/mouUdNeqwz3TNjnW6v01UqUNgpQ==",
+            "version": "7.14.2",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.14.2.tgz",
+            "integrity": "sha512-hPC6XBswt8P3G2D1tSV2HzdKvkqOpmbyoy+g73JG0qlF/qx2y3KaMmXb1fLrpmWGLZYA0ojCvaHdzFWjlmV+Pw==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-transforms": "^7.14.0",
+                "@babel/helper-module-transforms": "^7.14.2",
                 "@babel/helper-plugin-utils": "^7.13.0",
                 "babel-plugin-dynamic-import-node": "^2.3.3"
             }
@@ -943,25 +944,25 @@
             }
         },
         "@babel/plugin-transform-react-display-name": {
-            "version": "7.12.13",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.12.13.tgz",
-            "integrity": "sha512-MprESJzI9O5VnJZrL7gg1MpdqmiFcUv41Jc7SahxYsNP2kDkFqClxxTZq+1Qv4AFCamm+GXMRDQINNn+qrxmiA==",
+            "version": "7.14.2",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.14.2.tgz",
+            "integrity": "sha512-zCubvP+jjahpnFJvPaHPiGVfuVUjXHhFvJKQdNnsmSsiU9kR/rCZ41jHc++tERD2zV+p7Hr6is+t5b6iWTCqSw==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.12.13"
+                "@babel/helper-plugin-utils": "^7.13.0"
             }
         },
         "@babel/plugin-transform-react-jsx": {
-            "version": "7.13.12",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.13.12.tgz",
-            "integrity": "sha512-jcEI2UqIcpCqB5U5DRxIl0tQEProI2gcu+g8VTIqxLO5Iidojb4d77q+fwGseCvd8af/lJ9masp4QWzBXFE2xA==",
+            "version": "7.14.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.14.3.tgz",
+            "integrity": "sha512-uuxuoUNVhdgYzERiHHFkE4dWoJx+UFVyuAl0aqN8P2/AKFHwqgUC5w2+4/PjpKXJsFgBlYAFXlUmDQ3k3DUkXw==",
             "dev": true,
             "requires": {
                 "@babel/helper-annotate-as-pure": "^7.12.13",
                 "@babel/helper-module-imports": "^7.13.12",
                 "@babel/helper-plugin-utils": "^7.13.0",
                 "@babel/plugin-syntax-jsx": "^7.12.13",
-                "@babel/types": "^7.13.12"
+                "@babel/types": "^7.14.2"
             }
         },
         "@babel/plugin-transform-react-jsx-development": {
@@ -983,12 +984,12 @@
             }
         },
         "@babel/plugin-transform-react-jsx-source": {
-            "version": "7.12.13",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.12.13.tgz",
-            "integrity": "sha512-O5JJi6fyfih0WfDgIJXksSPhGP/G0fQpfxYy87sDc+1sFmsCS6wr3aAn+whbzkhbjtq4VMqLRaSzR6IsshIC0Q==",
+            "version": "7.14.2",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.14.2.tgz",
+            "integrity": "sha512-OMorspVyjxghAjzgeAWc6O7W7vHbJhV69NeTGdl9Mxgz6PaweAuo7ffB9T5A1OQ9dGcw0As4SYMUhyNC4u7mVg==",
             "dev": true,
             "requires": {
-                "@babel/helper-plugin-utils": "^7.12.13"
+                "@babel/helper-plugin-utils": "^7.13.0"
             }
         },
         "@babel/plugin-transform-react-pure-annotations": {
@@ -1065,12 +1066,12 @@
             }
         },
         "@babel/plugin-transform-typescript": {
-            "version": "7.13.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.13.0.tgz",
-            "integrity": "sha512-elQEwluzaU8R8dbVuW2Q2Y8Nznf7hnjM7+DSCd14Lo5fF63C9qNLbwZYbmZrtV9/ySpSUpkRpQXvJb6xyu4hCQ==",
+            "version": "7.14.3",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.14.3.tgz",
+            "integrity": "sha512-G5Bb5pY6tJRTC4ag1visSgiDoGgJ1u1fMUgmc2ijLkcIdzP83Q1qyZX4ggFQ/SkR+PNOatkaYC+nKcTlpsX4ag==",
             "dev": true,
             "requires": {
-                "@babel/helper-create-class-features-plugin": "^7.13.0",
+                "@babel/helper-create-class-features-plugin": "^7.14.3",
                 "@babel/helper-plugin-utils": "^7.13.0",
                 "@babel/plugin-syntax-typescript": "^7.12.13"
             }
@@ -1095,9 +1096,9 @@
             }
         },
         "@babel/preset-env": {
-            "version": "7.14.1",
-            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.14.1.tgz",
-            "integrity": "sha512-0M4yL1l7V4l+j/UHvxcdvNfLB9pPtIooHTbEhgD/6UGyh8Hy3Bm1Mj0buzjDXATCSz3JFibVdnoJZCrlUCanrQ==",
+            "version": "7.14.2",
+            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.14.2.tgz",
+            "integrity": "sha512-7dD7lVT8GMrE73v4lvDEb85cgcQhdES91BSD7jS/xjC6QY8PnRhux35ac+GCpbiRhp8crexBvZZqnaL6VrY8TQ==",
             "dev": true,
             "requires": {
                 "@babel/compat-data": "^7.14.0",
@@ -1105,18 +1106,18 @@
                 "@babel/helper-plugin-utils": "^7.13.0",
                 "@babel/helper-validator-option": "^7.12.17",
                 "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.13.12",
-                "@babel/plugin-proposal-async-generator-functions": "^7.13.15",
+                "@babel/plugin-proposal-async-generator-functions": "^7.14.2",
                 "@babel/plugin-proposal-class-properties": "^7.13.0",
                 "@babel/plugin-proposal-class-static-block": "^7.13.11",
-                "@babel/plugin-proposal-dynamic-import": "^7.13.8",
-                "@babel/plugin-proposal-export-namespace-from": "^7.12.13",
-                "@babel/plugin-proposal-json-strings": "^7.13.8",
-                "@babel/plugin-proposal-logical-assignment-operators": "^7.13.8",
-                "@babel/plugin-proposal-nullish-coalescing-operator": "^7.13.8",
-                "@babel/plugin-proposal-numeric-separator": "^7.12.13",
-                "@babel/plugin-proposal-object-rest-spread": "^7.13.8",
-                "@babel/plugin-proposal-optional-catch-binding": "^7.13.8",
-                "@babel/plugin-proposal-optional-chaining": "^7.13.12",
+                "@babel/plugin-proposal-dynamic-import": "^7.14.2",
+                "@babel/plugin-proposal-export-namespace-from": "^7.14.2",
+                "@babel/plugin-proposal-json-strings": "^7.14.2",
+                "@babel/plugin-proposal-logical-assignment-operators": "^7.14.2",
+                "@babel/plugin-proposal-nullish-coalescing-operator": "^7.14.2",
+                "@babel/plugin-proposal-numeric-separator": "^7.14.2",
+                "@babel/plugin-proposal-object-rest-spread": "^7.14.2",
+                "@babel/plugin-proposal-optional-catch-binding": "^7.14.2",
+                "@babel/plugin-proposal-optional-chaining": "^7.14.2",
                 "@babel/plugin-proposal-private-methods": "^7.13.0",
                 "@babel/plugin-proposal-private-property-in-object": "^7.14.0",
                 "@babel/plugin-proposal-unicode-property-regex": "^7.12.13",
@@ -1137,8 +1138,8 @@
                 "@babel/plugin-transform-arrow-functions": "^7.13.0",
                 "@babel/plugin-transform-async-to-generator": "^7.13.0",
                 "@babel/plugin-transform-block-scoped-functions": "^7.12.13",
-                "@babel/plugin-transform-block-scoping": "^7.14.1",
-                "@babel/plugin-transform-classes": "^7.13.0",
+                "@babel/plugin-transform-block-scoping": "^7.14.2",
+                "@babel/plugin-transform-classes": "^7.14.2",
                 "@babel/plugin-transform-computed-properties": "^7.13.0",
                 "@babel/plugin-transform-destructuring": "^7.13.17",
                 "@babel/plugin-transform-dotall-regex": "^7.12.13",
@@ -1148,14 +1149,14 @@
                 "@babel/plugin-transform-function-name": "^7.12.13",
                 "@babel/plugin-transform-literals": "^7.12.13",
                 "@babel/plugin-transform-member-expression-literals": "^7.12.13",
-                "@babel/plugin-transform-modules-amd": "^7.14.0",
+                "@babel/plugin-transform-modules-amd": "^7.14.2",
                 "@babel/plugin-transform-modules-commonjs": "^7.14.0",
                 "@babel/plugin-transform-modules-systemjs": "^7.13.8",
                 "@babel/plugin-transform-modules-umd": "^7.14.0",
                 "@babel/plugin-transform-named-capturing-groups-regex": "^7.12.13",
                 "@babel/plugin-transform-new-target": "^7.12.13",
                 "@babel/plugin-transform-object-super": "^7.12.13",
-                "@babel/plugin-transform-parameters": "^7.13.0",
+                "@babel/plugin-transform-parameters": "^7.14.2",
                 "@babel/plugin-transform-property-literals": "^7.12.13",
                 "@babel/plugin-transform-regenerator": "^7.13.15",
                 "@babel/plugin-transform-reserved-words": "^7.12.13",
@@ -1167,7 +1168,7 @@
                 "@babel/plugin-transform-unicode-escapes": "^7.12.13",
                 "@babel/plugin-transform-unicode-regex": "^7.12.13",
                 "@babel/preset-modules": "^0.1.4",
-                "@babel/types": "^7.14.1",
+                "@babel/types": "^7.14.2",
                 "babel-plugin-polyfill-corejs2": "^0.2.0",
                 "babel-plugin-polyfill-corejs3": "^0.2.0",
                 "babel-plugin-polyfill-regenerator": "^0.2.0",
@@ -1185,17 +1186,27 @@
                         "@babel/helper-plugin-utils": "^7.13.0"
                     }
                 },
-                "@babel/plugin-proposal-object-rest-spread": {
-                    "version": "7.13.8",
-                    "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.13.8.tgz",
-                    "integrity": "sha512-DhB2EuB1Ih7S3/IRX5AFVgZ16k3EzfRbq97CxAVI1KSYcW+lexV8VZb7G7L8zuPVSdQMRn0kiBpf/Yzu9ZKH0g==",
+                "@babel/plugin-proposal-nullish-coalescing-operator": {
+                    "version": "7.14.2",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.14.2.tgz",
+                    "integrity": "sha512-ebR0zU9OvI2N4qiAC38KIAK75KItpIPTpAtd2r4OZmMFeKbKJpUFLYP2EuDut82+BmYi8sz42B+TfTptJ9iG5Q==",
                     "dev": true,
                     "requires": {
-                        "@babel/compat-data": "^7.13.8",
-                        "@babel/helper-compilation-targets": "^7.13.8",
+                        "@babel/helper-plugin-utils": "^7.13.0",
+                        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3"
+                    }
+                },
+                "@babel/plugin-proposal-object-rest-spread": {
+                    "version": "7.14.2",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.14.2.tgz",
+                    "integrity": "sha512-hBIQFxwZi8GIp934+nj5uV31mqclC1aYDhctDu5khTi9PCCUOczyy0b34W0oE9U/eJXiqQaKyVsmjeagOaSlbw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/compat-data": "^7.14.0",
+                        "@babel/helper-compilation-targets": "^7.13.16",
                         "@babel/helper-plugin-utils": "^7.13.0",
                         "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-                        "@babel/plugin-transform-parameters": "^7.13.0"
+                        "@babel/plugin-transform-parameters": "^7.14.2"
                     }
                 },
                 "@babel/plugin-transform-destructuring": {
@@ -1220,9 +1231,9 @@
                     }
                 },
                 "@babel/plugin-transform-parameters": {
-                    "version": "7.13.0",
-                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.13.0.tgz",
-                    "integrity": "sha512-Jt8k/h/mIwE2JFEOb3lURoY5C85ETcYPnbuAJ96zRBzh1XHtQZfs62ChZ6EP22QlC8c7Xqr9q+e1SU5qttwwjw==",
+                    "version": "7.14.2",
+                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.14.2.tgz",
+                    "integrity": "sha512-NxoVmA3APNCC1JdMXkdYXuQS+EMdqy0vIwyDHeKHiJKRxmp1qGSdb0JLEIoPRhkx6H/8Qi3RJ3uqOCYw8giy9A==",
                     "dev": true,
                     "requires": {
                         "@babel/helper-plugin-utils": "^7.13.0"
@@ -1309,17 +1320,17 @@
             }
         },
         "@babel/traverse": {
-            "version": "7.14.0",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.0.tgz",
-            "integrity": "sha512-dZ/a371EE5XNhTHomvtuLTUyx6UEoJmYX+DT5zBCQN3McHemsuIaKKYqsc/fs26BEkHs/lBZy0J571LP5z9kQA==",
+            "version": "7.14.2",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.2.tgz",
+            "integrity": "sha512-TsdRgvBFHMyHOOzcP9S6QU0QQtjxlRpEYOy3mcCO5RgmC305ki42aSAmfZEMSSYBla2oZ9BMqYlncBaKmD/7iA==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.12.13",
-                "@babel/generator": "^7.14.0",
-                "@babel/helper-function-name": "^7.12.13",
+                "@babel/generator": "^7.14.2",
+                "@babel/helper-function-name": "^7.14.2",
                 "@babel/helper-split-export-declaration": "^7.12.13",
-                "@babel/parser": "^7.14.0",
-                "@babel/types": "^7.14.0",
+                "@babel/parser": "^7.14.2",
+                "@babel/types": "^7.14.2",
                 "debug": "^4.1.0",
                 "globals": "^11.1.0"
             },
@@ -1342,9 +1353,9 @@
             }
         },
         "@babel/types": {
-            "version": "7.14.1",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.1.tgz",
-            "integrity": "sha512-S13Qe85fzLs3gYRUnrpyeIrBJIMYv33qSTg1qoBwiG6nPKwUWAD9odSzWhEedpwOIzSEI6gbdQIWEMiCI42iBA==",
+            "version": "7.14.2",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.2.tgz",
+            "integrity": "sha512-SdjAG/3DikRHpUOjxZgnkbR11xUlyDMUFJdvnIgZEE16mqmY0BINMmc4//JMJglEmn6i7sq6p+mGrFWyZ98EEw==",
             "dev": true,
             "requires": {
                 "@babel/helper-validator-identifier": "^7.14.0",
@@ -2470,20 +2481,20 @@
             },
             "dependencies": {
                 "@babel/core": {
-                    "version": "7.14.0",
-                    "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.0.tgz",
-                    "integrity": "sha512-8YqpRig5NmIHlMLw09zMlPTvUVMILjqCOtVgu+TVNWEBvy9b5I3RRyhqnrV4hjgEK7n8P9OqvkWJAFmEL6Wwfw==",
+                    "version": "7.14.3",
+                    "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.3.tgz",
+                    "integrity": "sha512-jB5AmTKOCSJIZ72sd78ECEhuPiDMKlQdDI/4QRI6lzYATx5SSogS1oQA2AoPecRCknm30gHi2l+QVvNUu3wZAg==",
                     "dev": true,
                     "requires": {
                         "@babel/code-frame": "^7.12.13",
-                        "@babel/generator": "^7.14.0",
+                        "@babel/generator": "^7.14.3",
                         "@babel/helper-compilation-targets": "^7.13.16",
-                        "@babel/helper-module-transforms": "^7.14.0",
+                        "@babel/helper-module-transforms": "^7.14.2",
                         "@babel/helpers": "^7.14.0",
-                        "@babel/parser": "^7.14.0",
+                        "@babel/parser": "^7.14.3",
                         "@babel/template": "^7.12.13",
-                        "@babel/traverse": "^7.14.0",
-                        "@babel/types": "^7.14.0",
+                        "@babel/traverse": "^7.14.2",
+                        "@babel/types": "^7.14.2",
                         "convert-source-map": "^1.7.0",
                         "debug": "^4.1.0",
                         "gensync": "^1.0.0-beta.2",
@@ -2710,6 +2721,12 @@
                 "@types/testing-library__react": "^10.0.1"
             }
         },
+        "@tootallnate/once": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
+            "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+            "dev": true
+        },
         "@types/aria-query": {
             "version": "4.2.1",
             "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.1.tgz",
@@ -2773,9 +2790,9 @@
             }
         },
         "@types/eslint": {
-            "version": "7.2.10",
-            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.10.tgz",
-            "integrity": "sha512-kUEPnMKrqbtpCq/KTaGFFKAcz6Ethm2EjCoKIDaCmfRBWLbFuTcOJfTlorwbnboXBzahqWLgUp1BQeKHiJzPUQ==",
+            "version": "7.2.11",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-7.2.11.tgz",
+            "integrity": "sha512-WYhv//5K8kQtsSc9F1Kn2vHzhYor6KpwPbARH7hwYe3C3ETD0EVx/3P5qQybUoaBEuUa9f/02JjBiXFWalYUmw==",
             "dev": true,
             "requires": {
                 "@types/estree": "*",
@@ -2987,9 +3004,9 @@
             "dev": true
         },
         "@types/react": {
-            "version": "16.14.6",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.6.tgz",
-            "integrity": "sha512-Ol/aFKune+P0FSFKIgf+XbhGzYGyz0p7g5befSt4rmbzfGLaZR0q7jPew9k7d3bvrcuaL8dPy9Oz3XGZmf9n+w==",
+            "version": "16.14.8",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-16.14.8.tgz",
+            "integrity": "sha512-QN0/Qhmx+l4moe7WJuTxNiTsjBwlBGHqKGvInSQCBdo7Qio0VtOqwsC0Wq7q3PbJlB0cR4Y4CVo1OOe6BOsOmA==",
             "dev": true,
             "requires": {
                 "@types/prop-types": "*",
@@ -3428,6 +3445,32 @@
             "integrity": "sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==",
             "dev": true
         },
+        "agent-base": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+            "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+            "dev": true,
+            "requires": {
+                "debug": "4"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.3.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+                    "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.1.2"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                }
+            }
+        },
         "airbnb-prop-types": {
             "version": "2.16.0",
             "resolved": "https://registry.npmjs.org/airbnb-prop-types/-/airbnb-prop-types-2.16.0.tgz",
@@ -3861,12 +3904,6 @@
             "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
             "dev": true
         },
-        "array-filter": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-1.0.0.tgz",
-            "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM=",
-            "dev": true
-        },
         "array-find-index": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
@@ -3892,6 +3929,87 @@
             "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
             "dev": true
         },
+        "array.prototype.filter": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/array.prototype.filter/-/array.prototype.filter-1.0.0.tgz",
+            "integrity": "sha512-TfO1gz+tLm+Bswq0FBOXPqAchtCr2Rn48T8dLJoRFl8NoEosjZmzptmuo1X8aZBzZcqsR1W8U761tjACJtngTQ==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2",
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.18.0",
+                "es-array-method-boxes-properly": "^1.0.0",
+                "is-string": "^1.0.5"
+            },
+            "dependencies": {
+                "es-abstract": {
+                    "version": "1.18.2",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.2.tgz",
+                    "integrity": "sha512-byRiNIQXE6HWNySaU6JohoNXzYgbBjztwFnBLUTiJmWXjaU9bSq3urQLUlNLQ292tc+gc07zYZXNZjaOoAX3sw==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.2",
+                        "es-to-primitive": "^1.2.1",
+                        "function-bind": "^1.1.1",
+                        "get-intrinsic": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-symbols": "^1.0.2",
+                        "is-callable": "^1.2.3",
+                        "is-negative-zero": "^2.0.1",
+                        "is-regex": "^1.1.3",
+                        "is-string": "^1.0.6",
+                        "object-inspect": "^1.10.3",
+                        "object-keys": "^1.1.1",
+                        "object.assign": "^4.1.2",
+                        "string.prototype.trimend": "^1.0.4",
+                        "string.prototype.trimstart": "^1.0.4",
+                        "unbox-primitive": "^1.0.1"
+                    }
+                },
+                "has-symbols": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+                    "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+                    "dev": true
+                },
+                "is-regex": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
+                    "integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.2",
+                        "has-symbols": "^1.0.2"
+                    }
+                },
+                "object-inspect": {
+                    "version": "1.10.3",
+                    "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
+                    "integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==",
+                    "dev": true
+                },
+                "string.prototype.trimend": {
+                    "version": "1.0.4",
+                    "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+                    "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.2",
+                        "define-properties": "^1.1.3"
+                    }
+                },
+                "string.prototype.trimstart": {
+                    "version": "1.0.4",
+                    "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+                    "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.2",
+                        "define-properties": "^1.1.3"
+                    }
+                }
+            }
+        },
         "array.prototype.find": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.1.1.tgz",
@@ -3903,9 +4021,9 @@
             },
             "dependencies": {
                 "es-abstract": {
-                    "version": "1.18.0",
-                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
-                    "integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
+                    "version": "1.18.2",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.2.tgz",
+                    "integrity": "sha512-byRiNIQXE6HWNySaU6JohoNXzYgbBjztwFnBLUTiJmWXjaU9bSq3urQLUlNLQ292tc+gc07zYZXNZjaOoAX3sw==",
                     "dev": true,
                     "requires": {
                         "call-bind": "^1.0.2",
@@ -3916,20 +4034,36 @@
                         "has-symbols": "^1.0.2",
                         "is-callable": "^1.2.3",
                         "is-negative-zero": "^2.0.1",
-                        "is-regex": "^1.1.2",
-                        "is-string": "^1.0.5",
-                        "object-inspect": "^1.9.0",
+                        "is-regex": "^1.1.3",
+                        "is-string": "^1.0.6",
+                        "object-inspect": "^1.10.3",
                         "object-keys": "^1.1.1",
                         "object.assign": "^4.1.2",
                         "string.prototype.trimend": "^1.0.4",
                         "string.prototype.trimstart": "^1.0.4",
-                        "unbox-primitive": "^1.0.0"
+                        "unbox-primitive": "^1.0.1"
                     }
                 },
                 "has-symbols": {
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
                     "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+                    "dev": true
+                },
+                "is-regex": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
+                    "integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.2",
+                        "has-symbols": "^1.0.2"
+                    }
+                },
+                "object-inspect": {
+                    "version": "1.10.3",
+                    "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
+                    "integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==",
                     "dev": true
                 },
                 "string.prototype.trimend": {
@@ -4309,33 +4443,33 @@
             }
         },
         "babel-plugin-polyfill-corejs2": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.2.0.tgz",
-            "integrity": "sha512-9bNwiR0dS881c5SHnzCmmGlMkJLl0OUZvxrxHo9w/iNoRuqaPjqlvBf4HrovXtQs/au5yKkpcdgfT1cC5PAZwg==",
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.2.2.tgz",
+            "integrity": "sha512-kISrENsJ0z5dNPq5eRvcctITNHYXWOA4DUZRFYCz3jYCcvTb/A546LIddmoGNMVYg2U38OyFeNosQwI9ENTqIQ==",
             "dev": true,
             "requires": {
                 "@babel/compat-data": "^7.13.11",
-                "@babel/helper-define-polyfill-provider": "^0.2.0",
+                "@babel/helper-define-polyfill-provider": "^0.2.2",
                 "semver": "^6.1.1"
             }
         },
         "babel-plugin-polyfill-corejs3": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.2.0.tgz",
-            "integrity": "sha512-zZyi7p3BCUyzNxLx8KV61zTINkkV65zVkDAFNZmrTCRVhjo1jAS+YLvDJ9Jgd/w2tsAviCwFHReYfxO3Iql8Yg==",
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.2.2.tgz",
+            "integrity": "sha512-l1Cf8PKk12eEk5QP/NQ6TH8A1pee6wWDJ96WjxrMXFLHLOBFzYM4moG80HFgduVhTqAFez4alnZKEhP/bYHg0A==",
             "dev": true,
             "requires": {
-                "@babel/helper-define-polyfill-provider": "^0.2.0",
+                "@babel/helper-define-polyfill-provider": "^0.2.2",
                 "core-js-compat": "^3.9.1"
             }
         },
         "babel-plugin-polyfill-regenerator": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.2.0.tgz",
-            "integrity": "sha512-J7vKbCuD2Xi/eEHxquHN14bXAW9CXtecwuLrOIDJtcZzTaPzV1VdEfoUf9AzcRBMolKUQKM9/GVojeh0hFiqMg==",
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.2.2.tgz",
+            "integrity": "sha512-Goy5ghsc21HgPDFtzRkSirpZVW35meGoTmTOb2bxqdl60ghub4xOidgNTHaZfQ2FaxQsKmwvXtOAkcIS4SMBWg==",
             "dev": true,
             "requires": {
-                "@babel/helper-define-polyfill-provider": "^0.2.0"
+                "@babel/helper-define-polyfill-provider": "^0.2.2"
             }
         },
         "babel-preset-current-node-syntax": {
@@ -5216,9 +5350,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001228",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001228.tgz",
-            "integrity": "sha512-QQmLOGJ3DEgokHbMSA8cj2a+geXqmnpyOFT0lhQV6P3/YOJvGDEwoedcwxEQ30gJIwIIunHIicunJ2rzK5gB2A==",
+            "version": "1.0.30001230",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001230.tgz",
+            "integrity": "sha512-5yBd5nWCBS+jWKTcHOzXwo5xzcj4ePE/yjtkZyUV1BTUmrBaA9MRGC+e7mxnqXSA90CmCA8L3eKLaSUkt099IQ==",
             "dev": true
         },
         "capture-exit": {
@@ -5328,13 +5462,13 @@
             },
             "dependencies": {
                 "dom-serializer": {
-                    "version": "1.3.1",
-                    "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.1.tgz",
-                    "integrity": "sha512-Pv2ZluG5ife96udGgEDovOOOA5UELkltfJpnIExPrAk1LTvecolUGn6lIaoLh86d83GiB86CjzciMd9BuRB71Q==",
+                    "version": "1.3.2",
+                    "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
+                    "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
                     "dev": true,
                     "requires": {
                         "domelementtype": "^2.0.1",
-                        "domhandler": "^4.0.0",
+                        "domhandler": "^4.2.0",
                         "entities": "^2.0.0"
                     }
                 },
@@ -6087,12 +6221,6 @@
             "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
             "dev": true
         },
-        "contains-path": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
-            "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
-            "dev": true
-        },
         "convert-source-map": {
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
@@ -6128,9 +6256,9 @@
             "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
         },
         "core-js-compat": {
-            "version": "3.12.1",
-            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.12.1.tgz",
-            "integrity": "sha512-i6h5qODpw6EsHAoIdQhKoZdWn+dGBF3dSS8m5tif36RlWvW3A6+yu2S16QHUo3CrkzrnEskMAt9f8FxmY9fhWQ==",
+            "version": "3.13.0",
+            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.13.0.tgz",
+            "integrity": "sha512-jhbI2zpVskgfDC9mGRaDo1gagd0E0i/kYW0+WvibL/rafEHKAHO653hEXIxJHqRlRLITluXtRH3AGTL5qJmifQ==",
             "dev": true,
             "requires": {
                 "browserslist": "^4.16.6",
@@ -6146,9 +6274,9 @@
             }
         },
         "core-js-pure": {
-            "version": "3.12.1",
-            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.12.1.tgz",
-            "integrity": "sha512-1cch+qads4JnDSWsvc7d6nzlKAippwjUlf6vykkTLW53VSV+NkE6muGBToAjEA8pG90cSfcud3JgVmW2ds5TaQ==",
+            "version": "3.13.0",
+            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.13.0.tgz",
+            "integrity": "sha512-7VTvXbsMxROvzPAVczLgfizR8CyYnvWPrb1eGrtlZAJfjQWEHLofVfCKljLHdpazTfpaziRORwUH/kfGDKvpdA==",
             "dev": true
         },
         "core-util-is": {
@@ -7476,9 +7604,9 @@
             }
         },
         "electron-to-chromium": {
-            "version": "1.3.727",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.727.tgz",
-            "integrity": "sha512-Mfz4FIB4FSvEwBpDfdipRIrwd6uo8gUDoRDF4QEYb4h4tSuI3ov594OrjU6on042UlFHouIJpClDODGkPcBSbg==",
+            "version": "1.3.739",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.739.tgz",
+            "integrity": "sha512-+LPJVRsN7hGZ9EIUUiWCpO7l4E3qBYHNadazlucBfsXBbccDFNKUBAgzE68FnkWGJPwD/AfKhSzL+G+Iqb8A4A==",
             "dev": true
         },
         "electron-updater": {
@@ -7782,6 +7910,12 @@
                 "string.prototype.trimend": "^1.0.3",
                 "string.prototype.trimstart": "^1.0.3"
             }
+        },
+        "es-array-method-boxes-properly": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
+            "integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
+            "dev": true
         },
         "es-to-primitive": {
             "version": "1.2.1",
@@ -8311,22 +8445,22 @@
             }
         },
         "eslint-module-utils": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz",
-            "integrity": "sha512-6j9xxegbqe8/kZY8cYpcp0xhbK0EgJlg3g9mib3/miLaExuuwc3n5UEfSnU6hWMbT0FAYVvDbL9RrRgpUeQIvA==",
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.1.tgz",
+            "integrity": "sha512-ZXI9B8cxAJIH4nfkhTwcRTEAnrVfobYqwjWy/QMCZ8rHkZHFjf9yO4BzpiF9kCSfNlMG54eKigISHpX0+AaT4A==",
             "dev": true,
             "requires": {
-                "debug": "^2.6.9",
+                "debug": "^3.2.7",
                 "pkg-dir": "^2.0.0"
             },
             "dependencies": {
                 "debug": {
-                    "version": "2.6.9",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "version": "3.2.7",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+                    "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
                     "dev": true,
                     "requires": {
-                        "ms": "2.0.0"
+                        "ms": "^2.1.1"
                     }
                 },
                 "find-up": {
@@ -8347,6 +8481,12 @@
                         "p-locate": "^2.0.0",
                         "path-exists": "^3.0.0"
                     }
+                },
+                "ms": {
+                    "version": "2.1.3",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+                    "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+                    "dev": true
                 },
                 "p-limit": {
                     "version": "1.3.0",
@@ -8384,23 +8524,25 @@
             }
         },
         "eslint-plugin-import": {
-            "version": "2.22.1",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.22.1.tgz",
-            "integrity": "sha512-8K7JjINHOpH64ozkAhpT3sd+FswIZTfMZTjdx052pnWrgRCVfp8op9tbjpAk3DdUeI/Ba4C8OjdC0r90erHEOw==",
+            "version": "2.23.3",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.23.3.tgz",
+            "integrity": "sha512-wDxdYbSB55F7T5CC7ucDjY641VvKmlRwT0Vxh7PkY1mI4rclVRFWYfsrjDgZvwYYDZ5ee0ZtfFKXowWjqvEoRQ==",
             "dev": true,
             "requires": {
-                "array-includes": "^3.1.1",
-                "array.prototype.flat": "^1.2.3",
-                "contains-path": "^0.1.0",
+                "array-includes": "^3.1.3",
+                "array.prototype.flat": "^1.2.4",
                 "debug": "^2.6.9",
-                "doctrine": "1.5.0",
+                "doctrine": "^2.1.0",
                 "eslint-import-resolver-node": "^0.3.4",
-                "eslint-module-utils": "^2.6.0",
+                "eslint-module-utils": "^2.6.1",
+                "find-up": "^2.0.0",
                 "has": "^1.0.3",
+                "is-core-module": "^2.4.0",
                 "minimatch": "^3.0.4",
-                "object.values": "^1.1.1",
-                "read-pkg-up": "^2.0.0",
-                "resolve": "^1.17.0",
+                "object.values": "^1.1.3",
+                "pkg-up": "^2.0.0",
+                "read-pkg-up": "^3.0.0",
+                "resolve": "^1.20.0",
                 "tsconfig-paths": "^3.9.0"
             },
             "dependencies": {
@@ -8414,20 +8556,74 @@
                     }
                 },
                 "doctrine": {
-                    "version": "1.5.0",
-                    "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
-                    "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+                    "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
                     "dev": true,
                     "requires": {
-                        "esutils": "^2.0.2",
-                        "isarray": "^1.0.0"
+                        "esutils": "^2.0.2"
                     }
                 },
-                "isarray": {
+                "find-up": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+                    "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "^2.0.0"
+                    }
+                },
+                "is-core-module": {
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.4.0.tgz",
+                    "integrity": "sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==",
+                    "dev": true,
+                    "requires": {
+                        "has": "^1.0.3"
+                    }
+                },
+                "locate-path": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+                    "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+                    "dev": true,
+                    "requires": {
+                        "p-locate": "^2.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "p-limit": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+                    "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+                    "dev": true,
+                    "requires": {
+                        "p-try": "^1.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+                    "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+                    "dev": true,
+                    "requires": {
+                        "p-limit": "^1.1.0"
+                    }
+                },
+                "p-try": {
                     "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+                    "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
                     "dev": true
+                },
+                "pkg-up": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
+                    "integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
+                    "dev": true,
+                    "requires": {
+                        "find-up": "^2.1.0"
+                    }
                 }
             }
         },
@@ -9999,12 +10195,12 @@
             }
         },
         "html-element-map": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/html-element-map/-/html-element-map-1.3.0.tgz",
-            "integrity": "sha512-AqCt/m9YaiMwaaAyOPdq4Ga0cM+jdDWWGueUMkdROZcTeClaGpN0AQeyGchZhTegQoABmc6+IqH7oCR/8vhQYg==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/html-element-map/-/html-element-map-1.3.1.tgz",
+            "integrity": "sha512-6XMlxrAFX4UEEGxctfFnmrFaaZFNf9i5fNuV5wZ3WWQ4FVaNP1aX1LkX9j2mfEx1NpjeE/rL3nmgEn23GdFmrg==",
             "dev": true,
             "requires": {
-                "array-filter": "^1.0.0",
+                "array.prototype.filter": "^1.0.0",
                 "call-bind": "^1.0.2"
             }
         },
@@ -10051,6 +10247,34 @@
             "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
             "dev": true
         },
+        "http-proxy-agent": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-4.0.1.tgz",
+            "integrity": "sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==",
+            "dev": true,
+            "requires": {
+                "@tootallnate/once": "1",
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.3.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+                    "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.1.2"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                }
+            }
+        },
         "http-signature": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -10066,6 +10290,33 @@
             "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
             "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=",
             "dev": true
+        },
+        "https-proxy-agent": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+            "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+            "dev": true,
+            "requires": {
+                "agent-base": "6",
+                "debug": "4"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.3.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+                    "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.1.2"
+                    }
+                },
+                "ms": {
+                    "version": "2.1.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+                    "dev": true
+                }
+            }
         },
         "human-signals": {
             "version": "1.1.1",
@@ -12856,13 +13107,13 @@
             "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
         },
         "jsdom": {
-            "version": "16.5.3",
-            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.5.3.tgz",
-            "integrity": "sha512-Qj1H+PEvUsOtdPJ056ewXM4UJPCi4hhLA8wpiz9F2YvsRBhuFsXxtrIFAgGBDynQA9isAMGE91PfUYbdMPXuTA==",
+            "version": "16.6.0",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-16.6.0.tgz",
+            "integrity": "sha512-Ty1vmF4NHJkolaEmdjtxTfSfkdb8Ywarwf63f+F8/mDD1uLSSWDxDuMiZxiPhwunLrn9LOSVItWj4bLYsLN3Dg==",
             "dev": true,
             "requires": {
                 "abab": "^2.0.5",
-                "acorn": "^8.1.0",
+                "acorn": "^8.2.4",
                 "acorn-globals": "^6.0.0",
                 "cssom": "^0.4.4",
                 "cssstyle": "^2.3.0",
@@ -12870,12 +13121,13 @@
                 "decimal.js": "^10.2.1",
                 "domexception": "^2.0.1",
                 "escodegen": "^2.0.0",
+                "form-data": "^3.0.0",
                 "html-encoding-sniffer": "^2.0.1",
-                "is-potential-custom-element-name": "^1.0.0",
+                "http-proxy-agent": "^4.0.1",
+                "https-proxy-agent": "^5.0.0",
+                "is-potential-custom-element-name": "^1.0.1",
                 "nwsapi": "^2.2.0",
                 "parse5": "6.0.1",
-                "request": "^2.88.2",
-                "request-promise-native": "^1.0.9",
                 "saxes": "^5.0.1",
                 "symbol-tree": "^3.2.4",
                 "tough-cookie": "^4.0.0",
@@ -12885,7 +13137,7 @@
                 "whatwg-encoding": "^1.0.5",
                 "whatwg-mimetype": "^2.3.0",
                 "whatwg-url": "^8.5.0",
-                "ws": "^7.4.4",
+                "ws": "^7.4.5",
                 "xml-name-validator": "^3.0.0"
             },
             "dependencies": {
@@ -12894,6 +13146,17 @@
                     "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.2.4.tgz",
                     "integrity": "sha512-Ibt84YwBDDA890eDiDCEqcbwvHlBvzzDkU2cGBBDDI1QWT12jTiXIOn2CIw5KK4i6N5Z2HUxwYjzriDyqaqqZg==",
                     "dev": true
+                },
+                "form-data": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+                    "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+                    "dev": true,
+                    "requires": {
+                        "asynckit": "^0.4.0",
+                        "combined-stream": "^1.0.8",
+                        "mime-types": "^2.1.12"
+                    }
                 },
                 "tough-cookie": {
                     "version": "4.0.0",
@@ -13201,31 +13464,26 @@
             "integrity": "sha1-hMinKrWcRyUyFIDJdeZQg0LnCTc="
         },
         "load-json-file": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-            "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+            "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
             "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.2",
-                "parse-json": "^2.2.0",
-                "pify": "^2.0.0",
+                "parse-json": "^4.0.0",
+                "pify": "^3.0.0",
                 "strip-bom": "^3.0.0"
             },
             "dependencies": {
                 "parse-json": {
-                    "version": "2.2.0",
-                    "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-                    "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+                    "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
                     "dev": true,
                     "requires": {
-                        "error-ex": "^1.2.0"
+                        "error-ex": "^1.3.1",
+                        "json-parse-better-errors": "^1.0.1"
                     }
-                },
-                "pify": {
-                    "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-                    "dev": true
                 }
             }
         },
@@ -14399,9 +14657,9 @@
             }
         },
         "node-releases": {
-            "version": "1.1.71",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.71.tgz",
-            "integrity": "sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg==",
+            "version": "1.1.72",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.72.tgz",
+            "integrity": "sha512-LLUo+PpH3dU6XizX3iVoubUNheF/owjXCZZ5yACDxNnPtgFuludV1ZL3ayK1kVep42Rmm0+R9/Y60NQbZ2bifw==",
             "dev": true
         },
         "noop-logger": {
@@ -14657,9 +14915,9 @@
             }
         },
         "object-hash": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.1.1.tgz",
-            "integrity": "sha512-VOJmgmS+7wvXf8CjbQmimtCnEx3IAoLxI3fp2fbWehxrWBcAQFbk+vcwb6vzR0VZv/eNCJ/27j151ZTwqW/JeQ==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+            "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
             "dev": true
         },
         "object-inspect": {
@@ -15505,8 +15763,8 @@
             }
         },
         "pc-nrfconnect-shared": {
-            "version": "github:NordicSemiconductor/pc-nrfconnect-shared#0509b2ee2ce4f23796c001c909c2a72abf5f79ce",
-            "from": "github:NordicSemiconductor/pc-nrfconnect-shared#v4.23.0",
+            "version": "github:NordicSemiconductor/pc-nrfconnect-shared#016c8e1ae1f15f2de520570470e6758ae820dc92",
+            "from": "github:NordicSemiconductor/pc-nrfconnect-shared#v4.23.1",
             "dev": true,
             "requires": {
                 "@babel/core": "7.10.0",
@@ -15673,17 +15931,16 @@
             "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
         },
         "picomatch": {
-            "version": "2.2.3",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.3.tgz",
-            "integrity": "sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+            "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
             "dev": true
         },
         "pify": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
             "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-            "dev": true,
-            "optional": true
+            "dev": true
         },
         "pinkie": {
             "version": "2.0.4",
@@ -16538,41 +16795,35 @@
             }
         },
         "read-pkg": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-            "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+            "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
             "dev": true,
             "requires": {
-                "load-json-file": "^2.0.0",
+                "load-json-file": "^4.0.0",
                 "normalize-package-data": "^2.3.2",
-                "path-type": "^2.0.0"
+                "path-type": "^3.0.0"
             },
             "dependencies": {
                 "path-type": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-                    "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+                    "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
                     "dev": true,
                     "requires": {
-                        "pify": "^2.0.0"
+                        "pify": "^3.0.0"
                     }
-                },
-                "pify": {
-                    "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-                    "dev": true
                 }
             }
         },
         "read-pkg-up": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-            "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+            "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
             "dev": true,
             "requires": {
                 "find-up": "^2.0.0",
-                "read-pkg": "^2.0.0"
+                "read-pkg": "^3.0.0"
             },
             "dependencies": {
                 "find-up": {
@@ -16939,26 +17190,6 @@
                     "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
                     "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
                 }
-            }
-        },
-        "request-promise-core": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.4.tgz",
-            "integrity": "sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==",
-            "dev": true,
-            "requires": {
-                "lodash": "^4.17.19"
-            }
-        },
-        "request-promise-native": {
-            "version": "1.0.9",
-            "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.9.tgz",
-            "integrity": "sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==",
-            "dev": true,
-            "requires": {
-                "request-promise-core": "1.1.4",
-                "stealthy-require": "^1.1.1",
-                "tough-cookie": "^2.3.3"
             }
         },
         "require-directory": {
@@ -17944,12 +18175,6 @@
                 }
             }
         },
-        "stealthy-require": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-            "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
-            "dev": true
-        },
         "stream-browserify": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
@@ -18111,18 +18336,87 @@
             }
         },
         "string.prototype.matchall": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.4.tgz",
-            "integrity": "sha512-pknFIWVachNcyqRfaQSeu/FUfpvJTe4uskUSZ9Wc1RijsPuzbZ8TyYT8WCNnntCjUEqQ3vUHMAfVj2+wLAisPQ==",
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.5.tgz",
+            "integrity": "sha512-Z5ZaXO0svs0M2xd/6By3qpeKpLKd9mO4v4q3oMEQrk8Ck4xOD5d5XeBOOjGrmVZZ/AHB1S0CgG4N5r1G9N3E2Q==",
             "dev": true,
             "requires": {
                 "call-bind": "^1.0.2",
                 "define-properties": "^1.1.3",
-                "es-abstract": "^1.18.0-next.2",
-                "has-symbols": "^1.0.1",
+                "es-abstract": "^1.18.2",
+                "get-intrinsic": "^1.1.1",
+                "has-symbols": "^1.0.2",
                 "internal-slot": "^1.0.3",
                 "regexp.prototype.flags": "^1.3.1",
                 "side-channel": "^1.0.4"
+            },
+            "dependencies": {
+                "es-abstract": {
+                    "version": "1.18.2",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.2.tgz",
+                    "integrity": "sha512-byRiNIQXE6HWNySaU6JohoNXzYgbBjztwFnBLUTiJmWXjaU9bSq3urQLUlNLQ292tc+gc07zYZXNZjaOoAX3sw==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.2",
+                        "es-to-primitive": "^1.2.1",
+                        "function-bind": "^1.1.1",
+                        "get-intrinsic": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-symbols": "^1.0.2",
+                        "is-callable": "^1.2.3",
+                        "is-negative-zero": "^2.0.1",
+                        "is-regex": "^1.1.3",
+                        "is-string": "^1.0.6",
+                        "object-inspect": "^1.10.3",
+                        "object-keys": "^1.1.1",
+                        "object.assign": "^4.1.2",
+                        "string.prototype.trimend": "^1.0.4",
+                        "string.prototype.trimstart": "^1.0.4",
+                        "unbox-primitive": "^1.0.1"
+                    }
+                },
+                "has-symbols": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+                    "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+                    "dev": true
+                },
+                "is-regex": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
+                    "integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.2",
+                        "has-symbols": "^1.0.2"
+                    }
+                },
+                "object-inspect": {
+                    "version": "1.10.3",
+                    "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
+                    "integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==",
+                    "dev": true
+                },
+                "string.prototype.trimend": {
+                    "version": "1.0.4",
+                    "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+                    "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.2",
+                        "define-properties": "^1.1.3"
+                    }
+                },
+                "string.prototype.trimstart": {
+                    "version": "1.0.4",
+                    "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+                    "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.2",
+                        "define-properties": "^1.1.3"
+                    }
+                }
             }
         },
         "string.prototype.trim": {
@@ -18884,9 +19178,9 @@
             }
         },
         "tr46": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.0.2.tgz",
-            "integrity": "sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
+            "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
             "dev": true,
             "requires": {
                 "punycode": "^2.1.1"
@@ -19701,9 +19995,9 @@
             },
             "dependencies": {
                 "es-abstract": {
-                    "version": "1.18.0",
-                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0.tgz",
-                    "integrity": "sha512-LJzK7MrQa8TS0ja2w3YNLzUgJCGPdPOV1yVvezjNnS89D+VR08+Szt2mz3YB2Dck/+w5tfIq/RoUAFqJJGM2yw==",
+                    "version": "1.18.2",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.2.tgz",
+                    "integrity": "sha512-byRiNIQXE6HWNySaU6JohoNXzYgbBjztwFnBLUTiJmWXjaU9bSq3urQLUlNLQ292tc+gc07zYZXNZjaOoAX3sw==",
                     "dev": true,
                     "requires": {
                         "call-bind": "^1.0.2",
@@ -19714,14 +20008,14 @@
                         "has-symbols": "^1.0.2",
                         "is-callable": "^1.2.3",
                         "is-negative-zero": "^2.0.1",
-                        "is-regex": "^1.1.2",
-                        "is-string": "^1.0.5",
-                        "object-inspect": "^1.9.0",
+                        "is-regex": "^1.1.3",
+                        "is-string": "^1.0.6",
+                        "object-inspect": "^1.10.3",
                         "object-keys": "^1.1.1",
                         "object.assign": "^4.1.2",
                         "string.prototype.trimend": "^1.0.4",
                         "string.prototype.trimstart": "^1.0.4",
-                        "unbox-primitive": "^1.0.0"
+                        "unbox-primitive": "^1.0.1"
                     },
                     "dependencies": {
                         "has-symbols": {
@@ -19731,6 +20025,30 @@
                             "dev": true
                         }
                     }
+                },
+                "is-regex": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
+                    "integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.2",
+                        "has-symbols": "^1.0.2"
+                    },
+                    "dependencies": {
+                        "has-symbols": {
+                            "version": "1.0.2",
+                            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+                            "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+                            "dev": true
+                        }
+                    }
+                },
+                "object-inspect": {
+                    "version": "1.10.3",
+                    "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
+                    "integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==",
+                    "dev": true
                 },
                 "string.prototype.trimend": {
                     "version": "1.0.4",
@@ -20532,9 +20850,9 @@
             }
         },
         "ws": {
-            "version": "7.4.5",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.5.tgz",
-            "integrity": "sha512-xzyu3hFvomRfXKH8vOFMU3OguG6oOvhXMo3xsGy3xWExqaM2dxBbVxuD99O7m3ZUFMvvscsZDqxfgMaRr/Nr1g==",
+            "version": "7.4.6",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
+            "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
             "dev": true
         },
         "x-is-string": {

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
         "electron-notarize": "0.3.0",
         "mini-css-extract-plugin": "0.9.0",
         "pc-nrfconnect-build": "git+https://github.com/NordicPlayground/pc-nrfconnect-build.git#semver:0.3.0",
-        "pc-nrfconnect-shared": "github:NordicSemiconductor/pc-nrfconnect-shared#v4.23.0",
+        "pc-nrfconnect-shared": "github:NordicSemiconductor/pc-nrfconnect-shared#v4.23.1",
         "spectron": "7.0.0",
         "tar": "6.0.2",
         "xvfb-maybe": "0.2.1"

--- a/src/launcher/components/ErrorBoundaryLauncher.jsx
+++ b/src/launcher/components/ErrorBoundaryLauncher.jsx
@@ -1,0 +1,78 @@
+/* Copyright (c) 2015 - 2021, Nordic Semiconductor ASA
+ *
+ * All rights reserved.
+ *
+ * Use in source and binary forms, redistribution in binary form only, with
+ * or without modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 2. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 3. This software, with or without modification, must only be used with a Nordic
+ *    Semiconductor ASA integrated circuit.
+ *
+ * 4. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import React from 'react';
+import { useDispatch } from 'react-redux';
+import { remote } from 'electron';
+import { ErrorBoundary } from 'pc-nrfconnect-shared';
+import { node } from 'prop-types';
+
+import pkgJson from '../../../package.json';
+import * as AppsActions from '../actions/appsActions';
+import { sendLauncherUsageData } from '../actions/usageDataActions';
+
+const ErrorBoundaryLauncher = ({ children }) => {
+    const dispatch = useDispatch();
+
+    const restoreDefaults = () => {
+        dispatch(AppsActions.setAppManagementFilter(''));
+        dispatch(AppsActions.setAppManagementShow({}));
+        dispatch(AppsActions.setAppManagementSource({}));
+        remote.getCurrentWindow().reload();
+    };
+
+    const sendUsageData = error => {
+        const launcherInfo = pkgJson.version ? `v${pkgJson.version}` : '';
+        const errorLabel = `${process.platform}; ${process.arch}; v${launcherInfo}; ${error}`;
+        dispatch(sendLauncherUsageData('Report error', errorLabel));
+    };
+
+    return (
+        <ErrorBoundary
+            appName="Launcher"
+            restoreDefaults={restoreDefaults}
+            sendUsageData={sendUsageData}
+        >
+            {children}
+        </ErrorBoundary>
+    );
+};
+
+ErrorBoundaryLauncher.propTypes = {
+    children: node,
+};
+
+export default ErrorBoundaryLauncher;

--- a/src/launcher/components/Root.jsx
+++ b/src/launcher/components/Root.jsx
@@ -47,9 +47,10 @@ import SettingsContainer from '../containers/SettingsContainer';
 import UpdateAvailableContainer from '../containers/UpdateAvailableContainer';
 import UpdateProgressContainer from '../containers/UpdateProgressContainer';
 import UsageDataDialogContainer from '../containers/UsageDataDialogContainer';
+import ErrorBoundaryLauncher from './ErrorBoundaryLauncher';
 
 export default () => (
-    <>
+    <ErrorBoundaryLauncher>
         <Tab.Container id="launcher" defaultActiveKey="apps">
             <Nav>
                 {/* eslint-disable-next-line jsx-a11y/no-access-key */}
@@ -78,5 +79,5 @@ export default () => (
         <ConfirmLaunchContainer />
         <ProxyLoginContainer />
         <ProxyErrorContainer />
-    </>
+    </ErrorBoundaryLauncher>
 );

--- a/src/launcher/containers/AppManagementContainer.js
+++ b/src/launcher/containers/AppManagementContainer.js
@@ -48,7 +48,7 @@ const filterByInput = filter => app => {
     } catch (_) {
         //
     }
-    return app.displayName.includes(filter);
+    return app.displayName?.includes(filter);
 };
 
 function mapStateToProps(state) {


### PR DESCRIPTION
This PR implements [https://trello.com/c/Ktagc7cB/74-add-error-boundaries-to-launcher-itself](https://trello.com/c/Ktagc7cB/74-add-error-boundaries-to-launcher-itself).

Updates to `shared` [(v4.23.1)](https://github.com/NordicSemiconductor/pc-nrfconnect-shared/commit/a182e04e81de1cd512abfd7e458a9c9a72a9d8a0) now allows for overriding factory reset and GA event report sending when component is initialized, so add a wrapper which implements this functionality.

Turns out that just deleting `settings.json` and reloading the app didn't work properly as the file was just re-created with the problematic values. So instead we go for a softer factory reset where we just clear the `filter`, `show` and `source` state.

We also use the GA reporting functionality provided by the launcher itself instead of using the one from `shared` to avoid problems.