### PR TITLE
Fix initial focus on macOS

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,9 @@
 # Unreleased
 ### Fixed
-- Keyboard shortcuts to focus search field persists after selecting filter.
+- Keyboard shortcuts to focus search field were not working after clicking on
+  filter.
+- On macOS: When switching to another app while the splashscreen was displayed,
+  "APPS" was focussed.
 
 ## 3.9.0 - 2021-11-08
 ### Added
@@ -13,7 +16,7 @@
 ### Fixed
 - While offline, uninstalling apps would make it look like they are still
   installed until the next start of the launcher.
-- Make enumeration more robust in `nrf-device-lib-js`, which should reduce 
+- Make enumeration more robust in `nrf-device-lib-js`, which should reduce
   the frequency in which `EnumerateWorker json error` errors happen.
 - Increase timeout for the rare occasion when enumeration takes a long time.
 

--- a/src/launcher/components/Root.jsx
+++ b/src/launcher/components/Root.jsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-import React from 'react';
+import React, { useEffect } from 'react';
 import Nav from 'react-bootstrap/Nav';
 import Tab from 'react-bootstrap/Tab';
 import { ErrorDialog, Logo } from 'pc-nrfconnect-shared';
@@ -20,42 +20,69 @@ import UsageDataDialogContainer from '../containers/UsageDataDialogContainer';
 import AboutView from './AboutView';
 import ErrorBoundaryLauncher from './ErrorBoundaryLauncher';
 
-export default () => (
-    <ErrorBoundaryLauncher>
-        <Tab.Container id="launcher" defaultActiveKey="apps">
-            <Nav>
-                {/* eslint-disable-next-line jsx-a11y/no-access-key */}
-                <Nav.Link accessKey="1" eventKey="apps">
-                    apps
-                </Nav.Link>
-                {/* eslint-disable-next-line jsx-a11y/no-access-key */}
-                <Nav.Link accessKey="2" eventKey="settings">
-                    settings
-                </Nav.Link>
-                {/* eslint-disable-next-line jsx-a11y/no-access-key */}
-                <Nav.Link accessKey="3" eventKey="about">
-                    about
-                </Nav.Link>
-                <Logo />
-            </Nav>
-            <Tab.Content>
-                <Tab.Pane eventKey="apps">
-                    <AppManagementContainer />
-                </Tab.Pane>
-                <Tab.Pane eventKey="settings" className="mt_32px">
-                    <SettingsContainer />
-                </Tab.Pane>
-                <Tab.Pane eventKey="about" className="mt_32px">
-                    <AboutView />
-                </Tab.Pane>
-            </Tab.Content>
-        </Tab.Container>
-        <ErrorDialog />
-        <UpdateAvailableContainer />
-        <UpdateProgressContainer />
-        <UsageDataDialogContainer />
-        <ConfirmLaunchContainer />
-        <ProxyLoginContainer />
-        <ProxyErrorContainer />
-    </ErrorBoundaryLauncher>
-);
+const blurActiveElementOnLaunch = () => {
+    /* react-bootstrap 1.0.1 on macOS focusses the first nav item after a few
+       milliseconds. Seems to be a bug. To conterfeit this, we detect whether
+       something is focused within the first 50 milliseconds and if so we
+       deselect it again. This can probably be removed if we upgrade to a
+       later react-bootstrap or if we stop using react-bootstrap. */
+    let timePassed = 0;
+    const intervalLength = 5;
+
+    const interval = setInterval(() => {
+        const somethingIsFocused = document.activeElement !== document.body;
+        if (somethingIsFocused) {
+            document.activeElement.blur();
+        }
+
+        if (timePassed >= 50 || somethingIsFocused) {
+            clearInterval(interval);
+        }
+
+        timePassed += intervalLength;
+    }, intervalLength);
+};
+
+export default () => {
+    useEffect(blurActiveElementOnLaunch, []);
+
+    return (
+        <ErrorBoundaryLauncher>
+            <Tab.Container id="launcher" defaultActiveKey="apps">
+                <Nav>
+                    {/* eslint-disable-next-line jsx-a11y/no-access-key */}
+                    <Nav.Link accessKey="1" eventKey="apps">
+                        apps
+                    </Nav.Link>
+                    {/* eslint-disable-next-line jsx-a11y/no-access-key */}
+                    <Nav.Link accessKey="2" eventKey="settings">
+                        settings
+                    </Nav.Link>
+                    {/* eslint-disable-next-line jsx-a11y/no-access-key */}
+                    <Nav.Link accessKey="3" eventKey="about">
+                        about
+                    </Nav.Link>
+                    <Logo />
+                </Nav>
+                <Tab.Content>
+                    <Tab.Pane eventKey="apps">
+                        <AppManagementContainer />
+                    </Tab.Pane>
+                    <Tab.Pane eventKey="settings" className="mt_32px">
+                        <SettingsContainer />
+                    </Tab.Pane>
+                    <Tab.Pane eventKey="about" className="mt_32px">
+                        <AboutView />
+                    </Tab.Pane>
+                </Tab.Content>
+            </Tab.Container>
+            <ErrorDialog />
+            <UpdateAvailableContainer />
+            <UpdateProgressContainer />
+            <UsageDataDialogContainer />
+            <ConfirmLaunchContainer />
+            <ProxyLoginContainer />
+            <ProxyErrorContainer />
+        </ErrorBoundaryLauncher>
+    );
+};

--- a/src/launcher/index.js
+++ b/src/launcher/index.js
@@ -73,9 +73,9 @@ net.registerProxyLoginHandler((authInfo, callback) => {
 
 render(rootElement, document.getElementById('webapp'), async () => {
     await store.dispatch(UsageDataActions.checkUsageDataSetting());
+    await store.dispatch(AppsActions.setAppManagementFilter());
     await store.dispatch(AppsActions.loadLocalApps());
     await store.dispatch(AppsActions.loadOfficialApps());
-    await store.dispatch(AppsActions.setAppManagementFilter());
     await store.dispatch(AppsActions.setAppManagementShow());
     await store.dispatch(AppsActions.setAppManagementSource());
     await downloadLatestAppInfo();


### PR DESCRIPTION
Fixes https://trello.com/c/cSRL9Y9V/292-macos-remove-element-focus-on-some-launches

As described in the Trello card, an unwanted focus ring was shown sometimes on macOS.

The fix was not quite as easy as just adding a `document.activeElement.blur()` because the element was not already focussed right after the initial render but a moment later. And it is not always focussed, so after 50 milliseconds we stop waiting for it.
