### PR TITLE
Fix: Tailored error for missing source file

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,6 +10,8 @@
 ### Bugfixes
 - macOS: When clicking on URLs in log entries the web site was not opened
 - Fixed issue where undefined serialport attribute causes crash #521
+- The error message from #403 for an apps.json that is not found for a
+  source on the server did not show up correctly. #531
 
 ## Version 3.6.1
 ### Updates

--- a/src/launcher/actions/autoUpdateActions.js
+++ b/src/launcher/actions/autoUpdateActions.js
@@ -52,7 +52,6 @@ export const AUTO_UPDATE_DOWNLOADING = 'AUTO_UPDATE_DOWNLOADING';
 export const AUTO_UPDATE_ERROR = 'AUTO_UPDATE_ERROR';
 
 const mainApps = remote.require('../main/apps');
-const net = remote.require('../main/net');
 const { autoUpdater, CancellationToken } = remote.require('../main/autoUpdate');
 
 const isWindows = process.platform === 'win32';
@@ -218,7 +217,7 @@ export function downloadLatestAppInfo(options = { rejectIfError: false }) {
                 dispatch(AppsActions.downloadLatestAppInfoErrorAction());
                 if (options.rejectIfError) {
                     throw error;
-                } else if (net.isResourceNotFound(error)) {
+                } else if (error.sourceNotFound) {
                     dispatch(
                         ErrorDialogActions.showDialog(
                             `Unable to retrieve the source “${error.cause.name}” from ${error.cause.url}. \n\n` +

--- a/src/main/apps.js
+++ b/src/main/apps.js
@@ -120,6 +120,7 @@ function downloadAppsJsonFile(url, name) {
             );
             wrappedError.statusCode = error.statusCode;
             wrappedError.cause = { name, url };
+            wrappedError.sourceNotFound = net.isResourceNotFound(error);
             throw wrappedError;
         })
         .then(appsJson => {


### PR DESCRIPTION
The error message when an app.json for a source is missing on the server did not show up, because `isResourceNotFound` was called through a `remote.require`, which strangly lead to the error object not being filled correctly. Now `isResourceNotFound` is called in the main thread and thus it works.

You can reproduce this by putting a source in `~/.nrfconnect-apps/external/sources.json` with an URL that is not found. Then you get this:

![image](https://user-images.githubusercontent.com/260705/120343050-a9b7b900-c2f8-11eb-9a10-ac9e6e082658.png)


