### PR TITLE
Update/get version for uninstalled apps

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+## Unreleased
+### Updates
+- Display app version for uninstalled apps if the information is present in `apps.json` in the source.
+
 ## Version 3.7.0
 ### Updates
 - Added recovery assistance for when the application encounters an error

--- a/src/launcher/components/AppItem.jsx
+++ b/src/launcher/components/AppItem.jsx
@@ -73,8 +73,11 @@ const AppItem = ({
                     <div className="small text-muted-more">
                         {app.source || 'local'}
                         {installed && <>, v{app.currentVersion}</>}
-                        {app.upgradeAvailable && (
+                        {installed && app.upgradeAvailable && (
                             <> (v{app.latestVersion} available)</>
+                        )}
+                        {!installed && app.latestVersion && (
+                            <>, v{app.latestVersion}</>
                         )}
                     </div>
                 </Col>
@@ -83,7 +86,7 @@ const AppItem = ({
                     className="d-flex align-items-center my-3 pl-3"
                 >
                     <ButtonToolbar className="wide-btns">
-                        {app.upgradeAvailable && (
+                        {installed && app.upgradeAvailable && (
                             <Button
                                 variant="outline-primary"
                                 title={`Update ${app.displayName}`}

--- a/src/main/apps.js
+++ b/src/main/apps.js
@@ -469,7 +469,10 @@ function getOfficialAppsFromSource(source) {
                             decorateWithLatestVersion(app, availableUpdates)
                         );
                     }
-                    return Promise.resolve(officialApp);
+
+                    return decorateWithLatestVersion(officialApp, {
+                        [officialApp.name]: officialApp.version,
+                    });
                 })
                 .catch(err => {
                     return Promise.resolve({


### PR DESCRIPTION
This PR implements the remainder of [https://trello.com/c/zdRvVOnt/171-add-versions-in-the-app-list-in-the-launcher](https://trello.com/c/zdRvVOnt/171-add-versions-in-the-app-list-in-the-launcher).

This change will display the current app version if it is present in `apps.json` of uninstalled apps.

![image](https://user-images.githubusercontent.com/72191781/123974108-a75e8280-d9bc-11eb-80c7-52cd3ce551e3.png)
