### PR TITLE
Use source map in production

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,7 +29,7 @@ function createExternals() {
 
 module.exports = {
     mode: nodeEnv,
-    devtool: isProd ? 'hidden-source-map' : 'inline-eval-cheap-source-map',
+    devtool: isProd ? 'source-map' : 'inline-eval-cheap-source-map',
     entry: {
         app: './src/app',
         shared: './node_modules/pc-nrfconnect-shared/src/index.ts',


### PR DESCRIPTION
We already provided the source maps before but did not link them. With this small change the source map is also used in production.

Before this, when opening the sources in the developer tools, there were only the compiled sources: ![image](https://user-images.githubusercontent.com/260705/151826702-4f5caa64-181e-4176-ad67-c0e7235e0096.png)

After this, there is now an additional `webpack://`-entry containing the raw sources (which can also be opened using the Ctrl/Cmd-P shortcut): 

![ScreenCapture at Mon Jan 31 16:46:48 CET 2022](https://user-images.githubusercontent.com/260705/151826967-5d85dcce-8265-42c2-8b29-74323a22de46.png)

![image](https://user-images.githubusercontent.com/260705/151827022-9964b3e0-7c91-4c4d-aae2-ad85c2a39110.png)