### PR TITLE
Add lincense to launcher

### DIFF
--- a/resources/css/launcher.scss
+++ b/resources/css/launcher.scss
@@ -33,7 +33,6 @@
  * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-@import "~pc-nrfconnect-shared/styles";
 @import "~@mdi/font/css/materialdesignicons.min.css";
 
 $roboto-font-path: "~roboto-fontface/fonts" !default;
@@ -45,7 +44,7 @@ $theme-colors: (
 );
 $enable-transitions: false;
 $enable-rounded: false;
-$body-bg: $gray-100;
+$body-bg: #cfd8dc;
 @import "~bootstrap/scss/bootstrap";
 
 @import "./pretty-scrollbar";

--- a/resources/css/launcher.scss
+++ b/resources/css/launcher.scss
@@ -258,3 +258,13 @@ body {
     position: relative;
     top: 2px;
 }
+
+.settings-pane-container {
+    .toggle label {
+        justify-content: flex-start;
+    }
+
+    .toggle-label {
+        font-size: 1rem;
+    }
+}

--- a/resources/css/launcher.scss
+++ b/resources/css/launcher.scss
@@ -33,7 +33,7 @@
  * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
  * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-
+@import "~pc-nrfconnect-shared/styles";
 @import "~@mdi/font/css/materialdesignicons.min.css";
 
 $roboto-font-path: "~roboto-fontface/fonts" !default;
@@ -45,7 +45,7 @@ $theme-colors: (
 );
 $enable-transitions: false;
 $enable-rounded: false;
-$body-bg: #d9e1e2;
+$body-bg: $gray-100;
 @import "~bootstrap/scss/bootstrap";
 
 @import "./pretty-scrollbar";

