### PR TITLE
Enhance incompatibility messages

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -198,7 +198,7 @@ This version is released only for macOS.
 ### Changed
 - Updated to React Bootstrap 4 #306
 React Bootstrap is a fundamental dependency for nRF Connect for Desktop, used for UI components and layout. The update is a breaking change, requiring all apps to be updated.
-There are no changes to nRF Connect features, except for some minor visual differences.
+There are no changes to nRF Connect for Desktop features, except for some minor visual differences.
 - Updated to pc-nrfjprog-js v1.5.4, including bundled nrfjprog v10.2.1 #319
 ### Fixed
 - Fixed auto update issue #317
@@ -322,7 +322,7 @@ Pre-release with handling of edge cases in J-Link serial number lookup (#145).
 Pre-release with improved support for proxies, ref. #104.
 
 ## 2.0.0
-While nRF Connect v1 was a dedicated Bluetooth low energy tool, v2 is a framework that can launch multiple desktop apps. The Bluetooth low energy tool has been [rewritten as an app](https://github.com/NordicSemiconductor/pc-nrfconnect-ble) for the nRF Connect framework, and can be installed and launched through the nRF Connect UI.
+While nRF Connect for Desktop v1 was a dedicated Bluetooth low energy tool, v2 is a framework that can launch multiple desktop apps. The Bluetooth low energy tool has been [rewritten as an app](https://github.com/NordicSemiconductor/pc-nrfconnect-ble) for the nRF Connect for Desktop framework, and can be installed and launched through the nRF Connect for Desktop UI.
 ### Changed
 - Allows users to easily install, update, and launch apps
 - Allows developers to [create new apps](https://nordicsemiconductor.github.io/pc-nrfconnect-docs/create_new_app)

--- a/doc/proxy-settings.md
+++ b/doc/proxy-settings.md
@@ -1,10 +1,10 @@
-# Proxy settings for nRF Connect
+# Proxy settings for nRF Connect for Desktop
 
-nRF Connect has the same proxy support as [Google Chromium](https://www.chromium.org/developers/design-documents/network-settings), and should in most cases pick up the proxy settings configured in the underlying OS. However, in some cases you may need to add some extra configuration, as described below.
+nRF Connect for Desktop has the same proxy support as [Google Chromium](https://www.chromium.org/developers/design-documents/network-settings), and should in most cases pick up the proxy settings configured in the underlying OS. However, in some cases you may need to add some extra configuration, as described below.
 
 ## Custom proxy settings
 
-Custom proxy settings can be specified by starting nRF Connect with the following command line flags:
+Custom proxy settings can be specified by starting nRF Connect for Desktop with the following command line flags:
 
 ```
 # Disable proxy
@@ -22,8 +22,8 @@ Custom proxy settings can be specified by starting nRF Connect with the followin
 
 ## Authenticated proxies
 
-If a proxy server requires authentication, nRF Connect will show a login dialog for each network request:
+If a proxy server requires authentication, nRF Connect for Desktop will show a login dialog for each network request:
 
 ![screenshot](proxy-login-dialog.png)
 
-By default, nRF Connect checks for updates at startup, which will lead to this dialog popping up. Checking for updates at startup can be turned off in Settings.
+By default, nRF Connect for Desktop checks for updates at startup, which will lead to this dialog popping up. Checking for updates at startup can be turned off in Settings.

--- a/doc/serial-timeout-troubleshoot.md
+++ b/doc/serial-timeout-troubleshoot.md
@@ -1,7 +1,7 @@
 # Troubleshooting "serial timeout" errors
 
-Several nRF Connect Desktop applications use serial ports to communicate with
-development kits and dongles. nRF Connect Desktop also uses serial ports to
+Several nRF Connect for Desktop applications use serial ports to communicate with
+development kits and dongles. nRF Connect for Desktop also uses serial ports to
 perform DFU (Device Firmware Update) when a devkit/dongle is running a
 [DFU bootloader](http://infocenter.nordicsemi.com/topic/com.nordic.infocenter.sdk5.v15.0.0/sdk_app_serial_dfu_bootloader.html?cp=4_0_0_4_3_4).
 
@@ -27,7 +27,7 @@ errors.
 ## DevKit/dongle not running bootloader
 
 When using a nRF52840 devkit/dongle and performing a DFU operation with
-nRF Connect Desktop, a `Timeout while reading from serial transport.` error shows up.
+nRF Connect for Desktop, a `Timeout while reading from serial transport.` error shows up.
 
 When using a nRF52840 devkit/dongle and performing a DFU operation with
 [nrfutil](https://github.com/NordicSemiconductor/pc-nrfutil/), an error like
@@ -35,7 +35,7 @@ When using a nRF52840 devkit/dongle and performing a DFU operation with
 shows up.
 
 When performing a DFU operation, nrfutil *assumes* that the serial port
-specified is a devkit/dongle already in bootloader mode. nRF Connect Desktop (and
+specified is a devkit/dongle already in bootloader mode. nRF Connect for Desktop (and
 the underlying [`nrf-device-setup-js`](https://github.com/NordicSemiconductor/nrf-device-setup-js) library)
 will try to perform a [DFU trigger](http://infocenter.nordicsemi.com/topic/com.nordic.infocenter.sdk5.v15.0.0/lib_dfu_trigger_usb.html)
 first, but the DFU trigger might fail due to other reasons.
@@ -54,7 +54,7 @@ Ensure that the devkit/dongle is in bootloader mode.
 - For nRF52840 development kits:
     - Unplug the devkit's USB connector marked "nRF USB".
     - Connect a USB cable to the USB connector for the [Interface MCU](http://infocenter.nordicsemi.com/topic/com.nordic.infocenter.nrf52/dita/nrf52/development/nrf52840_pdk/if_mcu.html).
-    - Use nRF Connect Desktop Programmer to program it with bootloader firmware known to work.
+    - Use nRF Connect for Desktop Programmer to program it with bootloader firmware known to work.
     - Reconnect the cable to the USB connector marked "nRF USB".
     - Perform the DFU operation again.
 
@@ -63,12 +63,12 @@ Ensure that the devkit/dongle is in bootloader mode.
 Windows 8/10, macOS and all major Linux flavours include kernel drivers for USB CDC ACM.
 Windows 7 (and previous), however, does not.
 
-The normal case is that the Win7 drivers provided with the nRF Connect Desktop
+The normal case is that the Win7 drivers provided with the nRF Connect for Desktop
 installer will work without any further user interaction. However, it is possible
 that the Windows 7 drivers have a conflict with already-installed drivers.
 This leads to problems such as:
 
-- Applications for nRF Connect Desktop fail to detect a serial port in a nRF Device.
+- Applications for nRF Connect for Desktop fail to detect a serial port in a nRF Device.
 - Timeouts when opening/closing a serial port.
 - The serial port closes after *one* call to read/write data from/to the port is made.
 
@@ -78,7 +78,7 @@ operating system.
 
 #### Workaround
 
-[Download the latest installer for the nRF Connect Desktop](https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/releases)
+[Download the latest installer for the nRF Connect for Desktop](https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/releases)
 and run it. The installer includes the needed USB CDC ACM drivers.
 
 If that fails, [remove any nRF USB CDC ACM drivers](https://docs.microsoft.com/en-us/windows-hardware/drivers/install/using-device-manager-to-uninstall-devices-and-driver-packages),

--- a/doc/win32-usb-troubleshoot.md
+++ b/doc/win32-usb-troubleshoot.md
@@ -1,8 +1,8 @@
 # Troubleshooting LIBUSB_* errors on win32 platforms
 
-nRF Connect Desktop uses [libusb](https://libusb.info/) and [node-usb](https://github.com/tessel/node-usb) to know how many USB-capable Nordic SoCs (e.g. nRF52840) are connected to your PC, and also to set them into DFU mode when they need to be re-programmed by an nRF Connect Desktop application.
+nRF Connect for Desktop uses [libusb](https://libusb.info/) and [node-usb](https://github.com/tessel/node-usb) to know how many USB-capable Nordic SoCs (e.g. nRF52840) are connected to your PC, and also to set them into DFU mode when they need to be re-programmed by an nRF Connect for Desktop application.
 
-While this makes it easier to develop nRF Connect Desktop applications, it might also cause some errors to show up in some win32 environments. This document collects the known causes and workarounds for these errors.
+While this makes it easier to develop nRF Connect for Desktop applications, it might also cause some errors to show up in some win32 environments. This document collects the known causes and workarounds for these errors.
 
 # Scenarios where these errors happen
 
@@ -10,16 +10,16 @@ While this makes it easier to develop nRF Connect Desktop applications, it might
 
 A `LIBUSB_ERROR_NOT_FOUND` error shows up when connecting an nRF USB device into a Windows 7 computer for the first time. In particular, this sequence of actions (in this exact order) reproduces this scenario:
 
-- Run the nRF Connect Desktop installer.
+- Run the nRF Connect for Desktop installer.
   - This includes the *rules* for the right drivers, but not the actual link between a USB device and its driver.
-- Launch an nRF Connect Desktop application.
+- Launch an nRF Connect for Desktop application.
 - Plug an nRF52840 device into a USB port.
 - Let Windows 7 attach the right drivers.
   - This uses the *rules* already installed for actually *binding* a driver to the newly-connected nRF USB device.
-  - A yellow bubble appears from the system tray, indicating driver installation, like this: 
+  - A yellow bubble appears from the system tray, indicating driver installation, like this:
   ![screenshot](win32-drivers-installing.png)
 
-- A `LIBUSB_ERROR_NOT_FOUND` is shown on the log of the nRF Connect Desktop application.
+- A `LIBUSB_ERROR_NOT_FOUND` is shown on the log of the nRF Connect for Desktop application.
 - After a time (that varies between a few seconds and a couple of minutes), Windows 7 finishes binding the libusb driver to the nRF USB device.
   - A yellow bubble appears from the system tray, indicating drivers are ready, like this:
   ![screenshot](win32-drivers-ready.png)
@@ -30,10 +30,10 @@ Therefore, this error might happen the first time that an nRF USB device is conn
 
 #### Workaround
 
-- Close all programs and processes that might be using nRF USB devices (including nRF Connect Desktop).
+- Close all programs and processes that might be using nRF USB devices (including nRF Connect for Desktop).
 - Connect the nRF USB device(s).
 - **Wait** until Windows 7 has finished binding the right drivers to the USB device(s).
-- Launch nRF Connect Desktop.
+- Launch nRF Connect for Desktop.
 
 If the nRF USB device enters bootloader mode for the first time, or is loaded with new firmware, you may need to repeat this workaround.
 
@@ -43,7 +43,7 @@ A `LIBUSB_ERROR_NOT_FOUND` error shows up when connecting an nRF USB device **wi
 
 In order to check if this is also your scenario, launch the Windows Device Manager, set the view to "Devices by Connection", and find the part of the USB device tree with the nRF USB Device (usually under ACPI computer → PCI bus → USB root hub).
 
-The nRF USB device shall appear as a "USB Composite Device" and, beneath that, each USB interface appears as a device in the tree. nRF Connect Desktop *expects* a "nRF Connect DFU trigger" interface to be present, like so:
+The nRF USB device shall appear as a "USB Composite Device" and, beneath that, each USB interface appears as a device in the tree. nRF Connect for Desktop *expects* a "nRF Connect DFU trigger" interface to be present, like so:
 
 ![screenshot](win32-usbtree-expected.png)
 
@@ -51,20 +51,19 @@ The "nRF Connect DFU trigger" interface is implemented by the [Nordic USB DFU tr
 
 #### Workaround
 
-Most nRF Connect Desktop applications will automatically load the nRF USB device with firmware known to work.
+Most nRF Connect for Desktop applications will automatically load the nRF USB device with firmware known to work.
 
 - For nRF52840 dongles:
   - Press the reset button. The red LED should be pulsing, indicating the nRF device is in DFU bootloader mode.
-  - Launch an nRF Connect Desktop application (for example, the RSSI viewer).
-  - Make the nRF Connect Desktop application use the nRF USB device in bootloader mode. nRF Connect desktop will perform a DFU operation, programming the nRF device with firmware known to work.
+  - Launch an nRF Connect for Desktop application (for example, the RSSI viewer).
+  - Make the nRF Connect for Desktop application use the nRF USB device in bootloader mode. nRF Connect for Desktop will perform a DFU operation, programming the nRF device with firmware known to work.
 
 - For nRF52840 development kits:
   - Unplug the devkit's USB connector marked "nRF USB", and connect a USB cable to the USB connector for the [Interface MCU](http://infocenter.nordicsemi.com/topic/com.nordic.infocenter.nrf52/dita/nrf52/development/nrf52840_pdk/if_mcu.html)
-  - Use nRF Connect Destkop Programmer to program it with firmware known to work.
+  - Use nRF Connect for Desktop Programmer to program it with firmware known to work.
 
 Please note that it's safe to ignore this error **only** when **all** of the following are true:
 
 - You are developing firmware for nRF devices using the [USBD library](http://infocenter.nordicsemi.com/topic/com.nordic.infocenter.sdk5.v15.0.0/group__app__usbd.html?cp=4_0_0_6_11_58), **and**
 - You are using the Nordic Semiconductor USB Vendor ID (and a USB Product ID reserved for development), **and**
 - You are **not** using the [Nordic USB DFU trigger library](http://infocenter.nordicsemi.com/topic/com.nordic.infocenter.sdk5.v15.0.0/group__nrf__dfu__trigger__usb.html) **on purpose**.
-

--- a/src/launcher/actions/autoUpdateActions.js
+++ b/src/launcher/actions/autoUpdateActions.js
@@ -92,8 +92,8 @@ export function checkForCoreUpdates() {
         const checkForUpdatesPromise = autoUpdater.checkForUpdates();
         if (!checkForUpdatesPromise) {
             log.warn(
-                'Not checking for nRF Connect updates. Auto update is not ' +
-                    'yet supported for this platform.'
+                'Not checking for nRF Connect for Desktop updates. ' +
+                    'Auto update is not yet supported for this platform.'
             );
             return Promise.resolve();
         }

--- a/src/launcher/components/ProxyErrorDialog.jsx
+++ b/src/launcher/components/ProxyErrorDialog.jsx
@@ -18,14 +18,14 @@ const ProxyErrorDialog = ({ isVisible, onOk }) => (
             <p>
                 It appears that you are having problems authenticating with a
                 proxy server. This will prevent you from using certain features
-                of nRF Connect, such as installing apps from the
+                of nRF Connect for Desktop, such as installing apps from the
                 &quot;Add/remove apps&quot; screen.
             </p>
             <p>
                 If you are unable to resolve the issue, then go to Settings and
                 disable &quot;Check for updates at startup&quot;. Then restart
-                nRF Connect and install apps manually by following the
-                instructions at
+                nRF Connect for Desktop and install apps manually by following
+                the instructions at
                 https://github.com/NordicSemiconductor/pc-nrfconnect-launcher.
             </p>
         </Modal.Body>

--- a/src/launcher/components/UpdateAvailableDialog.jsx
+++ b/src/launcher/components/UpdateAvailableDialog.jsx
@@ -9,7 +9,7 @@ import { ConfirmationDialog } from 'pc-nrfconnect-shared';
 import { bool, func, string } from 'prop-types';
 
 /**
- * Dialog that is shown if an nRF Connect core update is available. The user
+ * Dialog that is shown if an nRF Connect for Desktop launcher update is available. The user
  * can either upgrade or cancel.
  *
  * @param {boolean} isVisible Show the dialog or not.
@@ -30,7 +30,7 @@ const UpdateAvailableDialog = ({
         isVisible={isVisible}
         title="Update available"
         text={
-            `A new version (${version}) of nRF Connect is available. ` +
+            `A new version (${version}) of nRF Connect for Desktop is available. ` +
             'Would you like to upgrade now?'
         }
         okButtonText="Yes"
@@ -39,8 +39,8 @@ const UpdateAvailableDialog = ({
         onCancel={onCancel}
     >
         <p>
-            A new version ({version}) of nRF Connect is available. Would you
-            like to upgrade now?
+            A new version ({version}) of nRF Connect for Desktop is available.
+            Would you like to upgrade now?
         </p>
         <button
             className="btn btn-link core-btn-link"

--- a/src/launcher/components/UpdateProgressDialog.jsx
+++ b/src/launcher/components/UpdateProgressDialog.jsx
@@ -25,7 +25,7 @@ const UpdateProgressDialog = ({
             <Modal.Title>Downloading update</Modal.Title>
         </Modal.Header>
         <Modal.Body>
-            <p>Downloading nRF Connect {version}...</p>
+            <p>Downloading nRF Connect for Desktop {version}...</p>
             {isProgressSupported && (
                 <ProgressBar
                     label={`${percentDownloaded}%`}

--- a/src/launcher/components/UsageDataDialog.jsx
+++ b/src/launcher/components/UsageDataDialog.jsx
@@ -32,7 +32,7 @@ const UsageDataPolicy = (
         <h5>How do we use this information?</h5>
         <p>
             The information is used to analyze user interaction with nRF Connect
-            for desktop and determine areas of improvement.
+            for Desktop and determine areas of improvement.
         </p>
 
         <h5>How is this information processed and shared?</h5>

--- a/src/launcher/components/__tests__/__snapshots__/AppManagementView-test.jsx.snap
+++ b/src/launcher/components/__tests__/__snapshots__/AppManagementView-test.jsx.snap
@@ -171,7 +171,7 @@ Array [
                 />
                 <span
                   className="mdi mdi-alert"
-                  title="The app does not specify which nRF Connect version(s) it supports"
+                  title="The app does not specify which nRF Connect for Desktop versions it supports"
                 />
               </div>
             </div>
@@ -295,7 +295,7 @@ Array [
                 />
                 <span
                   className="mdi mdi-alert"
-                  title="The app does not specify which nRF Connect version(s) it supports"
+                  title="The app does not specify which nRF Connect for Desktop versions it supports"
                 />
               </div>
             </div>
@@ -828,7 +828,7 @@ Array [
                 />
                 <span
                   className="mdi mdi-alert"
-                  title="The app does not specify which nRF Connect version(s) it supports"
+                  title="The app does not specify which nRF Connect for Desktop versions it supports"
                 />
               </div>
             </div>
@@ -911,7 +911,7 @@ Array [
                 />
                 <span
                   className="mdi mdi-alert"
-                  title="The app does not specify which nRF Connect version(s) it supports"
+                  title="The app does not specify which nRF Connect for Desktop versions it supports"
                 />
               </div>
             </div>

--- a/src/launcher/components/__tests__/__snapshots__/UpdateProgressDialog-test.jsx.snap
+++ b/src/launcher/components/__tests__/__snapshots__/UpdateProgressDialog-test.jsx.snap
@@ -27,7 +27,7 @@ exports[`UpdateProgressDialog should render cancelling 1`] = `
   </ModalHeader>
   <ModalBody>
     <p>
-      Downloading nRF Connect 
+      Downloading nRF Connect for Desktop 
       1.2.3
       ...
     </p>
@@ -85,7 +85,7 @@ exports[`UpdateProgressDialog should render invisible 1`] = `
   </ModalHeader>
   <ModalBody>
     <p>
-      Downloading nRF Connect 
+      Downloading nRF Connect for Desktop 
       ...
     </p>
     <p>
@@ -125,7 +125,7 @@ exports[`UpdateProgressDialog should render with cancel disabled when 100 percen
   </ModalHeader>
   <ModalBody>
     <p>
-      Downloading nRF Connect 
+      Downloading nRF Connect for Desktop 
       1.2.3
       ...
     </p>
@@ -183,7 +183,7 @@ exports[`UpdateProgressDialog should render with version, percent downloaded, an
   </ModalHeader>
   <ModalBody>
     <p>
-      Downloading nRF Connect 
+      Downloading nRF Connect for Desktop 
       1.2.3
       ...
     </p>
@@ -241,7 +241,7 @@ exports[`UpdateProgressDialog should render with version, without progress, and 
   </ModalHeader>
   <ModalBody>
     <p>
-      Downloading nRF Connect 
+      Downloading nRF Connect for Desktop 
       1.2.3
       ...
     </p>

--- a/src/launcher/util/checkAppCompatibility.ts
+++ b/src/launcher/util/checkAppCompatibility.ts
@@ -46,12 +46,11 @@ export const checkEngineVersionIsSet: AppCompatibilityChecker = app =>
     app.engineVersion
         ? undecided
         : incompatible(
-              'The app does not specify which nRF Connect version(s) ' +
-                  'it supports',
-              'The app does not specify ' +
-                  'which nRF Connect version(s) it supports. Ask the app ' +
-                  'author to add an engines.nrfconnect definition to package.json, ' +
-                  'ref. the documentation.'
+              'The app does not specify which nRF Connect for Desktop ' +
+                  'versions it supports',
+              'The app does not specify which nRF Connect for Desktop ' +
+                  'versions it supports. Ask the app author to add an ' +
+                  'engines.nrfconnect definition to package.json.'
           );
 
 export const checkEngineIsSupported: AppCompatibilityChecker = (
@@ -66,11 +65,12 @@ export const checkEngineIsSupported: AppCompatibilityChecker = (
     return isSupportedEngine
         ? undecided
         : incompatible(
-              `The app only supports nRF Connect ${app.engineVersion}, ` +
-                  'which does not match your currently installed version',
-              'The app only supports ' +
-                  `nRF Connect ${app.engineVersion} while your installed version ` +
-                  `is ${providedVersionOfEngine}. It might not work as expected.`
+              'The app only supports nRF Connect for Desktop ' +
+                  `${app.engineVersion}, which does not match your ` +
+                  'currently installed version',
+              'The app only supports nRF Connect for Desktop ' +
+                  `${app.engineVersion} while your installed version is ` +
+                  `${providedVersionOfEngine}. It might not work as expected.`
           );
 };
 
@@ -90,31 +90,36 @@ export const checkProvidedVersionOfSharedIsValid: AppCompatibilityChecker = (
     isValidVersionNumber(providedVersionOfShared)
         ? undecided
         : incompatible(
-              `nRF Connect uses "${providedVersionOfShared}" of shared ` +
-                  'which cannot be checked against the version required by ' +
-                  'this app.',
-              `nRF Connect uses "${providedVersionOfShared}" of shared ` +
-                  'which cannot be checked against the version required by ' +
-                  'this app. Inform the developer, that the launcher needs ' +
-                  'to reference a correct version of shared. The app might ' +
-                  'not work as expected.'
+              `nRF Connect for Desktop uses "${providedVersionOfShared}" of ` +
+                  'the internal pc-nrfconnect-shared library which cannot ' +
+                  'be checked against the version required by this app.',
+              `nRF Connect for Desktop uses "${providedVersionOfShared}" of ` +
+                  'the internal pc-nrfconnect-shared library which cannot ' +
+                  'be checked against the version required by this app. ' +
+                  'Inform the developer, that the launcher needs to ' +
+                  'reference a correct version of pc-nrfconnect-shared. ' +
+                  'The app might not work as expected.'
           );
 
 export const checkRequestedVersionOfSharedIsValid: AppCompatibilityChecker =
-    app =>
-        requestedVersionOfShared(app) == null ||
-        isValidVersionNumber(requestedVersionOfShared(app))
+    app => {
+        return requestedVersionOfShared(app) == null ||
+            isValidVersionNumber(requestedVersionOfShared(app))
             ? undecided
             : incompatible(
                   `The app requires "${requestedVersionOfShared(app)}" of ` +
-                      'shared which cannot be checked against the version ' +
-                      'provided by nRF Connect.',
+                      'the internal pc-nrfconnect-shared library which ' +
+                      'cannot be checked against the version provided by ' +
+                      'nRF Connect for Desktop.',
                   `The app requires "${requestedVersionOfShared(app)}" of ` +
-                      'shared which cannot be checked against the version ' +
-                      'provided by nRF Connect. Inform the developer, that the ' +
-                      'app needs to reference a correct version of shared. The ' +
-                      'app might not work as expected.'
+                      'the internal pc-nrfconnect-shared library which ' +
+                      'cannot be checked against the version provided by ' +
+                      'nRF Connect for Desktop. Inform the developer, that ' +
+                      'the app needs to reference a correct version of ' +
+                      'pc-nrfconnect-shared. The app might not work as ' +
+                      'expected.'
               );
+    };
 
 export const checkRequestedSharedIsProvided: AppCompatibilityChecker = (
     app,
@@ -128,15 +133,17 @@ export const checkRequestedSharedIsProvided: AppCompatibilityChecker = (
     return providesRequestedVersionOfShared
         ? undecided
         : incompatible(
-              `The app requires ${requestedVersionOfShared(app)} of ` +
-                  'pc-nrfconnect-shared, but nRF Connect only provided ' +
-                  `${providedVersionOfShared}. Inform the app developer, that ` +
-                  'the app needs a more recent version of nRF Connect.',
-              `The app requires ${requestedVersionOfShared(app)} of ` +
-                  'pc-nrfconnect-shared, but nRF Connect only provided ' +
-                  `${providedVersionOfShared}. Inform the app developer, that ` +
-                  'the app needs a more recent version of nRF Connect. The app ' +
-                  'might not work as expected.'
+              `The app requires ${requestedVersionOfShared(app)} of the ` +
+                  'internal pc-nrfconnect-shared library, but your version ' +
+                  'of nRF Connect for Desktop only provided ' +
+                  `${providedVersionOfShared}`,
+              `The app requires ${requestedVersionOfShared(app)} of the ` +
+                  'internal pc-nrfconnect-shared library, but your version ' +
+                  'of nRF Connect for Desktop only provided ' +
+                  `${providedVersionOfShared}. Upgrading nRF Connect for ` +
+                  'Desktop might help. Inform the app developer, that the ' +
+                  'app needs a more recent version of nRF Connect for ' +
+                  'Desktop. The app might not work as expected.'
           );
 };
 

--- a/src/legacy/app/actions/mainMenuActions.js
+++ b/src/legacy/app/actions/mainMenuActions.js
@@ -8,7 +8,7 @@ import { ipcRenderer } from 'electron';
 import { systemReport } from 'pc-nrfconnect-shared';
 
 /**
- * Indicates that opening the nRF Connect app launcher has been requested.
+ * Indicates that opening the nRF Connect for Desktop app launcher has been requested.
  *
  * @deprecated
  */

--- a/src/legacy/app/components/__tests__/DeviceSelector-test.jsx
+++ b/src/legacy/app/components/__tests__/DeviceSelector-test.jsx
@@ -46,9 +46,11 @@ describe('DeviceSelector', () => {
                             serialNumber: '123456789',
                             serialPorts: [
                                 {
+                                    comName: '/dev/ttyACM0',
                                     path: '/dev/ttyACM0',
                                 },
                                 {
+                                    comName: '/dev/ttyACM1',
                                     path: '/dev/ttyACM1',
                                 },
                             ],

--- a/src/legacy/components/Logo.jsx
+++ b/src/legacy/components/Logo.jsx
@@ -31,7 +31,7 @@ Logo.propTypes = {
 
 Logo.defaultProps = {
     src: logo,
-    alt: 'nRF Connect',
+    alt: 'nRF Connect for Desktop',
     cssClass: 'core-logo',
     containerCssClass: 'core-logo-container',
     onClick: () => openUrl('http://www.nordicsemi.com/nRFConnect'),

--- a/src/main/config.js
+++ b/src/main/config.js
@@ -51,7 +51,7 @@ let isRunningLauncherFromSource;
  *                       Default: "<userDataDir>/settings.json"
  * --skip-update-apps    Do not download info/updates about apps.
  *                       Default: false
- * --skip-update-core    Skip checking for updates for nRF Connect.
+ * --skip-update-core    Skip checking for updates for nRF Connect for Desktop.
  *                       Default: false
  * --skip-splash-screen  Skip the splash screen at startup.
  *                       Default: false

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -81,8 +81,8 @@ ipcMain.on('show-about-dialog', event => {
             `${app.description}\n\n` +
             `Version: ${app.currentVersion}\n` +
             `Official: ${app.isOfficial}\n` +
-            `Supported engines: nRF Connect ${app.engineVersion}\n` +
-            `Current engine: nRF Connect ${config.getVersion()}\n` +
+            `Supported engines: nRF Connect for Desktop ${app.engineVersion}\n` +
+            `Current engine: nRF Connect for Desktop ${config.getVersion()}\n` +
             `App directory: ${app.path}`;
         dialog.showMessageBox(
             appWindow.browserWindow,

--- a/test-e2e/launcher/engineVersionCheck.test.js
+++ b/test-e2e/launcher/engineVersionCheck.test.js
@@ -19,12 +19,12 @@ describe('checks the version of the engine against what the app declares', () =>
 
             await expect(
                 app.client.isVisible(
-                    'span[title="The app does not specify which nRF Connect version(s) it supports'
+                    'span[title="The app does not specify which nRF Connect for Desktop version(s) it supports'
                 )
             ).resolves.toBe(false);
             await expect(
                 app.client.isVisible(
-                    'span[title*="The app only supports nRF Connect'
+                    'span[title*="The app only supports nRF Connect for Desktop'
                 )
             ).resolves.toBe(false);
         });
@@ -38,7 +38,7 @@ describe('checks the version of the engine against what the app declares', () =>
 
         it('shows a warning in the app list', () =>
             app.client.waitForVisible(
-                'span[title*="The app only supports nRF Connect 1.x'
+                'span[title*="The app only supports nRF Connect for Desktop 1.x'
             ));
 
         it('shows a warning dialog when launching the app', async () => {
@@ -56,7 +56,7 @@ describe('checks the version of the engine against what the app declares', () =>
 
         it('shows a warning in the app list', () =>
             app.client.waitForVisible(
-                'span[title="The app does not specify which nRF Connect version(s) it supports'
+                'span[title="The app does not specify which nRF Connect for Desktop version(s) it supports'
             ));
 
         it('shows a warning dialog when launching the app', async () => {


### PR DESCRIPTION
Enhanced the messages shown when an app is not compatible with the launcher. E.g. when the versions of shared did not match, this was before the dialog:

![old dialog](https://user-images.githubusercontent.com/260705/150967950-6eaa3aa7-96fd-4825-aef5-8524ed2ef0a7.png)

The new dialog looks like this:

![new dialog](https://user-images.githubusercontent.com/260705/150967986-a4c6c4e3-51a5-4e88-854b-7537372b6ead.png)

Notable changes:
- Call it "nRF Connect for Desktop" not just "nRF Connect".
- Users usually have no clue, what is meant by "shared", so be a bit more verbatim and call it "the internal pc-nrfconnect-shared library".
- When an app needs a more recent version of shared, indicate also that updating nRF Connect for Desktop might help.

I consider none of these changes to be relevant enough, to also mention them in the changelog.

In 9555c95f9bc75900ed9f43827ebd89879b5d9109 also all other usages of the short "nRF Connect" was changed to "nRF Connect for Desktop", which should help to not confuse it with other nRF Connect products.


