### PR TITLE
Fix: Small spelling mistake

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -10,7 +10,7 @@
   kernel.
 - macOS: Thingy:91 detection broken when a nRF52 firmware version older than
   1.6.0 is used. In these cases, please upgrade to the latest firmware from the
-  [Thing:91 product page](https://www.nordicsemi.com/Products/Development-hardware/Nordic-Thingy-91/Download).
+  [Thingy:91 product page](https://www.nordicsemi.com/Products/Development-hardware/Nordic-Thingy-91/Download).
 
 ## 3.9.1 - 2021-11-25
 ### Fixed


### PR DESCRIPTION
Also fixed it in [the 3.9.2 release notes](https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/releases/tag/v3.9.2).