### PR TITLE
Set user data dir

### DIFF
--- a/Changelog-dev.md
+++ b/Changelog-dev.md
@@ -1,23 +1,31 @@
-## Version 3.7.0
-### Updates
-- Updated to pc-nrfconnect-shared 4.27.1
+# Developer Changelog
+All notable changes to this project which affect app developers will be
+documented in this file. The changes which also affect end users are documented
+in [Changelog.md](./Changelog.md).
 
-## Version 3.6.0
-### Bugfixes
-- Added workaround to prevent errors when proxy authentication is required
-- Fixed when error message is object instead of string
-- Fixed client id generation on Linux
-- Added temporary fix to hide electron dialog api change for apps not yet requiring 3.6+ engine #485
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
-## Version 3.5.0
-### Features
-- Added portable executable for Windows #459 #460
+## 3.7.0 - 2021-06-23
+### Changed
+- Updated to pc-nrfconnect-shared 4.27.3.
 
-## Version 3.4.0
-### Developer features
-- Enabled use of Redux DevTools and ease installation of React and Redux DevTools #381
-- Updated additional app architecture with new design. #392, #393, #394, #433, #434
-- Removed dependency of react-infinite. #401
-### Updates
+## 3.6.0 - 2020-10-15
+### Fixed
+- Added workaround to prevent errors when proxy authentication is required.
+- Error message was object instead of string.
+- Client id generation on Linux.
+- Added temporary fix to hide electron dialog api change for apps not yet requiring 3.6+ engine.
+
+## 3.5.0 - 2020-09-02
+### Added
+- Portable executable for Windows.
+
+## 3.4.0 - 2020-06-08
+### Added
+- Enabled use of Redux DevTools and ease installation of React and Redux DevTools.
+### Removed
+- Dependency of react-infinite.
+### Changed
 - This project was renamed to pc-nrfconnect-launcher.
-- Fewer requests for entering proxy credentials when needed. #370
+- Fewer requests for entering proxy credentials when needed.
+- Updated additional app architecture with new design.

--- a/Changelog.md
+++ b/Changelog.md
@@ -5,90 +5,93 @@
   through command line switch `--user-data-dir` or environment variable
   `NRF_USER_DATA_DIR`.
 
-## Version 3.7.0
-### Updates
-- Added recovery assistance for when the application encounters an error
-- Added `Restore Default` button in the `About` pane in the apps which have the `About` pane
-- Added app version in title bar (previously only the version of the launcher was shown) #515
-- Added links to product page for Power Profiler Kit 2 and updated links for nRF5340 Development Kit
-- Updated styles in the `About` pane
-- Created shortcut in `~/.local/share/applications` for Ubuntu #545
+## 3.7.0 - 2021-06-23
+### Added
+- Recovery assistance when the application encounters an error.
+- `Restore Default` button in the `About` pane in the apps which have the `About` pane.
+- App version in title bar (previously only the version of the launcher was shown).
+- Links to product page for Power Profiler Kit 2 and updated links for nRF5340 Development Kit.
+- Shortcut in `~/.local/share/applications` for Ubuntu.
+### Changed
+- Look of `About` pane.
 