--- a/src/launcher/components/AboutView.jsx
+++ b/src/launcher/components/AboutView.jsx
@@ -47,6 +47,28 @@ const AboutView = () => (
         <Card body>
             <Row>
                 <Col>
+                    <Card.Title>Version</Card.Title>
+                </Col>
+            </Row>
+            <p>nRF Connect for Desktop v{appVersion}</p>
+        </Card>
+        <Card body>
+            <Row>
+                <Col>
+                    <Card.Title>Documentation</Card.Title>
+                </Col>
+            </Row>
+            <Button
+                href="https://devzone.nordicsemi.com/nordic/nordic-blog/b/blog/posts/nrf-connect-for-visual-studio-code-preview"
+                target="_blank"
+                variant="outline-primary"
+            >
+                Open documentation
+            </Button>
+        </Card>
+        <Card body>
+            <Row>
+                <Col>
                     <Card.Title>License</Card.Title>
                 </Col>
             </Row>
@@ -111,28 +133,6 @@ const AboutView = () => (
                 IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
                 THE POSSIBILITY OF SUCH DAMAGE.
             </p>
-        </Card>
-        <Card body>
-            <Row>
-                <Col>
-                    <Card.Title>Version</Card.Title>
-                </Col>
-            </Row>
-            <p>nRF Connect for Desktop v{appVersion}</p>
-        </Card>
-        <Card body>
-            <Row>
-                <Col>
-                    <Card.Title>Documentation</Card.Title>
-                </Col>
-            </Row>
-            <Button
-                href="https://devzone.nordicsemi.com/nordic/nordic-blog/b/blog/posts/nrf-connect-for-visual-studio-code-preview"
-                target="_blank"
-                variant="outline-primary"
-            >
-                Open documentation
-            </Button>
         </Card>
     </>
 );

--- a/src/launcher/components/AboutView.jsx
+++ b/src/launcher/components/AboutView.jsx
@@ -1,0 +1,136 @@
+/* Copyright (c) 2015 - 2017, Nordic Semiconductor ASA
+ *
+ * All rights reserved.
+ *
+ * Use in source and binary forms, redistribution in binary form only, with
+ * or without modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions in binary form, except as embedded into a Nordic
+ *    Semiconductor ASA integrated circuit in a product or a software update for
+ *    such product, must reproduce the above copyright notice, this list of
+ *    conditions and the following disclaimer in the documentation and/or other
+ *    materials provided with the distribution.
+ *
+ * 2. Neither the name of Nordic Semiconductor ASA nor the names of its
+ *    contributors may be used to endorse or promote products derived from this
+ *    software without specific prior written permission.
+ *
+ * 3. This software, with or without modification, must only be used with a Nordic
+ *    Semiconductor ASA integrated circuit.
+ *
+ * 4. Any software provided in binary form under this license must not be reverse
+ *    engineered, decompiled, modified and/or disassembled.
+ *
+ * THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA "AS IS" AND ANY EXPRESS OR
+ * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+ * TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import React from 'react';
+import Card from 'react-bootstrap/Card';
+import Col from 'react-bootstrap/Col';
+import Row from 'react-bootstrap/Row';
+
+const appVersion = require('electron').remote.app.getVersion();
+
+const AboutView = () => (
+    <>
+        <Card body>
+            <Row>
+                <Col>
+                    <Card.Title>License</Card.Title>
+                </Col>
+            </Row>
+            <p>Copyright (c) 2015 - 2017, Nordic Semiconductor ASA</p>
+            <p>All rights reserved.</p>
+            <p>
+                Use in source and binary forms, redistribution in binary form
+                only, with or without modification, are permitted provided that
+                the following conditions are met:
+            </p>
+            <ol>
+                <li>
+                    <p>
+                        Redistributions in binary form, except as embedded into
+                        a Nordic * Semiconductor ASA integrated circuit in a
+                        product or a software update for * such product, must
+                        reproduce the above copyright notice, this list of
+                        conditions and the following disclaimer in the
+                        documentation and/or other materials provided with the
+                        distribution.
+                    </p>
+                </li>
+
+                <li>
+                    <p>
+                        Neither the name of Nordic Semiconductor ASA nor the
+                        names of its contributors may be used to endorse or
+                        promote products derived from this software without
+                        specific prior written permission.
+                    </p>
+                </li>
+
+                <li>
+                    <p>
+                        This software, with or without modification, must only
+                        be used with a Nordic Semiconductor ASA integrated
+                        circuit.
+                    </p>
+                </li>
+
+                <li>
+                    <p>
+                        Any software provided in binary form under this license
+                        must not be reverse engineered, decompiled, modified
+                        and/or disassembled.
+                    </p>
+                </li>
+            </ol>
+            <p>
+                THIS SOFTWARE IS PROVIDED BY NORDIC SEMICONDUCTOR ASA &quot;AS
+                IS&quot; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+                NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,
+                NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE ARE
+                DISCLAIMED. IN NO EVENT SHALL NORDIC SEMICONDUCTOR ASA OR
+                CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+                SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+                LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+                USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+                AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+                LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+                IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+                THE POSSIBILITY OF SUCH DAMAGE.
+            </p>
+        </Card>
+        <Card body>
+            <Row>
+                <Col>
+                    <Card.Title>Version</Card.Title>
+                </Col>
+            </Row>
+            <p>nRF Connect {appVersion}</p>
+        </Card>
+        <Card body>
+            <Row>
+                <Col>
+                    <Card.Title>Documentation</Card.Title>
+                </Col>
+            </Row>
+            <p>
+                <a href="https://devzone.nordicsemi.com/nordic/nordic-blog/b/blog/posts/nrf-connect-for-visual-studio-code-preview">
+                    Link to Infocenter
+                </a>
+            </p>
+        </Card>
+    </>
+);
+
+export default AboutView;

--- a/src/launcher/components/AboutView.jsx
+++ b/src/launcher/components/AboutView.jsx
@@ -35,6 +35,7 @@
  */
 
 import React from 'react';
+import Button from 'react-bootstrap/Button';
 import Card from 'react-bootstrap/Card';
 import Col from 'react-bootstrap/Col';
 import Row from 'react-bootstrap/Row';
@@ -49,8 +50,9 @@ const AboutView = () => (
                     <Card.Title>License</Card.Title>
                 </Col>
             </Row>
-            <p>Copyright (c) 2015 - 2017, Nordic Semiconductor ASA</p>
+            <p>Copyright (c) 2015 Nordic Semiconductor ASA</p>
             <p>All rights reserved.</p>
+            <p>SPDX-License-Identifier: Nordic-4-Clause</p>
             <p>
                 Use in source and binary forms, redistribution in binary form
                 only, with or without modification, are permitted provided that
@@ -60,8 +62,8 @@ const AboutView = () => (
                 <li>
                     <p>
                         Redistributions in binary form, except as embedded into
-                        a Nordic * Semiconductor ASA integrated circuit in a
-                        product or a software update for * such product, must
+                        a Nordic Semiconductor ASA integrated circuit in a
+                        product or a software update for such product, must
                         reproduce the above copyright notice, this list of
                         conditions and the following disclaimer in the
                         documentation and/or other materials provided with the
@@ -116,7 +118,7 @@ const AboutView = () => (
                     <Card.Title>Version</Card.Title>
                 </Col>
             </Row>
-            <p>nRF Connect {appVersion}</p>
+            <p>nRF Connect for Desktop v{appVersion}</p>
         </Card>
         <Card body>
             <Row>
@@ -124,11 +126,13 @@ const AboutView = () => (
                     <Card.Title>Documentation</Card.Title>
                 </Col>
             </Row>
-            <p>
-                <a href="https://devzone.nordicsemi.com/nordic/nordic-blog/b/blog/posts/nrf-connect-for-visual-studio-code-preview">
-                    Link to Infocenter
-                </a>
-            </p>
+            <Button
+                href="https://devzone.nordicsemi.com/nordic/nordic-blog/b/blog/posts/nrf-connect-for-visual-studio-code-preview"
+                target="_blank"
+                variant="outline-primary"
+            >
+                Open documentation
+            </Button>
         </Card>
     </>
 );

--- a/src/launcher/components/Root.jsx
+++ b/src/launcher/components/Root.jsx
@@ -47,6 +47,7 @@ import SettingsContainer from '../containers/SettingsContainer';
 import UpdateAvailableContainer from '../containers/UpdateAvailableContainer';
 import UpdateProgressContainer from '../containers/UpdateProgressContainer';
 import UsageDataDialogContainer from '../containers/UsageDataDialogContainer';
+import AboutView from './AboutView';
 import ErrorBoundaryLauncher from './ErrorBoundaryLauncher';
 
 export default () => (
@@ -61,6 +62,10 @@ export default () => (
                 <Nav.Link accessKey="2" eventKey="settings">
                     settings
                 </Nav.Link>
+                {/* eslint-disable-next-line jsx-a11y/no-access-key */}
+                <Nav.Link accessKey="3" eventKey="about">
+                    about
+                </Nav.Link>
                 <Logo />
             </Nav>
             <Tab.Content>
@@ -69,6 +74,9 @@ export default () => (
                 </Tab.Pane>
                 <Tab.Pane eventKey="settings">
                     <SettingsContainer />
+                </Tab.Pane>
+                <Tab.Pane eventKey="about">
+                    <AboutView />
                 </Tab.Pane>
             </Tab.Content>
         </Tab.Container>

--- a/src/launcher/components/SettingsView.jsx
+++ b/src/launcher/components/SettingsView.jsx
@@ -144,7 +144,6 @@ class SettingsView extends React.Component {
                         )}
                     </p>
                     <Toggle
-                        className="toggle-settings"
                         id="checkForUpdates"
                         label="Check for updates at startup"
                         onToggle={() => this.onCheckUpdatesAtStartupChanged()}
@@ -220,7 +219,6 @@ class SettingsView extends React.Component {
                     <Row>
                         <Col>
                             <Toggle
-                                className="toggle-settings"
                                 id="checkForShare"
                                 label="Collect anonymous usage data"
                                 onToggle={() => toggleSendingUsageData()}

--- a/src/launcher/components/SettingsView.jsx
+++ b/src/launcher/components/SettingsView.jsx
@@ -44,10 +44,13 @@ import Modal from 'react-bootstrap/Modal';
 import Row from 'react-bootstrap/Row';
 import formatDate from 'date-fns/format';
 import { clipboard } from 'electron';
+import { colors, Toggle } from 'pc-nrfconnect-shared';
 import { bool, func, instanceOf, shape } from 'prop-types';
 
 import ConfirmRemoveSourceDialog from '../containers/ConfirmRemoveSourceDialog';
 import InputLineDialog from './InputLineDialog';
+
+const { white, gray700, nordicBlue } = colors;
 
 function cancel(event) {
     event.preventDefault();
@@ -70,9 +73,12 @@ class SettingsView extends React.Component {
         onMount();
     }
 
-    onCheckUpdatesAtStartupChanged(event) {
-        const { onCheckUpdatesAtStartupChanged } = this.props;
-        onCheckUpdatesAtStartupChanged(event.target.checked);
+    onCheckUpdatesAtStartupChanged() {
+        const {
+            onCheckUpdatesAtStartupChanged,
+            shouldCheckForUpdatesAtStartup,
+        } = this.props;
+        onCheckUpdatesAtStartupChanged(!shouldCheckForUpdatesAtStartup);
     }
 
     onTriggerUpdateCheckClicked() {
@@ -109,7 +115,7 @@ class SettingsView extends React.Component {
         const sourcesJS = sources.toJS();
 
         return (
-            <>
+            <div className="settings-pane-container">
                 <Card body>
                     <Row>
                         <Col>
@@ -138,12 +144,16 @@ class SettingsView extends React.Component {
                             </>
                         )}
                     </p>
-                    <Form.Check
-                        custom
+                    <Toggle
+                        className="toggle-settings"
                         id="checkForUpdates"
                         label="Check for updates at startup"
-                        checked={shouldCheckForUpdatesAtStartup}
-                        onChange={this.onCheckUpdatesAtStartupChanged}
+                        onToggle={() => this.onCheckUpdatesAtStartupChanged()}
+                        isToggled={shouldCheckForUpdatesAtStartup}
+                        variant="primary"
+                        handleColor={white}
+                        barColor={gray700}
+                        barColorToggled={nordicBlue}
                     />
                 </Card>
                 <Card
@@ -210,12 +220,16 @@ class SettingsView extends React.Component {
                     </Row>
                     <Row>
                         <Col>
-                            <Form.Check
-                                custom
+                            <Toggle
+                                className="toggle-settings"
                                 id="checkForShare"
                                 label="Collect anonymous usage data"
-                                checked={isSendingUsageData}
-                                onChange={toggleSendingUsageData}
+                                onToggle={() => toggleSendingUsageData()}
+                                isToggled={isSendingUsageData}
+                                variant="primary"
+                                handleColor={white}
+                                barColor={gray700}
+                                barColorToggled={nordicBlue}
                             />
                         </Col>
                         <Col xs="auto">
@@ -266,7 +280,7 @@ class SettingsView extends React.Component {
                     onCancel={onHideAddSourceDialog}
                 />
                 <ConfirmRemoveSourceDialog />
-            </>
+            </div>
         );
     }
 }

--- a/src/launcher/components/SettingsView.jsx
+++ b/src/launcher/components/SettingsView.jsx
@@ -39,7 +39,6 @@ import Button from 'react-bootstrap/Button';
 import ButtonToolbar from 'react-bootstrap/ButtonToolbar';
 import Card from 'react-bootstrap/Card';
 import Col from 'react-bootstrap/Col';
-import Form from 'react-bootstrap/Form';
 import Modal from 'react-bootstrap/Modal';
 import Row from 'react-bootstrap/Row';
 import formatDate from 'date-fns/format';

--- a/src/launcher/components/__tests__/__snapshots__/SettingsView-test.jsx.snap
+++ b/src/launcher/components/__tests__/__snapshots__/SettingsView-test.jsx.snap
@@ -37,7 +37,6 @@ exports[`SettingsView should render check for updates completed, with everything
       2017-02-03 13:41:36
     </p>
     <Toggle
-      className="toggle-settings"
       id="checkForUpdates"
       isToggled={false}
       label="Check for updates at startup"
@@ -92,7 +91,6 @@ exports[`SettingsView should render check for updates completed, with everything
     >
       <Col>
         <Toggle
-          className="toggle-settings"
           id="checkForShare"
           isToggled={false}
           label="Collect anonymous usage data"
@@ -191,7 +189,6 @@ exports[`SettingsView should render check for updates completed, with updates av
       2017-02-03 13:41:36
     </p>
     <Toggle
-      className="toggle-settings"
       id="checkForUpdates"
       isToggled={false}
       label="Check for updates at startup"
@@ -246,7 +243,6 @@ exports[`SettingsView should render check for updates completed, with updates av
     >
       <Col>
         <Toggle
-          className="toggle-settings"
           id="checkForShare"
           isToggled={false}
           label="Collect anonymous usage data"
@@ -341,7 +337,6 @@ exports[`SettingsView should render empty div while loading 1`] = `
       className="small text-muted"
     />
     <Toggle
-      className="toggle-settings"
       id="checkForUpdates"
       isToggled={true}
       label="Check for updates at startup"
@@ -396,7 +391,6 @@ exports[`SettingsView should render empty div while loading 1`] = `
     >
       <Col>
         <Toggle
-          className="toggle-settings"
           id="checkForShare"
           isToggled={false}
           label="Collect anonymous usage data"
@@ -491,7 +485,6 @@ exports[`SettingsView should render when checking for updates 1`] = `
       className="small text-muted"
     />
     <Toggle
-      className="toggle-settings"
       id="checkForUpdates"
       isToggled={false}
       label="Check for updates at startup"
@@ -546,7 +539,6 @@ exports[`SettingsView should render when checking for updates 1`] = `
     >
       <Col>
         <Toggle
-          className="toggle-settings"
           id="checkForShare"
           isToggled={false}
           label="Collect anonymous usage data"
@@ -641,7 +633,6 @@ exports[`SettingsView should render with check for updates disabled 1`] = `
       className="small text-muted"
     />
     <Toggle
-      className="toggle-settings"
       id="checkForUpdates"
       isToggled={false}
       label="Check for updates at startup"
@@ -696,7 +687,6 @@ exports[`SettingsView should render with check for updates disabled 1`] = `
     >
       <Col>
         <Toggle
-          className="toggle-settings"
           id="checkForShare"
           isToggled={false}
           label="Collect anonymous usage data"
@@ -791,7 +781,6 @@ exports[`SettingsView should render with check for updates enabled 1`] = `
       className="small text-muted"
     />
     <Toggle
-      className="toggle-settings"
       id="checkForUpdates"
       isToggled={true}
       label="Check for updates at startup"
@@ -846,7 +835,6 @@ exports[`SettingsView should render with check for updates enabled 1`] = `
     >
       <Col>
         <Toggle
-          className="toggle-settings"
           id="checkForShare"
           isToggled={false}
           label="Collect anonymous usage data"
@@ -945,7 +933,6 @@ exports[`SettingsView should render with last update check date 1`] = `
       2017-02-03 13:41:36
     </p>
     <Toggle
-      className="toggle-settings"
       id="checkForUpdates"
       isToggled={false}
       label="Check for updates at startup"
@@ -1000,7 +987,6 @@ exports[`SettingsView should render with last update check date 1`] = `
     >
       <Col>
         <Toggle
-          className="toggle-settings"
           id="checkForShare"
           isToggled={false}
           label="Collect anonymous usage data"

--- a/src/launcher/components/__tests__/__snapshots__/SettingsView-test.jsx.snap
+++ b/src/launcher/components/__tests__/__snapshots__/SettingsView-test.jsx.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SettingsView should render check for updates completed, with everything up to date 1`] = `
-<Fragment>
+<div
+  className="settings-pane-container"
+>
   <Card
     body={true}
   >
@@ -34,18 +36,13 @@ exports[`SettingsView should render check for updates completed, with everything
        
       2017-02-03 13:41:36
     </p>
-    <FormCheck
-      checked={false}
-      custom={true}
-      disabled={false}
+    <Toggle
+      className="toggle-settings"
       id="checkForUpdates"
-      inline={false}
-      isInvalid={false}
-      isValid={false}
+      isToggled={false}
       label="Check for updates at startup"
-      onChange={[Function]}
-      title=""
-      type="checkbox"
+      onToggle={[Function]}
+      variant="primary"
     />
   </Card>
   <Card
@@ -94,18 +91,13 @@ exports[`SettingsView should render check for updates completed, with everything
       noGutters={false}
     >
       <Col>
-        <FormCheck
-          checked={false}
-          custom={true}
-          disabled={false}
+        <Toggle
+          className="toggle-settings"
           id="checkForShare"
-          inline={false}
-          isInvalid={false}
-          isValid={false}
+          isToggled={false}
           label="Collect anonymous usage data"
-          onChange={[Function]}
-          title=""
-          type="checkbox"
+          onToggle={[Function]}
+          variant="primary"
         />
       </Col>
       <Col
@@ -159,11 +151,13 @@ exports[`SettingsView should render check for updates completed, with everything
     title="Add source"
   />
   <div />
-</Fragment>
+</div>
 `;
 
 exports[`SettingsView should render check for updates completed, with updates available 1`] = `
-<Fragment>
+<div
+  className="settings-pane-container"
+>
   <Card
     body={true}
   >
@@ -196,18 +190,13 @@ exports[`SettingsView should render check for updates completed, with updates av
        
       2017-02-03 13:41:36
     </p>
-    <FormCheck
-      checked={false}
-      custom={true}
-      disabled={false}
+    <Toggle
+      className="toggle-settings"
       id="checkForUpdates"
-      inline={false}
-      isInvalid={false}
-      isValid={false}
+      isToggled={false}
       label="Check for updates at startup"
-      onChange={[Function]}
-      title=""
-      type="checkbox"
+      onToggle={[Function]}
+      variant="primary"
     />
   </Card>
   <Card
@@ -256,18 +245,13 @@ exports[`SettingsView should render check for updates completed, with updates av
       noGutters={false}
     >
       <Col>
-        <FormCheck
-          checked={false}
-          custom={true}
-          disabled={false}
+        <Toggle
+          className="toggle-settings"
           id="checkForShare"
-          inline={false}
-          isInvalid={false}
-          isValid={false}
+          isToggled={false}
           label="Collect anonymous usage data"
-          onChange={[Function]}
-          title=""
-          type="checkbox"
+          onToggle={[Function]}
+          variant="primary"
         />
       </Col>
       <Col
@@ -321,11 +305,13 @@ exports[`SettingsView should render check for updates completed, with updates av
     title="Add source"
   />
   <div />
-</Fragment>
+</div>
 `;
 
 exports[`SettingsView should render empty div while loading 1`] = `
-<Fragment>
+<div
+  className="settings-pane-container"
+>
   <Card
     body={true}
   >
@@ -354,18 +340,13 @@ exports[`SettingsView should render empty div while loading 1`] = `
     <p
       className="small text-muted"
     />
-    <FormCheck
-      checked={true}
-      custom={true}
-      disabled={false}
+    <Toggle
+      className="toggle-settings"
       id="checkForUpdates"
-      inline={false}
-      isInvalid={false}
-      isValid={false}
+      isToggled={true}
       label="Check for updates at startup"
-      onChange={[Function]}
-      title=""
-      type="checkbox"
+      onToggle={[Function]}
+      variant="primary"
     />
   </Card>
   <Card
@@ -414,18 +395,13 @@ exports[`SettingsView should render empty div while loading 1`] = `
       noGutters={false}
     >
       <Col>
-        <FormCheck
-          checked={false}
-          custom={true}
-          disabled={false}
+        <Toggle
+          className="toggle-settings"
           id="checkForShare"
-          inline={false}
-          isInvalid={false}
-          isValid={false}
+          isToggled={false}
           label="Collect anonymous usage data"
-          onChange={[Function]}
-          title=""
-          type="checkbox"
+          onToggle={[Function]}
+          variant="primary"
         />
       </Col>
       <Col
@@ -479,11 +455,13 @@ exports[`SettingsView should render empty div while loading 1`] = `
     title="Add source"
   />
   <div />
-</Fragment>
+</div>
 `;
 
 exports[`SettingsView should render when checking for updates 1`] = `
-<Fragment>
+<div
+  className="settings-pane-container"
+>
   <Card
     body={true}
   >
@@ -512,18 +490,13 @@ exports[`SettingsView should render when checking for updates 1`] = `
     <p
       className="small text-muted"
     />
-    <FormCheck
-      checked={false}
-      custom={true}
-      disabled={false}
+    <Toggle
+      className="toggle-settings"
       id="checkForUpdates"
-      inline={false}
-      isInvalid={false}
-      isValid={false}
+      isToggled={false}
       label="Check for updates at startup"
-      onChange={[Function]}
-      title=""
-      type="checkbox"
+      onToggle={[Function]}
+      variant="primary"
     />
   </Card>
   <Card
@@ -572,18 +545,13 @@ exports[`SettingsView should render when checking for updates 1`] = `
       noGutters={false}
     >
       <Col>
-        <FormCheck
-          checked={false}
-          custom={true}
-          disabled={false}
+        <Toggle
+          className="toggle-settings"
           id="checkForShare"
-          inline={false}
-          isInvalid={false}
-          isValid={false}
+          isToggled={false}
           label="Collect anonymous usage data"
-          onChange={[Function]}
-          title=""
-          type="checkbox"
+          onToggle={[Function]}
+          variant="primary"
         />
       </Col>
       <Col
@@ -637,11 +605,13 @@ exports[`SettingsView should render when checking for updates 1`] = `
     title="Add source"
   />
   <div />
-</Fragment>
+</div>
 `;
 
 exports[`SettingsView should render with check for updates disabled 1`] = `
-<Fragment>
+<div
+  className="settings-pane-container"
+>
   <Card
     body={true}
   >
@@ -670,18 +640,13 @@ exports[`SettingsView should render with check for updates disabled 1`] = `
     <p
       className="small text-muted"
     />
-    <FormCheck
-      checked={false}
-      custom={true}
-      disabled={false}
+    <Toggle
+      className="toggle-settings"
       id="checkForUpdates"
-      inline={false}
-      isInvalid={false}
-      isValid={false}
+      isToggled={false}
       label="Check for updates at startup"
-      onChange={[Function]}
-      title=""
-      type="checkbox"
+      onToggle={[Function]}
+      variant="primary"
     />
   </Card>
   <Card
@@ -730,18 +695,13 @@ exports[`SettingsView should render with check for updates disabled 1`] = `
       noGutters={false}
     >
       <Col>
-        <FormCheck
-          checked={false}
-          custom={true}
-          disabled={false}
+        <Toggle
+          className="toggle-settings"
           id="checkForShare"
-          inline={false}
-          isInvalid={false}
-          isValid={false}
+          isToggled={false}
           label="Collect anonymous usage data"
-          onChange={[Function]}
-          title=""
-          type="checkbox"
+          onToggle={[Function]}
+          variant="primary"
         />
       </Col>
       <Col
@@ -795,11 +755,13 @@ exports[`SettingsView should render with check for updates disabled 1`] = `
     title="Add source"
   />
   <div />
-</Fragment>
+</div>
 `;
 
 exports[`SettingsView should render with check for updates enabled 1`] = `
-<Fragment>
+<div
+  className="settings-pane-container"
+>
   <Card
     body={true}
   >
@@ -828,18 +790,13 @@ exports[`SettingsView should render with check for updates enabled 1`] = `
     <p
       className="small text-muted"
     />
-    <FormCheck
-      checked={true}
-      custom={true}
-      disabled={false}
+    <Toggle
+      className="toggle-settings"
       id="checkForUpdates"
-      inline={false}
-      isInvalid={false}
-      isValid={false}
+      isToggled={true}
       label="Check for updates at startup"
-      onChange={[Function]}
-      title=""
-      type="checkbox"
+      onToggle={[Function]}
+      variant="primary"
     />
   </Card>
   <Card
@@ -888,18 +845,13 @@ exports[`SettingsView should render with check for updates enabled 1`] = `
       noGutters={false}
     >
       <Col>
-        <FormCheck
-          checked={false}
-          custom={true}
-          disabled={false}
+        <Toggle
+          className="toggle-settings"
           id="checkForShare"
-          inline={false}
-          isInvalid={false}
-          isValid={false}
+          isToggled={false}
           label="Collect anonymous usage data"
-          onChange={[Function]}
-          title=""
-          type="checkbox"
+          onToggle={[Function]}
+          variant="primary"
         />
       </Col>
       <Col
@@ -953,11 +905,13 @@ exports[`SettingsView should render with check for updates enabled 1`] = `
     title="Add source"
   />
   <div />
-</Fragment>
+</div>
 `;
 
 exports[`SettingsView should render with last update check date 1`] = `
-<Fragment>
+<div
+  className="settings-pane-container"
+>
   <Card
     body={true}
   >
@@ -990,18 +944,13 @@ exports[`SettingsView should render with last update check date 1`] = `
        
       2017-02-03 13:41:36
     </p>
-    <FormCheck
-      checked={false}
-      custom={true}
-      disabled={false}
+    <Toggle
+      className="toggle-settings"
       id="checkForUpdates"
-      inline={false}
-      isInvalid={false}
-      isValid={false}
+      isToggled={false}
       label="Check for updates at startup"
-      onChange={[Function]}
-      title=""
-      type="checkbox"
+      onToggle={[Function]}
+      variant="primary"
     />
   </Card>
   <Card
@@ -1050,18 +999,13 @@ exports[`SettingsView should render with last update check date 1`] = `
       noGutters={false}
     >
       <Col>
-        <FormCheck
-          checked={false}
-          custom={true}
-          disabled={false}
+        <Toggle
+          className="toggle-settings"
           id="checkForShare"
-          inline={false}
-          isInvalid={false}
-          isValid={false}
+          isToggled={false}
           label="Collect anonymous usage data"
-          onChange={[Function]}
-          title=""
-          type="checkbox"
+          onToggle={[Function]}
+          variant="primary"
         />
       </Col>
       <Col
@@ -1115,5 +1059,5 @@ exports[`SettingsView should render with last update check date 1`] = `
     title="Add source"
   />
   <div />
-</Fragment>
+</div>
 `;


### PR DESCRIPTION
# Add about pane to launcher

Trello task: https://trello.com/c/jqpJN6MA/226-add-license-to-launcher

## Add `about` pane to launcher

![image](https://user-images.githubusercontent.com/34618612/131670452-7048b9b0-3750-437f-b966-28be7f7d2262.png)

## Content in `about` pane

![image](https://user-images.githubusercontent.com/34618612/131671127-179496ef-176d-4078-b2cf-faaa3fddef50.png)


## Refactoring

### Changed to toggle in settings pane

![image](https://user-images.githubusercontent.com/34618612/131673150-d00da49b-7f2b-4488-8967-45eeddbe7a7e.png)

changed from 

![image](https://user-images.githubusercontent.com/34618612/131671252-bbf5f6cb-71e1-4553-8d8c-e38505fa6915.png)

## Updated snapshots to make tests pass