### PR TITLE
Improve user experience when installed files are corrupted.

### DIFF
--- a/src/launcher/actions/appsActions.js
+++ b/src/launcher/actions/appsActions.js
@@ -39,10 +39,14 @@ import { join } from 'path';
 import { ErrorDialogActions } from 'pc-nrfconnect-shared';
 
 import checkAppCompatibility from '../util/checkAppCompatibility';
-import { EventAction, sendAppUsageData } from './usageDataActions';
+import {
+    EventAction,
+    sendAppUsageData,
+    sendLauncherUsageData,
+} from './usageDataActions';
 
 const net = remote.require('../main/net');
-const fs = remote.require('fs');
+const fs = remote.require('fs-extra');
 
 const mainApps = remote.require('../main/apps');
 const config = remote.require('../main/config');
@@ -312,66 +316,87 @@ export function loadLocalApps() {
 }
 
 export function loadOfficialApps(appName, appSource) {
-    return dispatch => {
+    return async dispatch => {
         dispatch(loadOfficialAppsAction());
-        return mainApps
-            .getOfficialApps()
-            .then(apps => {
-                dispatch(
-                    loadOfficialAppsSuccess(
-                        apps,
-                        appName && { name: appName, source: appSource }
-                    )
-                );
-                apps.filter(({ path }) => !path).forEach(
-                    ({ source, name, url }) => {
-                        const iconPath = join(
-                            `${config.getAppsRootDir(source)}`,
-                            `${name}.svg`
-                        );
-                        const iconUrl = `${url}.svg`;
+        const { fulfilled: apps, rejected: appsWithErrors } =
+            await mainApps.getOfficialApps();
+
+        dispatch(
+            loadOfficialAppsSuccess(
+                apps,
+                appName && { name: appName, source: appSource }
+            )
+        );
+        apps.filter(({ path }) => !path).forEach(({ source, name, url }) => {
+            const iconPath = join(
+                `${config.getAppsRootDir(source)}`,
+                `${name}.svg`
+            );
+            const iconUrl = `${url}.svg`;
+            dispatch(downloadAppIcon(source, name, iconPath, iconUrl));
+        });
+        const downloadAllReleaseNotes = (app, ...rest) => {
+            if (!app) {
+                return Promise.resolve();
+            }
+            if (
+                appName &&
+                !(app.name === appName && app.source === appSource)
+            ) {
+                return downloadAllReleaseNotes(...rest);
+            }
+            return mainApps
+                .downloadReleaseNotes(app)
+                .then(
+                    releaseNote =>
+                        releaseNote &&
                         dispatch(
-                            downloadAppIcon(source, name, iconPath, iconUrl)
-                        );
-                    }
-                );
-                const downloadAllReleaseNotes = (app, ...rest) => {
-                    if (!app) {
-                        return Promise.resolve();
-                    }
-                    if (
-                        appName &&
-                        !(app.name === appName && app.source === appSource)
-                    ) {
-                        return downloadAllReleaseNotes(...rest);
-                    }
-                    return mainApps
-                        .downloadReleaseNotes(app)
-                        .then(
-                            releaseNote =>
-                                releaseNote &&
-                                dispatch(
-                                    setAppReleaseNoteAction(
-                                        app.source,
-                                        app.name,
-                                        releaseNote
-                                    )
-                                )
+                            setAppReleaseNoteAction(
+                                app.source,
+                                app.name,
+                                releaseNote
+                            )
                         )
-                        .then(() => downloadAllReleaseNotes(...rest));
-                };
-                downloadAllReleaseNotes(...apps);
-            })
-            .catch(error => {
-                dispatch(loadOfficialAppsError());
-                dispatch(
-                    ErrorDialogActions.showDialog(
-                        `Unable to load apps: ${error.message}`
-                    )
-                );
-            });
+                )
+                .then(() => downloadAllReleaseNotes(...rest));
+        };
+        downloadAllReleaseNotes(...apps);
+
+        if (appsWithErrors.length > 0) {
+            handleAppsWithErrors(dispatch, appsWithErrors);
+        }
     };
 }
+
+const handleAppsWithErrors = (dispatch, apps) => {
+    dispatch(loadOfficialAppsError());
+    apps.forEach(app => {
+        dispatch(
+            sendLauncherUsageData(
+                EventAction.REPORT_INSTALLATION_ERROR,
+                app.name
+            )
+        );
+    });
+
+    const recover = invalidPaths => () => {
+        invalidPaths.forEach(p => fs.remove(p));
+        remote.getCurrentWindow().reload();
+    };
+
+    dispatch(
+        ErrorDialogActions.showDialog(buildErrorMessage(apps), {
+            Recover: recover(apps.map(app => app.path)),
+            Close: () => dispatch(ErrorDialogActions.hideDialog()),
+        })
+    );
+};
+
+const buildErrorMessage = apps => {
+    const errors = apps.map(app => `* \`${app.reason}\`\n\n`).join('');
+    const paths = apps.map(app => `* *${app.path}*\n\n`).join('');
+    return `Unable to load all apps, these are the error messages:\n\n${errors}Clicking **Recover** will attempt to remove the following broken installation directories:\n\n${paths}`;
+};
 
 export function installOfficialApp(name, source) {
     return dispatch => {

--- a/src/launcher/actions/appsActions.js
+++ b/src/launcher/actions/appsActions.js
@@ -374,7 +374,7 @@ const handleAppsWithErrors = (dispatch, apps) => {
         dispatch(
             sendLauncherUsageData(
                 EventAction.REPORT_INSTALLATION_ERROR,
-                app.name
+                `${app.source} - ${app.name}`
             )
         );
     });

--- a/src/launcher/actions/usageDataActions.js
+++ b/src/launcher/actions/usageDataActions.js
@@ -53,6 +53,7 @@ export const EventAction = {
     UPGRADE_APP: 'Upgrade app',
     REPORT_OS_INFO: 'Report OS info',
     REPORT_LAUNCHER_INFO: 'Report launcher info',
+    REPORT_INSTALLATION_ERROR: 'Report installation error',
 };
 
 const EventLabel = {

--- a/src/main/apps.js
+++ b/src/main/apps.js
@@ -496,6 +496,8 @@ function getOfficialApps() {
             currentValue.value.forEach(result => {
                 if (result.value.status === 'rejected') {
                     rejected.push({ ...result.value });
+                } else if (result.status === 'rejected') {
+                    throw new Error(result.value);
                 } else {
                     fulfilled.push(result.value);
                 }

--- a/src/main/apps.js
+++ b/src/main/apps.js
@@ -453,14 +453,13 @@ function getOfficialAppsFromSource(source) {
     ]).then(([officialApps, availableUpdates]) => {
         const { ...cleanedApps } = officialApps;
         const officialAppsArray = officialAppsObjToArray(cleanedApps, source);
-        const promises = officialAppsArray.map(officialApp =>
-            fs
-                .exists(
-                    path.join(
-                        config.getNodeModulesDir(source),
-                        officialApp.name
-                    )
-                )
+        const promises = officialAppsArray.map(officialApp => {
+            const filePath = path.join(
+                config.getNodeModulesDir(source),
+                officialApp.name
+            );
+            return fs
+                .exists(filePath)
                 .then(isInstalled => {
                     if (isInstalled) {
                         return decorateWithInstalledAppInfo(
@@ -472,20 +471,39 @@ function getOfficialAppsFromSource(source) {
                     }
                     return Promise.resolve(officialApp);
                 })
-        );
-        return Promise.all(promises);
+                .catch(err => {
+                    return Promise.resolve({
+                        status: 'rejected',
+                        reason: err,
+                        path: filePath,
+                        name: officialApp.name,
+                    });
+                });
+        });
+        return Promise.allSettled(promises);
     });
 }
 
 function getOfficialApps() {
     const sources = settings.getSources();
-    return Promise.all(
+    return Promise.allSettled(
         Object.keys(sources).map(source => getOfficialAppsFromSource(source))
     ).then(arrayOfArrays =>
-        arrayOfArrays.reduce(
-            (accumulator, currentValue) => [...accumulator, ...currentValue],
-            []
-        )
+        arrayOfArrays.reduce((acc, currentValue) => {
+            const fulfilled = acc.fulfilled ? [...acc.fulfilled] : [];
+            const rejected = acc.rejected ? [...acc.rejected] : [];
+            currentValue.value.forEach(result => {
+                if (result.value.status === 'rejected') {
+                    rejected.push({ ...result.value });
+                } else {
+                    fulfilled.push(result.value);
+                }
+            });
+            return {
+                fulfilled,
+                rejected,
+            };
+        }, {})
     );
 }
 

--- a/src/main/apps.js
+++ b/src/main/apps.js
@@ -459,7 +459,7 @@ function getOfficialAppsFromSource(source) {
                 officialApp.name
             );
             return fs
-                .exists(filePath)
+                .pathExists(filePath)
                 .then(isInstalled => {
                     if (isInstalled) {
                         return decorateWithInstalledAppInfo(

--- a/src/main/apps.js
+++ b/src/main/apps.js
@@ -477,6 +477,7 @@ function getOfficialAppsFromSource(source) {
                         reason: err,
                         path: filePath,
                         name: officialApp.name,
+                        source,
                     });
                 });
         });


### PR DESCRIPTION
This commit contains three core improvements:
- Replace `Promise.all` with `Promise.allSettled` to let the user select
among the working apps even if one has failed.
- Send event to GA to know how frequently this occurs. If it is a common
occurence we might consider improving the robustness of the installation
routine.
- Add `Recover` button that attempts to remove the corrupted directories

![image](https://user-images.githubusercontent.com/72191781/120447738-2bf0bd80-c38b-11eb-96d6-d140c679244d.png)