-### Bugfixes
-- Prevented crash when incomplete regular expression is entered in search box
-- Fixed that the launcher does not show any apps when the files of an app are corrupted (e.g. by a partial sync of a file sync tool)
+### Fixed
+- Crash when special symbols (from regular expression, like `*` or `]` are entered in search box.
+- Launcher did not show apps when the files of an app are corrupted (e.g. by a partial sync of a file sync tool).
   Now the launcher offers an additional recovery mechanism.
-- Fixed when clicking on URLs in log entries the web site was not opened on macOS
-- Fixed issue where undefined serialport attribute causes crash #521
-- Fixed the error message from #403 for an apps.json that is not found for a
-  source on the server did not show up correctly. #531
+- Clicking on URLs in log entries on macOS.
+- Undefined serialport attribute caused a crash.
+- Error message from #403 for an `apps.json` that is not found for a
+  source on the server did not show up correctly.
 
-## Version 3.6.1
-### Updates
-- Updated to pc-nrfjprog-js v1.7.6, including bundled nrfjprog v10.12.1 and JLink 6.88a
-- Small visual enhancements to apps using the new design
-### Bugfixes
-- After updating an app, the other apps showed no release notes anymore #502
+## 3.6.1 - 2020-12-07
+### Changed
+- Updated to pc-nrfjprog-js v1.7.6, including bundled nrfjprog v10.12.1 and JLink 6.88a.
+- Small visual enhancements to apps using the new design.
+### Fixed
+- After updating an app, the other apps showed no release notes anymore.
 
-## Version 3.6.0
-### Updates
-- Upgraded Electron to version 8
-### Bugfixes
-- Fixed app loader animation
+## 3.6.0 - 2020-10-15
+### Changed
+- Upgraded Electron to version 8.
+### Fixed
+- App loader animation.
 
-## Version 3.5.0
-### Features
-- Updated design for new apps #458
-- Added usage statistics #457
-### Bugfixes
-- Fixed JLink device enumeration issue
+## 3.5.0 - 2020-09-02
+### Added
+- Usage statistics.
+### Changed
+- Updated design for new apps.
+### Fixed
+- Fixed JLink device enumeration issue.
 
-## Version 3.4.2
-### Updates
-- Updated pc-ble-driver-js to 2.7.2 #452
+## 3.4.2 - 2020-08-06
+### Changed
+- Updated pc-ble-driver-js to 2.7.2
     See changes https://github.com/NordicSemiconductor/pc-ble-driver-js/releases/tag/v2.7.2
-### Bugfixes
-- Fixed that “Update all apps” sometimes showed an error message (even though it worked
-  correctly). #451
+### Fixed
+- “Update all apps” sometimes showed an error message (even though it worked
+  correctly).
 
-## Version 3.4.1
-### Updates
-- Updated to pc-nrfjprog-js v1.7.3, including bundled nrfjprog v10.9.0 and JLink 6.80a
+## 3.4.1 - 2020-06-18
+### Changed
+- Updated to pc-nrfjprog-js v1.7.3, including bundled nrfjprog v10.9.0 and JLink 6.80a.
 
-## Version 3.4.0
-### Features
-- Added app filter and button to update all apps #369
-- Updated pc-ble-driver-js to 2.7.1 with SoftDevice 5 support #438
-- Updated with fewer requests for entering proxy credentials when needed #370
-- Enhanced error messages #403
+## 3.4.0 - 2020-06-08
+# Added
+- App filter and button to update all apps.
+### Changed
+- Updated pc-ble-driver-js to 2.7.1 with SoftDevice 5 support.
+- Updated with fewer requests for entering proxy credentials when needed.
+- Enhanced error messages:
     - Links in messages are clickable.
     - If an app source is removed from the server, users are assisted in removing it from client.
-### Bugfixes
-- Made retrieval of release notes more reliable, by not retrieving them from GitHub Releases anymore but our own server instead #388
+### Fixed
+- Made retrieval of release notes more reliable, by not retrieving them from GitHub Releases anymore but our own server instead.
 
-## Version 3.3.3
-### Updates
+## 3.3.3 - 2020-04-22
+### Changed
 - Notarized macOS build. #419
 - Updated to pc-nrfjprog-js v1.7.2, including bundled nrfjprog v10.8.0 and JLink 6.70d
 
-## Version 3.3.1
-### Features
+## 3.3.1 - 2020-03-23
+### Changed
 - Added support for nRF52820
 - Added support for modem UART DFU
 
-### Updates
+### Changed
 - Updated to pc-nrfjprog-js v1.7.0, including bundled nrfjprog v10.7.0 and JLink 6.62b
 
-## Version 3.3.0
-### Features
+## 3.3.0 - 2019-11-14
+### Changed
 - Added support for nRF53 series, nRF52833, and MCUboot DFU
 - Updated to pc-nrfjprog-js v1.6.0, including bundled nrfjprog v10.5.0 and JLink 6.54c #385
 - Updated icon colors #373
-### Bugfixes
+### Fixed
 - Fixed bug where app was opened in unreachable location #383
 
-## Version 3.2.0
-### Features
+## 3.2.0 - 2019-09-02
+### Changed
 - Updated UI design of Launcher #326
 - Updated logo and brand color #352
 - Unified installation and launch of apps into the same page #326
@@ -96,54 +99,54 @@
 - Shown release notes before updating #351
 - Faster startup #350
 - Apps get a read more link when the source provides a homepage URL #344
-### Bugfixes
+### Fixed
 - Desktop shortcuts for apps from sources with names with white space are now generated correctly #358
 - Text in log views is now selectable again #343
 
-## Version 3.1.0
-### Updates
+## 3.1.0 - 2019-08-16
+### Changed
 - Updated to pc-ble-driver-js v2.6.1 with electron 5 support #324
 - Updated to pc-nrfjprog-js v1.5.8, including bundled nrfjprog v10.3.0 and electron 5 support #324
 - Updated log transports to winston 3 API #327
-### Bugfixes
+### Fixed
 - Fixed shortcut generation on macOS #331 #332 #333  #334
 - Fixed libusb errors and multiple event handlers #337
 - Fixed winston multiple arguments #325
 - Fixed multiple postinstall #325
 - Fixed main layout scroll #340
 
-## Version 3.0.0
-### Updates
+## 3.0.0
+### Changed
 - Updated to React Bootstrap 4 #306
 React Bootstrap is a fundamental dependency for nRF Connect for Desktop, used for UI components and layout. The update is a breaking change, requiring all apps to be updated.
 There are no changes to nRF Connect features, except for some minor visual differences.
 - Updated to pc-nrfjprog-js v1.5.4, including bundled nrfjprog v10.2.1 #319
-### Bugfixes
+### Fixed
 - Fixed auto update issue #317
 - Fixed nrfjprog library path issue for pc-nrfjprog-js #310 #311 #312
 - Fixed shortcut generation on macOS #314
 
-## Version 2.7.0
-### Features
+## 2.7.0
+### Changed
 - Added support for pc-nrfjprog-js v1.5.1, including nrfjprog v10.1.1 with DFU programming #295 #296  #301
 - Added system report generation #289
 - Bundled nrfjprog libraries on Windows #296
 - Added copy-to-clipboard to source URL and make it selectable #291
-### Bugfixes
+### Fixed
 - Fixed proxy handling by ensuring sequential requests #302
 - Fixed multiple loading of libusb issue #288
 
-## Version 2.6.2
-### Bugfix
+## 2.6.2
+### Fixed
 - Updated pc-nrfjprog-js to version 1.4.4 that fixes logging related crash experienced with PPK app
 - Updated related prebuilt modules
 
-## Version 2.6.1
-### Bugfixes
+## 2.6.1
+### Fixed
 - Fixed multiple source updating issue  #272
 
-## Version 2.6.0
-### Features
+## 2.6.0
+### Changed
 - Added new way of distributing apps such as official, internal, etc, by introducing support for multiple app sources #256 #259
 - Provided all precompiled​ dependencies. #263 #266  #267
 - Updated pc-nrfjprog-js to version 1.4.1 along with nrfjprog v9.8.1 #263
@@ -152,11 +155,11 @@ There are no changes to nRF Connect features, except for some minor visual diffe
 - Updated electron to 2.0.11 #261
 - Supported displaying multiple serialports and board version of a device #262
 - Removed 'Debug probe' item in device selector #264
-### Bugfixes
+### Fixed
 - Fixed links in LogViewer to open urls in browser #258
 
-## Version 2.5.0
-### Features
+## 2.5.0
+### Changed
 - Updated pc-ble-driver-js to 2.4.2 #254
     See changes for v2.4.2 https://github.com/NordicSemiconductor/pc-ble-driver-js/releases
 - Updated electron to 2.0 #252
@@ -165,11 +168,11 @@ There are no changes to nRF Connect features, except for some minor visual diffe
 - Supported link in log messages #245
 - Supported to relaunch app when encountering libusb error #242
 - Exposed start & stop watching device API #244  #246
-### Bugfixes
+### Fixed
 - Fixed tests for breaking issue of jsdom #251
 
-## Version 2.4.0
-### Features
+## 2.4.0
+### Changed
 - Added support for nRF52840 dongle #204, #219, #220
 - Updated pc-ble-driver-js to 2.4.1 #214
     See changes for v2.4.0 and v2.4.1 https://github.com/NordicSemiconductor/pc-ble-driver-js/releases
@@ -178,19 +181,19 @@ There are no changes to nRF Connect features, except for some minor visual diffe
 - Added API documentation of using the new DeviceSelector and device setup configuration
 - Added troubleshooting documentation related to USB issues #208, #212, #223
 
-## Version 2.3.2
-### Bugfixes
+## 2.3.2
+### Fixed
 - Used developer.nordicsemi.com as registry for apps (0c6a405)
 
-## Version 2.3.1
-### Bugfixes
+## 2.3.1
+### Fixed
 - Fixed issue with apps failing to install (#206)
 
-## Version 2.3.0-alpha.6
+## 2.3.0-alpha.6
 Pre-release with Linux AppImage.
 
-## Version 2.3.0
-### Features
+## 2.3.0
+### Changed
 - Added AppImage release artifact for Linux with support for automatic updates (#156)
 - Added the [usb module](https://www.npmjs.com/package/usb) from npm, so that apps can import it (#157)
 - New opt-in device selector with support for libusb devices (experimental) (#157)
@@ -200,56 +203,52 @@ Pre-release with Linux AppImage.
 - Using separate log and data directories for apps (#139)
 - Upgraded to pc-nrfjprog-js v1.2.0 (https://github.com/NordicSemiconductor/pc-nrfjprog-js/releases/tag/v1.2.0)
 - Upgraded to pc-ble-driver-js v2.3.0 (https://github.com/NordicSemiconductor/pc-ble-driver-js/releases/tag/v2.3.0)
-### Bugfixes
+### Fixed
 - Improved icon resolution for app shortcuts (#152)
 - Improved icon resolution on macOS (#147)
 - Improved handling of edge cases in J-Link serial number lookup (#145, #146)
 - Fixed issue with side panel not visible on narrow screens (#141)
 - Verifying that serial port is not dead when selected (#137)
 
-## Version 2.3.0-alpha.3
+## 2.3.0-alpha.3
 Pre-release which improves serial number lookup on Windows (#146).
 
-## Version 2.3.0-alpha.2
+## 2.3.0-alpha.2
 Pre-release with handling of edge cases in J-Link serial number lookup (#145).
 
-## Version 2.2.1
-### Bugfixes
+## 2.2.1
+### Fixed
 - Improve JLink serial number lookup time on Windows (#135)
 - pc-ble-driver-js: Increase retransmission interval to give the peer more time to repond (https://github.com/NordicSemiconductor/pc-ble-driver-js/pull/99)
 - pc-ble-driver-js: Emit debug message instead of error for unsupported devkits (https://github.com/NordicSemiconductor/pc-ble-driver-js/pull/95)
 
-## Version 2.2.0
-### Features
+## 2.2.0
+### Changed
 - Allow creating desktop shortcuts for installed apps (#118, #120, #124)
 - Upgrade to pc-nrfjprog-js v1.1.0 and nRF5x-Command-Line-Tools v9.7.1 (#134)
 - Upgrade to pc-ble-driver-js v2.1.0 (https://github.com/NordicSemiconductor/pc-ble-driver-js/releases/tag/v2.1.0)
-### Bugfixes
+### Fixed
 - Fix issue with JLink library not found when installed in custom location on Linux/macOS (fixed by command line tools v9.7.1)
 
-## Version 2.1.0
-### Features
+## 2.1.0
+### Changed
 - Improved support for proxy servers (#104, #107, #113)
 - New settings screen that allows turning off checking for updates at startup (#104)
 - Make it easier for users to install apps manually (#105, #111)
 - Allow apps to filter ports in the serial port selector (#106)
-### Fixes
+### Fixed
 - Disable navigation when items are dragged and dropped into the application (#110)
-### Installation
-Downloads are available for Windows (exe), macOS (dmg), and Linux (tar.gz).
 
-## Version 2.1.0-alpha.0
+## 2.1.0-alpha.0
 Pre-release with improved support for proxies, ref. #104.
 
-## Version 2.0.0
+## 2.0.0
 While nRF Connect v1 was a dedicated Bluetooth low energy tool, v2 is a framework that can launch multiple desktop apps. The Bluetooth low energy tool has been [rewritten as an app](https://github.com/NordicSemiconductor/pc-nrfconnect-ble) for the nRF Connect framework, and can be installed and launched through the nRF Connect UI.
-### Features
+### Changed
 - Allows users to easily install, update, and launch apps
 - Allows developers to [create new apps](https://nordicsemiconductor.github.io/pc-nrfconnect-docs/create_new_app)
 - Supports Windows, macOS, and Linux
 - Automatic updates for Windows and macOS
-### Installation
-Downloads are available for Windows (exe), macOS (dmg), and Linux (tar.gz).
 
-## Version 2.0.0-alpha.15
+## 2.0.0-alpha.15
 Alpha release for testing.

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,10 @@
+## Unreleased
+### Added
+- Set
+  [user data directory](https://www.electronjs.org/docs/api/app#appgetpathname)
+  through command line switch `--user-data-dir` or environment variable
+  `NRF_USER_DATA_DIR`.
+
 ## Version 3.7.0
 ### Updates
 - Added recovery assistance for when the application encounters an error

--- a/src/main/config.js
+++ b/src/main/config.js
@@ -72,6 +72,11 @@ let isRunningLauncherFromSource;
  * Supported command line arguments:
  * --apps-root-dir       The directory where app data is stored.
  *                       Default: "<homeDir>/.nrfconnect-apps"
+ * --user-data-dir       Path to the user data dir. If this is not
+ *                       set, the environment variable NRF_USER_DATA_DIR
+ *                       is also used.
+ *                       See also https://www.electronjs.org/docs/api/app#appgetpathname
+ *                       Default: The appData directory appended with 'nrfconnect'.
  * --settings-json-path  Path to the user's settings file.
  *                       Default: "<userDataDir>/settings.json"
  * --skip-update-apps    Do not download info/updates about apps.

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -36,6 +36,9 @@
 
 'use strict';
 
+// Run this as soon as possible, so that the user data folder is not already initialised by Electron
+require('./setUserDataDir');
+
 const { existsSync } = require('fs');
 const { resolve } = require('path');
 

--- a/src/main/setUserDataDir.js
+++ b/src/main/setUserDataDir.js
@@ -1,0 +1,48 @@
+/* Copyright (c) 2015 - 2017, Nordic Semiconductor ASA
+ *
+ * All rights reserved.
+ *
+ * Use in source and binary forms, redistribution in binary form only, with
+ * or without modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 2. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 3. This software, with or without modification, must only be used with a Nordic
+ *    Semiconductor ASA integrated circuit.
+ *
+ * 4. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+'use strict';
+
+const { argv } = require('yargs');
+const { ensureDirSync } = require('fs-extra');
+const { app } = require('electron');
+
+const userDataDir = argv['user-data-dir'] || process.env.NRF_USER_DATA_DIR;
+
+if (userDataDir != null) {
+    ensureDirSync(userDataDir);
+    app.setPath('userData', userDataDir);
+}


### PR DESCRIPTION
Fixes #551 by enabling users to set the [user data directory](https://www.electronjs.org/docs/api/app#appgetpathname) through command line switch `--user-data-dir` or environment variable `NRF_USER_DATA_DIR`. 

Also updates `Changelog.md` and `Changelog-dev.md` according to our latest discussions.