### PR TITLE
Fix: Crash when opening device details in device lister

### DIFF
--- a/Changelog-dev.md
+++ b/Changelog-dev.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## 3.9.2 - Unreleased
 ### Changed
 - Updated nrf-device-lib-js to 0.4.1.
-- Updated pc-nrfconnect-shared to 5.12.1.
+- Updated pc-nrfconnect-shared to 5.12.2.
 
 ## 3.9.1 - 2021-11-25
 ### Changed

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 ### Fixed
 - Switching focus after selecting the `About` pane caused incorrect or missing
   defails in `Application` card.
+- Some disabled buttons (e.g. in the `About` pane) had no borders and were hard
+  to see.
 
 ## 3.9.1 - 2021-11-25
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -3218,13 +3218,13 @@
             "dev": true
         },
         "@typescript-eslint/eslint-plugin": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.7.0.tgz",
-            "integrity": "sha512-8RTGBpNn5a9M628wBPrCbJ+v3YTEOE2qeZb7TDkGKTDXSj36KGRg92SpFFaR/0S3rSXQxM0Og/kV9EyadsYSBg==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.8.0.tgz",
+            "integrity": "sha512-spu1UW7QuBn0nJ6+psnfCc3iVoQAifjKORgBngKOmC8U/1tbe2YJMzYQqDGYB4JCss7L8+RM2kKLb1B1Aw9BNA==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/experimental-utils": "5.7.0",
-                "@typescript-eslint/scope-manager": "5.7.0",
+                "@typescript-eslint/experimental-utils": "5.8.0",
+                "@typescript-eslint/scope-manager": "5.8.0",
                 "debug": "^4.3.2",
                 "functional-red-black-tree": "^1.0.1",
                 "ignore": "^5.1.8",
@@ -3245,55 +3245,55 @@
             }
         },
         "@typescript-eslint/experimental-utils": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.7.0.tgz",
-            "integrity": "sha512-u57eZ5FbEpzN5kSjmVrSesovWslH2ZyNPnaXQMXWgH57d5+EVHEt76W75vVuI9qKZ5BMDKNfRN+pxcPEjQjb2A==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.8.0.tgz",
+            "integrity": "sha512-KN5FvNH71bhZ8fKtL+lhW7bjm7cxs1nt+hrDZWIqb6ViCffQcWyLunGrgvISgkRojIDcXIsH+xlFfI4RCDA0xA==",
             "dev": true,
             "requires": {
                 "@types/json-schema": "^7.0.9",
-                "@typescript-eslint/scope-manager": "5.7.0",
-                "@typescript-eslint/types": "5.7.0",
-                "@typescript-eslint/typescript-estree": "5.7.0",
+                "@typescript-eslint/scope-manager": "5.8.0",
+                "@typescript-eslint/types": "5.8.0",
+                "@typescript-eslint/typescript-estree": "5.8.0",
                 "eslint-scope": "^5.1.1",
                 "eslint-utils": "^3.0.0"
             }
         },
         "@typescript-eslint/parser": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.7.0.tgz",
-            "integrity": "sha512-m/gWCCcS4jXw6vkrPQ1BjZ1vomP01PArgzvauBqzsoZ3urLbsRChexB8/YV8z9HwE3qlJM35FxfKZ1nfP/4x8g==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.8.0.tgz",
+            "integrity": "sha512-Gleacp/ZhRtJRYs5/T8KQR3pAQjQI89Dn/k+OzyCKOsLiZH2/Vh60cFBTnFsHNI6WAD+lNUo/xGZ4NeA5u0Ipw==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/scope-manager": "5.7.0",
-                "@typescript-eslint/types": "5.7.0",
-                "@typescript-eslint/typescript-estree": "5.7.0",
+                "@typescript-eslint/scope-manager": "5.8.0",
+                "@typescript-eslint/types": "5.8.0",
+                "@typescript-eslint/typescript-estree": "5.8.0",
                 "debug": "^4.3.2"
             }
         },
         "@typescript-eslint/scope-manager": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.7.0.tgz",
-            "integrity": "sha512-7mxR520DGq5F7sSSgM0HSSMJ+TFUymOeFRMfUfGFAVBv8BR+Jv1vHgAouYUvWRZeszVBJlLcc9fDdktxb5kmxA==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.8.0.tgz",
+            "integrity": "sha512-x82CYJsLOjPCDuFFEbS6e7K1QEWj7u5Wk1alw8A+gnJiYwNnDJk0ib6PCegbaPMjrfBvFKa7SxE3EOnnIQz2Gg==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "5.7.0",
-                "@typescript-eslint/visitor-keys": "5.7.0"
+                "@typescript-eslint/types": "5.8.0",
+                "@typescript-eslint/visitor-keys": "5.8.0"
             }
         },
         "@typescript-eslint/types": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.7.0.tgz",
-            "integrity": "sha512-5AeYIF5p2kAneIpnLFve8g50VyAjq7udM7ApZZ9JYjdPjkz0LvODfuSHIDUVnIuUoxafoWzpFyU7Sqbxgi79mA==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.8.0.tgz",
+            "integrity": "sha512-LdCYOqeqZWqCMOmwFnum6YfW9F3nKuxJiR84CdIRN5nfHJ7gyvGpXWqL/AaW0k3Po0+wm93ARAsOdzlZDPCcXg==",
             "dev": true
         },
         "@typescript-eslint/typescript-estree": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.7.0.tgz",
