### PR TITLE
Fix: search field shortcuts persists

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+# Unreleased
+### Fixed
+- Keyboard shortcuts to focus search field persists after selecting filter.
+
 ## 3.9.0 - 2021-11-08
 ### Added
 - Keyboard shortcuts to focus search field: `ctrl + e` or `cmd + e`.

--- a/src/launcher/components/AppManagementFilter.jsx
+++ b/src/launcher/components/AppManagementFilter.jsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-import React from 'react';
+import React, { useRef } from 'react';
 import Button from 'react-bootstrap/Button';
 import Col from 'react-bootstrap/Col';
 import Dropdown from 'react-bootstrap/Dropdown';
@@ -136,10 +136,12 @@ const AppManagementFilter = ({
     setAppManagementFilter,
     setAppManagementSource,
 }) => {
+    const searchFieldRef = useRef(null);
+
     useHotKey(
         ['command+e', 'ctrl+e', 'command+f', 'ctrl+f', 'command+l', 'ctrl+l'],
         () => {
-            document.querySelector('.filterbox input').focus();
+            searchFieldRef.current.focus();
         }
     );
     return (
@@ -154,6 +156,7 @@ const AppManagementFilter = ({
                 type="text"
                 placeholder="Search..."
                 value={filter}
+                ref={searchFieldRef}
                 onChange={({ target }) => setAppManagementFilter(target.value)}
             />
             <div className="flex-fill" />


### PR DESCRIPTION
Fixes an issue with shortcuts not persisting after opening the filtering
menu. This commit fixes the issue by using a reference to the target
component to be focused when pressing the key binding.