### PR TITLE
Show a warning when launcher apps using the old architecture

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,6 @@
 ## Unreleased
 ### Added
+- Display a warning for outdated apps, still using the old app architecture.
 - Set
   [user data directory](https://www.electronjs.org/docs/api/app#appgetpathname)
   through command line switch `--user-data-dir` or environment variable

--- a/src/legacy/app/actions/legacyAppDialogActions.ts
+++ b/src/legacy/app/actions/legacyAppDialogActions.ts
@@ -34,24 +34,14 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { combineReducers } from 'redux';
-
-import errorDialog from '../../reducers/errorDialogReducer';
-import appReloadDialog from './appReloadDialogReducer';
-import device from './deviceReducer';
-import firmwareDialog from './firmwareDialogReducer';
-import legacyAppDialog from './legacyAppDialogReducer';
-import log from './logReducer';
-import navMenu from './navMenuReducer';
-import serialPort from './serialPortReducer';
-
-export default combineReducers({
-    navMenu,
-    log,
-    serialPort,
-    device,
-    firmwareDialog,
-    appReloadDialog,
-    errorDialog,
-    legacyAppDialog,
+export const LEGACY_APP_DIALOG_SHOW_MAYBE = 'LEGACY_APP_DIALOG_SHOW_MAYBE';
+export const showMaybeLegacyAppDialog = () => ({
+    type: LEGACY_APP_DIALOG_SHOW_MAYBE,
 });
+
+export const LEGACY_APP_DIALOG_HIDE = 'LEGACY_APP_DIALOG_HIDE';
+export const hideLegacyAppDialog = () => ({ type: LEGACY_APP_DIALOG_HIDE });
+
+export type LegacyAppAction =
+    | ReturnType<typeof showMaybeLegacyAppDialog>
+    | ReturnType<typeof hideLegacyAppDialog>;

--- a/src/legacy/app/components/LegacyAppDialog.jsx
+++ b/src/legacy/app/components/LegacyAppDialog.jsx
@@ -34,24 +34,50 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { combineReducers } from 'redux';
+import React from 'react';
+import { bool, func } from 'prop-types';
 
-import errorDialog from '../../reducers/errorDialogReducer';
-import appReloadDialog from './appReloadDialogReducer';
-import device from './deviceReducer';
-import firmwareDialog from './firmwareDialogReducer';
-import legacyAppDialog from './legacyAppDialogReducer';
-import log from './logReducer';
-import navMenu from './navMenuReducer';
-import serialPort from './serialPortReducer';
+import ConfirmationDialog from '../../components/ConfirmationDialog';
 
-export default combineReducers({
-    navMenu,
-    log,
-    serialPort,
-    device,
-    firmwareDialog,
-    appReloadDialog,
-    errorDialog,
-    legacyAppDialog,
-});
+const LegacyAppDialog = ({ isVisible, close, closeAndRemember }) => (
+    <ConfirmationDialog
+        dimBackground
+        isVisible={isVisible}
+        okButtonText="Do not remind me again"
+        onOk={closeAndRemember}
+        title="Outdated app"
+        onCancel={close}
+    >
+        <p>
+            This app in its current form will not be supported by future
+            versions of nRF Connect for Desktop.
+        </p>
+        <p>
+            As a user of this app, please have a look for an updated version of
+            this app. If the developers do not provide a new version, consider
+            to remind them that they need to release an updated version of their
+            app.
+        </p>
+        <p>
+            As an app developer, be aware that you need to update your app,
+            otherwise it might cease to work with future versions of nRF Connect
+            for Desktop. Follow the instructions at{' '}
+            <a
+                href="https://nordicsemiconductor.github.io/pc-nrfconnect-docs/migrating_apps"
+                target="_blank"
+                rel="noreferrer"
+            >
+                https://nordicsemiconductor.github.io/pc-nrfconnect-docs/migrating_apps
+            </a>{' '}
+            to update your app and release a new version in time to your users.
+        </p>
+    </ConfirmationDialog>
+);
+
+LegacyAppDialog.propTypes = {
+    isVisible: bool.isRequired,
+    close: func.isRequired,
+    closeAndRemember: func.isRequired,
+};
+
+export default LegacyAppDialog;

--- a/src/legacy/app/components/Root.jsx
+++ b/src/legacy/app/components/Root.jsx
@@ -43,6 +43,7 @@ import AppReloadDialogContainer from '../containers/AppReloadDialogContainer';
 import DeviceSetupContainer from '../containers/DeviceSetupContainer';
 import ErrorDialogContainer from '../containers/ErrorDialogContainer';
 import FirmwareDialogContainer from '../containers/FirmwareDialogContainer';
+import LegacyAppDialogContainer from '../containers/LegacyAppDialogContainer';
 import LogViewerContainer from '../containers/LogViewerContainer';
 import MainViewContainer from '../containers/MainViewContainer';
 import SidePanelContainer from '../containers/SidePanelContainer';
@@ -120,6 +121,7 @@ const Root = ({ resizeLogContainer }) => (
             <AppReloadDialogContainer />
             <DeviceSetupContainer />
             <ErrorDialogContainer />
+            <LegacyAppDialogContainer />
         </ErrorBoundary>
     </div>
 );

--- a/src/legacy/app/containers/LegacyAppDialogContainer.js
+++ b/src/legacy/app/containers/LegacyAppDialogContainer.js
@@ -34,24 +34,24 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { combineReducers } from 'redux';
+import { connect } from '../../decoration';
+import { hideLegacyAppDialog } from '../actions/legacyAppDialogActions';
+import LegacyAppDialog from '../components/LegacyAppDialog';
+import { addToDoNotShowLegacyAppDialogAgain } from '../legacyAppWarning';
 
-import errorDialog from '../../reducers/errorDialogReducer';
-import appReloadDialog from './appReloadDialogReducer';
-import device from './deviceReducer';
-import firmwareDialog from './firmwareDialogReducer';
-import legacyAppDialog from './legacyAppDialogReducer';
-import log from './logReducer';
-import navMenu from './navMenuReducer';
-import serialPort from './serialPortReducer';
-
-export default combineReducers({
-    navMenu,
-    log,
-    serialPort,
-    device,
-    firmwareDialog,
-    appReloadDialog,
-    errorDialog,
-    legacyAppDialog,
+const mapStateToProps = state => ({
+    isVisible: state.core.legacyAppDialog,
 });
+
+const mapDispatchToProps = dispatch => ({
+    close: () => dispatch(hideLegacyAppDialog()),
+    closeAndRemember: () => {
+        addToDoNotShowLegacyAppDialogAgain();
+        dispatch(hideLegacyAppDialog());
+    },
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(
+    LegacyAppDialog,
+    'LegacyAppDialog'
+);

--- a/src/legacy/app/legacyAppWarning.ts
+++ b/src/legacy/app/legacyAppWarning.ts
@@ -34,24 +34,41 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { combineReducers } from 'redux';
+import Store from 'electron-store';
+import path from 'path';
 
-import errorDialog from '../../reducers/errorDialogReducer';
-import appReloadDialog from './appReloadDialogReducer';
-import device from './deviceReducer';
-import firmwareDialog from './firmwareDialogReducer';
-import legacyAppDialog from './legacyAppDialogReducer';
-import log from './logReducer';
-import navMenu from './navMenuReducer';
-import serialPort from './serialPortReducer';
+const store = new Store({ name: 'pc-nrfconnect-launcher' });
 
-export default combineReducers({
-    navMenu,
-    log,
-    serialPort,
-    device,
-    firmwareDialog,
-    appReloadDialog,
-    errorDialog,
-    legacyAppDialog,
-});
+const currentAppName = () => {
+    const params = new URL(window.location.toString()).searchParams;
+    const appPath = params.get('appPath') ?? 'unknown app';
+
+    return path.basename(appPath);
+};
+
+const appsWithoutWarningPermanently = [
+    'pc-nrfconnect-ble',
+    'pc-nrfconnect-gettingstarted',
+    'pc-nrfconnect-programmer',
+    'pc-nrfconnect-linkmonitor',
+    'pc-nrfconnect-tracecollector',
+    'pc-nrfconnect-dtm',
+];
+
+const appsWithoutWarningLocally = () =>
+    store.get('doNotShowLegacyAppDialogAgain', []);
+
+const appsWithoutWarning = appsWithoutWarningPermanently.concat(
+    appsWithoutWarningLocally()
+);
+
+export const showWarningForCurrentApp = () =>
+    !appsWithoutWarning.includes(currentAppName());
+
+export const addToDoNotShowLegacyAppDialogAgain = () => {
+    const previousApps = store.get('doNotShowLegacyAppDialogAgain', []);
+    store.set('doNotShowLegacyAppDialogAgain', [
+        ...previousApps,
+        currentAppName(),
+    ]);
+};

--- a/src/legacy/app/legacyAppWarning.ts
+++ b/src/legacy/app/legacyAppWarning.ts
@@ -37,6 +37,10 @@
 import Store from 'electron-store';
 import path from 'path';
 
+const {
+    sendLauncherUsageData,
+} = require('../../launcher/actions/usageDataActions');
+
 const store = new Store({ name: 'pc-nrfconnect-launcher' });
 
 const currentAppName = () => {
@@ -71,4 +75,8 @@ export const addToDoNotShowLegacyAppDialogAgain = () => {
         ...previousApps,
         currentAppName(),
     ]);
+};
+
+export const sendUsageDataForLegacyApp = () => {
+    sendLauncherUsageData('Display legacy app warning', currentAppName());
 };

--- a/src/legacy/app/reducers/legacyAppDialogReducer.ts
+++ b/src/legacy/app/reducers/legacyAppDialogReducer.ts
@@ -34,24 +34,22 @@
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import { combineReducers } from 'redux';
+import {
+    LEGACY_APP_DIALOG_HIDE,
+    LEGACY_APP_DIALOG_SHOW_MAYBE,
+    LegacyAppAction,
+} from '../actions/legacyAppDialogActions';
+import { showWarningForCurrentApp } from '../legacyAppWarning';
 
-import errorDialog from '../../reducers/errorDialogReducer';
-import appReloadDialog from './appReloadDialogReducer';
-import device from './deviceReducer';
-import firmwareDialog from './firmwareDialogReducer';
-import legacyAppDialog from './legacyAppDialogReducer';
-import log from './logReducer';
-import navMenu from './navMenuReducer';
-import serialPort from './serialPortReducer';
+const reducer = (state = false, action: LegacyAppAction) => {
+    switch (action.type) {
+        case LEGACY_APP_DIALOG_SHOW_MAYBE:
+            return showWarningForCurrentApp();
+        case LEGACY_APP_DIALOG_HIDE:
+            return false;
+        default:
+            return state;
+    }
+};
 
-export default combineReducers({
-    navMenu,
-    log,
-    serialPort,
-    device,
-    firmwareDialog,
-    appReloadDialog,
-    errorDialog,
-    legacyAppDialog,
-});
+export default reducer;

--- a/src/legacy/app/reducers/legacyAppDialogReducer.ts
+++ b/src/legacy/app/reducers/legacyAppDialogReducer.ts
@@ -39,12 +39,20 @@ import {
     LEGACY_APP_DIALOG_SHOW_MAYBE,
     LegacyAppAction,
 } from '../actions/legacyAppDialogActions';
-import { showWarningForCurrentApp } from '../legacyAppWarning';
+import {
+    sendUsageDataForLegacyApp,
+    showWarningForCurrentApp,
+} from '../legacyAppWarning';
 
 const reducer = (state = false, action: LegacyAppAction) => {
     switch (action.type) {
-        case LEGACY_APP_DIALOG_SHOW_MAYBE:
-            return showWarningForCurrentApp();
+        case LEGACY_APP_DIALOG_SHOW_MAYBE: {
+            const showDialog = showWarningForCurrentApp();
+            if (showDialog) {
+                sendUsageDataForLegacyApp();
+            }
+            return showDialog;
+        }
         case LEGACY_APP_DIALOG_HIDE:
             return false;
         default:

--- a/src/legacy/components/ConfirmationDialog.jsx
+++ b/src/legacy/components/ConfirmationDialog.jsx
@@ -70,11 +70,12 @@ const ConfirmationDialog = ({
     okButtonText,
     cancelButtonText,
     isOkButtonEnabled,
+    dimBackground,
 }) => (
     <Modal
         show={isVisible}
         onHide={onCancel}
-        backdrop={isInProgress ? 'static' : false}
+        backdrop={isInProgress || dimBackground ? 'static' : false}
     >
         <Modal.Header closeButton={!isInProgress}>
             <Modal.Title>{title}</Modal.Title>
@@ -115,6 +116,7 @@ ConfirmationDialog.propTypes = {
     cancelButtonText: string,
     isInProgress: bool,
     isOkButtonEnabled: bool,
+    dimBackground: bool,
 };
 
 ConfirmationDialog.defaultProps = {
@@ -126,6 +128,7 @@ ConfirmationDialog.defaultProps = {
     onCancel: null,
     okButtonText: 'OK',
     cancelButtonText: 'Cancel',
+    dimBackground: false,
 };
 
 export default ConfirmationDialog;

--- a/src/legacy/legacyRenderer.jsx
+++ b/src/legacy/legacyRenderer.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render } from 'react-dom';
 
+import { showMaybeLegacyAppDialog } from './app/actions/legacyAppDialogActions';
 import RootContainer from './app/containers/RootContainer';
 import rootReducer from './app/reducers';
 import { invokeAppFn, setApp } from './decoration';
@@ -13,6 +14,7 @@ export default (app, container, onLoaded) => {
     invokeAppFn('onInit', store.dispatch, store.getState);
     render(<RootContainer store={store} />, container, () => {
         onLoaded();
+        store.dispatch(showMaybeLegacyAppDialog());
         invokeAppFn('onReady', store.dispatch, store.getState);
     });
 };


### PR DESCRIPTION
Since we would like to deprecate the old architecture eventually, this change displays this warning when users launch an app that still uses the old architecture:

![image](https://user-images.githubusercontent.com/260705/131521397-98e9bfb8-40f9-4aa2-8512-99fdd1e3bcd1.png)

The warning also points app developers to https://nordicsemiconductor.github.io/pc-nrfconnect-docs/migrating_apps, so they know how to update their apps.

Besides that users can permanently dismiss the warning per app, our own apps where we are aware that we still have to update them are also excluded: https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/blob/bc92cfbccf57f27eebc186b0037ade54d25d57be/src/legacy/app/legacyAppWarning.ts#L53-L60

One way of testing this feature is by adding the Actinus source https://cdn.actini.us/nrf-apps/apps.json to the launcher and then installing and launching their programmer.