### PR TITLE
Cleanup usage data

### DIFF
--- a/src/launcher/actions/appsActions.js
+++ b/src/launcher/actions/appsActions.js
@@ -371,11 +371,9 @@ export function loadOfficialApps(appName, appSource) {
 const handleAppsWithErrors = (dispatch, apps) => {
     dispatch(loadOfficialAppsError());
     apps.forEach(app => {
-        dispatch(
-            sendLauncherUsageData(
-                EventAction.REPORT_INSTALLATION_ERROR,
-                `${app.source} - ${app.name}`
-            )
+        sendLauncherUsageData(
+            EventAction.REPORT_INSTALLATION_ERROR,
+            `${app.source} - ${app.name}`
         );
     });
 
@@ -400,7 +398,7 @@ const buildErrorMessage = apps => {
 
 export function installOfficialApp(name, source) {
     return dispatch => {
-        dispatch(sendAppUsageData(EventAction.INSTALL_APP, source, name));
+        sendAppUsageData(EventAction.INSTALL_APP, source, name);
         dispatch(installOfficialAppAction(name, source));
         mainApps
             .installOfficialApp(name, 'latest', source)
@@ -421,7 +419,7 @@ export function installOfficialApp(name, source) {
 
 export function removeOfficialApp(name, source) {
     return dispatch => {
-        dispatch(sendAppUsageData(EventAction.REMOVE_APP, source, name));
+        sendAppUsageData(EventAction.REMOVE_APP, source, name);
         dispatch(removeOfficialAppAction(name, source));
         mainApps
             .removeOfficialApp(name, source)
@@ -442,7 +440,7 @@ export function removeOfficialApp(name, source) {
 
 export function upgradeOfficialApp(name, version, source) {
     return dispatch => {
-        dispatch(sendAppUsageData(EventAction.UPGRADE_APP, source, name));
+        sendAppUsageData(EventAction.UPGRADE_APP, source, name);
         dispatch(upgradeOfficialAppAction(name, version, source));
         return mainApps
             .installOfficialApp(name, version, source)
@@ -464,18 +462,14 @@ export function upgradeOfficialApp(name, version, source) {
 }
 
 export function launch(app) {
-    return dispatch => {
-        // The apps in state are Immutable Maps which cannot be sent over IPC.
-        // Converting to plain JS object before sending to the main process.
-        const appObj = app.toJS();
-        const sharedData =
-            `App version: ${appObj.currentVersion};` +
-            ` Engine version: ${appObj.engineVersion};`;
-        dispatch(
-            sendAppUsageData(EventAction.LAUNCH_APP, sharedData, appObj.name)
-        );
-        ipcRenderer.send('open-app', appObj);
-    };
+    // The apps in state are Immutable Maps which cannot be sent over IPC.
+    // Converting to plain JS object before sending to the main process.
+    const appObj = app.toJS();
+    const sharedData =
+        `App version: ${appObj.currentVersion};` +
+        ` Engine version: ${appObj.engineVersion};`;
+    sendAppUsageData(EventAction.LAUNCH_APP, sharedData, appObj.name);
+    ipcRenderer.send('open-app', appObj);
 }
 
 export function checkEngineAndLaunch(app) {
@@ -485,13 +479,12 @@ export function checkEngineAndLaunch(app) {
             appCompatibility.isCompatible ||
             config.isRunningLauncherFromSource();
 
-        dispatch(
-            launchAppWithoutWarning
-                ? launch(app)
-                : showConfirmLaunchDialogAction(
-                      appCompatibility.longWarning,
-                      app
-                  )
-        );
+        if (launchAppWithoutWarning) {
+            launch(app);
+        } else {
+            dispatch(
+                showConfirmLaunchDialogAction(appCompatibility.longWarning, app)
+            );
+        }
     };
 }

--- a/src/launcher/actions/usageDataActions.js
+++ b/src/launcher/actions/usageDataActions.js
@@ -149,11 +149,7 @@ export function checkUsageDataSetting() {
 }
 
 export function sendLauncherUsageData(eventAction, eventLabel) {
-    return (_, getState) => {
-        const { isSendingUsageData } = getState().settings;
-        if (!isSendingUsageData) {
-            return;
-        }
+    return () => {
         usageData.sendUsageData(eventAction, eventLabel);
     };
 }

--- a/src/launcher/actions/usageDataActions.js
+++ b/src/launcher/actions/usageDataActions.js
@@ -149,9 +149,7 @@ export function checkUsageDataSetting() {
 }
 
 export function sendLauncherUsageData(eventAction, eventLabel) {
-    return () => {
-        usageData.sendUsageData(eventAction, eventLabel);
-    };
+    usageData.sendUsageData(eventAction, eventLabel);
 }
 
 export function sendAppUsageData(
@@ -159,25 +157,16 @@ export function sendAppUsageData(
     eventLabel = null,
     appName = null
 ) {
-    return () => {
-        const updatedEventAction = appName
-            ? `${eventAction} ${appName}`
-            : eventAction;
-        usageData.sendUsageData(updatedEventAction, eventLabel);
-    };
+    const updatedEventAction = appName
+        ? `${eventAction} ${appName}`
+        : eventAction;
+    usageData.sendUsageData(updatedEventAction, eventLabel);
 }
 
-export function sendEnvInfo() {
-    return async dispatch => {
-        const [{ platform, arch }] = await Promise.all([si.osInfo()]);
-        const osInfo = `${platform}; ${arch}`;
-        dispatch(sendLauncherUsageData(EventAction.REPORT_OS_INFO, osInfo));
-        const launcherInfo = pkgJson.version ? `v${pkgJson.version}` : '';
-        dispatch(
-            sendLauncherUsageData(
-                EventAction.REPORT_LAUNCHER_INFO,
-                launcherInfo
-            )
-        );
-    };
+export async function sendEnvInfo() {
+    const [{ platform, arch }] = await Promise.all([si.osInfo()]);
+    const osInfo = `${platform}; ${arch}`;
+    sendLauncherUsageData(EventAction.REPORT_OS_INFO, osInfo);
+    const launcherInfo = pkgJson.version ? `v${pkgJson.version}` : '';
+    sendLauncherUsageData(EventAction.REPORT_LAUNCHER_INFO, launcherInfo);
 }

--- a/src/launcher/components/ErrorBoundaryLauncher.jsx
+++ b/src/launcher/components/ErrorBoundaryLauncher.jsx
@@ -57,7 +57,7 @@ const ErrorBoundaryLauncher = ({ children }) => {
     const sendUsageData = error => {
         const launcherInfo = pkgJson.version ? `v${pkgJson.version}` : '';
         const errorLabel = `${process.platform}; ${process.arch}; v${launcherInfo}; ${error}`;
-        dispatch(sendLauncherUsageData('Report error', errorLabel));
+        sendLauncherUsageData('Report error', errorLabel);
     };
 
     return (

--- a/src/launcher/containers/ConfirmLaunchContainer.js
+++ b/src/launcher/containers/ConfirmLaunchContainer.js
@@ -53,7 +53,7 @@ function mapDispatchToProps(dispatch) {
     return {
         onConfirm: app => {
             dispatch(AppsActions.hideConfirmLaunchDialogAction());
-            dispatch(AppsActions.launch(app));
+            AppsActions.launch(app);
         },
         onCancel: () => dispatch(AppsActions.hideConfirmLaunchDialogAction()),
     };

--- a/src/launcher/index.js
+++ b/src/launcher/index.js
@@ -105,5 +105,5 @@ render(rootElement, document.getElementById('webapp'), async () => {
     await store.dispatch(AppsActions.setAppManagementSource());
     await downloadLatestAppInfo();
     await checkForCoreUpdates();
-    store.dispatch(UsageDataActions.sendEnvInfo());
+    UsageDataActions.sendEnvInfo();
 });


### PR DESCRIPTION
Main change is in cfacdc0: Checking `isSendingUsageData` in `sendLauncherUsageData` was unneeded, because in `usageData.sendUsageData` it is also checked whether the users opted-in sending usage data.

The function `sendAppUsageData` also did not do the same check, so it confused me why one function did the check, the other did not.

9f6784d then just does further cleanups: `sendAppUsageData`, `sendLauncherUsageData` and some other thunks calling these could easily be turned into normal functions.