-            "integrity": "sha512-aO1Ql+izMrTnPj5aFFlEJkpD4jRqC4Gwhygu2oHK2wfVQpmOPbyDSveJ+r/NQo+PWV43M6uEAeLVbTi09dFLhg==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.8.0.tgz",
+            "integrity": "sha512-srfeZ3URdEcUsSLbkOFqS7WoxOqn8JNil2NSLO9O+I2/Uyc85+UlfpEvQHIpj5dVts7KKOZnftoJD/Fdv0L7nQ==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "5.7.0",
-                "@typescript-eslint/visitor-keys": "5.7.0",
+                "@typescript-eslint/types": "5.8.0",
+                "@typescript-eslint/visitor-keys": "5.8.0",
                 "debug": "^4.3.2",
                 "globby": "^11.0.4",
                 "is-glob": "^4.0.3",
@@ -3313,12 +3313,12 @@
             }
         },
         "@typescript-eslint/visitor-keys": {
-            "version": "5.7.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.7.0.tgz",
-            "integrity": "sha512-hdohahZ4lTFcglZSJ3DGdzxQHBSxsLVqHzkiOmKi7xVAWC4y2c1bIMKmPJSrA4aOEoRUPOKQ87Y/taC7yVHpFg==",
+            "version": "5.8.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.8.0.tgz",
+            "integrity": "sha512-+HDIGOEMnqbxdAHegxvnOqESUH6RWFRR2b8qxP1W9CZnnYh4Usz6MBL+2KMAgPk/P0o9c1HqnYtwzVH6GTIqug==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "5.7.0",
+                "@typescript-eslint/types": "5.8.0",
                 "eslint-visitor-keys": "^3.0.0"
             }
         },
@@ -5418,9 +5418,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001287",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001287.tgz",
-            "integrity": "sha512-4udbs9bc0hfNrcje++AxBuc6PfLNHwh3PO9kbwnfCQWyqtlzg3py0YgFu8jyRTTo85VAz4U+VLxSlID09vNtWA==",
+            "version": "1.0.30001292",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001292.tgz",
+            "integrity": "sha512-jnT4Tq0Q4ma+6nncYQVe7d73kmDmE9C3OGTx3MvW7lBM/eY1S1DZTMBON7dqV481RhNiS5OxD7k9JQvmDOTirw==",
             "dev": true
         },
         "capture-exit": {
@@ -7569,9 +7569,9 @@
             }
         },
         "electron-to-chromium": {
-            "version": "1.4.23",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.23.tgz",
-            "integrity": "sha512-q3tB59Api3+DMbLnDPkW/UBHBO7KTGcF+rDCeb0GAGyqFj562s6y+c/2tDKTS/y5lbC+JOvT4MSUALJLPqlcSA==",
+            "version": "1.4.26",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.26.tgz",
+            "integrity": "sha512-cA1YwlRzO6TGp7yd3+KAqh9Tt6Z4CuuKqsAJP6uF/H5MQryjAGDhMhnY5cEXo8MaRCczpzSBhMPdqRIodkbZYw==",
             "dev": true
         },
         "electron-updater": {
@@ -10143,9 +10143,9 @@
             "dev": true
         },
         "ignore": {
-            "version": "5.1.9",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.9.tgz",
-            "integrity": "sha512-2zeMQpbKz5dhZ9IwL0gbxSW5w0NK/MSAMtNuhgIHEPmaU3vPdKPL0UdvUCXs5SS4JAwsBxysK5sFMW8ocFiVjQ==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+            "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
             "dev": true
         },
         "ignore-walk": {
@@ -14907,8 +14907,8 @@
             }
         },
         "pc-nrfconnect-shared": {
-            "version": "github:NordicSemiconductor/pc-nrfconnect-shared#bcc00f1a4883e81350466090c7a305cb92825ec9",
-            "from": "github:NordicSemiconductor/pc-nrfconnect-shared#v5.12.1",
+            "version": "github:NordicSemiconductor/pc-nrfconnect-shared#aef529af7c536dd12ade9c046cdd3966fdbce3f9",
+            "from": "github:NordicSemiconductor/pc-nrfconnect-shared#v5.12.2",
             "dev": true,
             "requires": {
                 "@babel/core": "7.10.0",
@@ -15366,9 +15366,9 @@
             }
         },
         "postcss-selector-parser": {
-            "version": "6.0.7",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.7.tgz",
-            "integrity": "sha512-U+b/Deoi4I/UmE6KOVPpnhS7I7AYdKbhGcat+qTQ27gycvaACvNEw11ba6RrkwVmDVRW7sigWgLj4/KbbJjeDA==",
+            "version": "6.0.8",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.8.tgz",
+            "integrity": "sha512-D5PG53d209Z1Uhcc0qAZ5U3t5HagH3cxu+WLZ22jt3gLUpXM4eXXfiO14jiDWST3NNooX/E8wISfOhZ9eIjGTQ==",
             "dev": true,
             "requires": {
                 "cssesc": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
         "electron-is-dev": "1.2.0",
         "electron-notarize": "0.3.0",
         "mini-css-extract-plugin": "0.9.0",
-        "pc-nrfconnect-shared": "github:NordicSemiconductor/pc-nrfconnect-shared#v5.12.1",
+        "pc-nrfconnect-shared": "github:NordicSemiconductor/pc-nrfconnect-shared#v5.12.2",
         "sander": "0.6.0",
         "spectron": "7.0.0",
         "xvfb-maybe": "0.2.1"


### PR DESCRIPTION
Because the bug was not released, we do not need to note it in the changelog.

The upgrade to shared 5.12.2 also fixes two other minor aspects but I think barely anyone will notice the added margin on macOS, so I did not copy that into the changelog.