### PR TITLE
Replace `loadURL` with `loadFile` when loading Launcher HTML file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nrfconnect",
-    "version": "3.8.0-pre6",
+    "version": "3.8.0-pre7",
     "description": "nRF Connect for Desktop",
     "repository": {
         "type": "git",

--- a/src/main/browser.js
+++ b/src/main/browser.js
@@ -50,7 +50,11 @@ function createWindow(options) {
         splashScreen = createSplashScreen();
     }
 
-    browserWindow.loadURL(options.url);
+    if (options.filePath) {
+        browserWindow.loadFile(options.filePath);
+    } else {
+        browserWindow.loadURL(options.url);
+    }
 
     // Never navigate away from the given url, e.g. when the
     // user drags and drops a file into the browser window.

--- a/src/main/windows.js
+++ b/src/main/windows.js
@@ -30,7 +30,10 @@ function openLauncherWindow() {
     } else {
         launcherWindow = browser.createWindow({
             title: `nRF Connect for Desktop v${config.getVersion()}`,
-            url: `file://${config.getElectronResourcesDir()}/launcher.html`,
+            filePath: path.join(
+                config.getElectronResourcesDir(),
+                'launcher.html'
+            ),
             icon: getDefaultIconPath(),
             width: 760,
             height: 500,


### PR DESCRIPTION
This PR hopefully fixes [this issue](https://trello.com/c/GTmCpCug/275-launcher-freezes-on-startup-until-window-is-moved).

A bug in newer versions of Electron seems to cause the launcher to hang indefinitely on start-up. This issue refers to something similar: [https://github.com/electron/electron/issues/24329](https://github.com/electron/electron/issues/24329)
In this issue the reporter mentions that replacing `loadURL` with `loadFile` avoids the problem. So we'll try this fix in lack of something better.

The reason I write hopefully fix is that since this issue didn't occur on every app start, we cannot be 100% confident that this fixes the problem. I have started the apps many many times to test and never encountered the issue with this fix implemented, so it seems to be good.

Another potential issue is that we still use `loadURL` when loading the app html files. This could potentially cause the same issue in the apps, but I've never seen this problem actually occur, so I will leave this as is for now, as it would requires some more effort which might be completely useless.