### PR TITLE
Fix: Use correct node version in automated build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,7 +11,7 @@ jobs:
   - name: WIN_TZ
     value: 'W. Europe Standard Time'
   - name: NODE_VERSION
-    value: 12.13.0
+    value: 14.18.0
   strategy:
     matrix:
       linux:


### PR DESCRIPTION
Since shared 5.0.0 we need at least Node.js 14. Without this, the builds currently fail.