### PR TITLE
Update jlink

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### Changed 
+- Bundle newer version of J-Link (758b).
+
 ## 3.9.3 - 2022-01-04
 ### Fixed
 - Selecting device no longer prompts firmware upgrade when the firmware on the 

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -32,8 +32,8 @@
   ; ===============================================================
 
   ; J-Link installer (downloaded by 'npm run get-jlink')
-  !define BundledJLinkVersion "V758e"
-  !define JLinkInstaller "JLink_Windows_${BundledJLinkVersion}.exe"
+  !define BundledJLinkVersion "V758b"
+  !define JLinkInstaller "JLink_Windows_${BundledJLinkVersion}_i386.exe"
   !define JlinkInstallerResPath "${BUILD_RESOURCES_DIR}\${JLinkInstaller}"
 
   File ${JlinkInstallerResPath}

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -32,7 +32,7 @@
   ; ===============================================================
 
   ; J-Link installer (downloaded by 'npm run get-jlink')
-  !define BundledJLinkVersion "V688a"
+  !define BundledJLinkVersion "V758e"
   !define JLinkInstaller "JLink_Windows_${BundledJLinkVersion}.exe"
   !define JlinkInstallerResPath "${BUILD_RESOURCES_DIR}\${JLinkInstaller}"
 

--- a/getJlink.js
+++ b/getJlink.js
@@ -19,9 +19,9 @@ const sander = require('sander');
 const path = require('path');
 const crypto = require('crypto');
 
-const minVersion = 'V758e';
-const filename = `JLink_Windows_${minVersion}.exe`;
-const fileUrl = `https://github.com/NordicSemiconductor/pc-nrfjprog-js/releases/download/nrfjprog/${filename}`;
+const minVersion = 'V758b';
+const filename = `JLink_Windows_${minVersion}_i386.exe`;
+const fileUrl = `https://developer.nordicsemi.com/.pc-tools/jlink/${filename}`;
 
 const outputDirectory = 'build';
 const destinationFile = path.join(outputDirectory, filename);

--- a/getJlink.js
+++ b/getJlink.js
@@ -19,7 +19,7 @@ const sander = require('sander');
 const path = require('path');
 const crypto = require('crypto');
 
-const minVersion = 'V688a';
+const minVersion = 'V758e';
 const filename = `JLink_Windows_${minVersion}.exe`;
 const fileUrl = `https://github.com/NordicSemiconductor/pc-nrfjprog-js/releases/download/nrfjprog/${filename}`;
 


### PR DESCRIPTION
Tested locally, the bundled jlink only prompts to install on installing if its not already installed.