### PR TITLE
Fix wrong button in release notes

### DIFF
--- a/src/launcher/components/ReleaseNotesDialogView.jsx
+++ b/src/launcher/components/ReleaseNotesDialogView.jsx
@@ -49,6 +49,7 @@ const view = ({
     source,
     onUpgrade,
     onHideReleaseNotes,
+    isInstalled,
 }) => (
     <Modal
         show={!!name}
@@ -72,7 +73,7 @@ const view = ({
                         onHideReleaseNotes();
                     }}
                 >
-                    Update to latest version
+                    {isInstalled ? 'Update to latest version' : 'Install'}
                 </Button>
             )}
             <Button variant="outline-primary" onClick={onHideReleaseNotes}>
@@ -91,6 +92,7 @@ view.propTypes = {
     name: string,
     onUpgrade: func.isRequired,
     onHideReleaseNotes: func.isRequired,
+    isInstalled: bool,
 };
 
 view.defaultProps = {

--- a/src/launcher/containers/ReleaseNotesDialogContainer.js
+++ b/src/launcher/containers/ReleaseNotesDialogContainer.js
@@ -55,6 +55,7 @@ function mapStateToProps({
             releaseNote: app.releaseNote,
             canUpdate: app.currentVersion !== app.latestVersion,
             latestVersion: app.latestVersion,
+            isInstalled: app.currentVersion != null,
         };
     }
 


### PR DESCRIPTION
Trello: [Wrong button in Release notes for uninstalled apps](https://trello.com/c/aBGhRWQ0/193-wrong-button-in-release-notes-for-uninstalled-apps).

For uninstalled apps there was a wrong “Update to latest version” button in the release notes dialog. This changes the wording to “Install”.