### PR TITLE
fix: manual spacing for update button

### DIFF
--- a/src/launcher/components/AppManagementFilter.jsx
+++ b/src/launcher/components/AppManagementFilter.jsx
@@ -172,6 +172,7 @@ const AppManagementFilter = ({
                                 onUpgrade(name, latestVersion, source)
                         )
                     }
+                    className="me_32px"
                 >
                     Update all apps
                 </Button>


### PR DESCRIPTION
An earlier change removed the outer padding on the right side of the
launcher window, surrounding the content. The "Update all apps" button
was not given appropriate spacing form the edge, which this commit provides.