### PR TITLE
Upgrade electron-store

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3742,6 +3742,32 @@
             "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
             "dev": true
         },
+        "ajv-formats": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+            "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+            "requires": {
+                "ajv": "^8.0.0"
+            },
+            "dependencies": {
+                "ajv": {
+                    "version": "8.10.0",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.10.0.tgz",
+                    "integrity": "sha512-bzqAEZOjkrUMl2afH8dknrq5KEk2SrwdBROR+vH1EKVQTqaUbJVPdc/gEdggTMM0Se+s+Ja4ju4TlNcStKl2Hw==",
+                    "requires": {
+                        "fast-deep-equal": "^3.1.1",
+                        "json-schema-traverse": "^1.0.0",
+                        "require-from-string": "^2.0.2",
+                        "uri-js": "^4.2.2"
+                    }
+                },
+                "json-schema-traverse": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+                    "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+                }
+            }
+        },
         "ajv-keywords": {
             "version": "3.5.2",
             "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
@@ -4362,6 +4388,11 @@
             "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
             "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
             "dev": true
+        },
+        "atomically": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/atomically/-/atomically-1.7.0.tgz",
+            "integrity": "sha512-Xcz9l0z7y9yQ9rdDaxlmaI4uJHf/T8g9hOEzJcsEqX2SjCj4J20uK7+ldkDHMbpJDK76wF7xEIgxc/vSlsfw5w=="
         },
         "aws-sign2": {
             "version": "0.7.0",
@@ -5981,26 +6012,53 @@
             }
         },
         "conf": {
-            "version": "6.2.4",
-            "resolved": "https://registry.npmjs.org/conf/-/conf-6.2.4.tgz",
-            "integrity": "sha512-GjgyPRLo1qK1LR9RWAdUagqo+DP18f5HWCFk4va7GS+wpxQTOzfuKTwKOvGW2c01/YXNicAyyoyuSddmdkBzZQ==",
+            "version": "10.1.1",
+            "resolved": "https://registry.npmjs.org/conf/-/conf-10.1.1.tgz",
+            "integrity": "sha512-z2civwq/k8TMYtcn3SVP0Peso4otIWnHtcTuHhQ0zDZDdP4NTxqEc8owfkz4zBsdMYdn/LFcE+ZhbCeqkhtq3Q==",
             "requires": {
-                "ajv": "^6.10.2",
-                "debounce-fn": "^3.0.1",
-                "dot-prop": "^5.0.0",
-                "env-paths": "^2.2.0",
-                "json-schema-typed": "^7.0.1",
-                "make-dir": "^3.0.0",
-                "onetime": "^5.1.0",
-                "pkg-up": "^3.0.1",
-                "semver": "^6.2.0",
-                "write-file-atomic": "^3.0.0"
+                "ajv": "^8.6.3",
+                "ajv-formats": "^2.1.1",
+                "atomically": "^1.7.0",
+                "debounce-fn": "^4.0.0",
+                "dot-prop": "^6.0.1",
+                "env-paths": "^2.2.1",
+                "json-schema-typed": "^7.0.3",
+                "onetime": "^5.1.2",
+                "pkg-up": "^3.1.0",
+                "semver": "^7.3.5"
             },
             "dependencies": {
+                "ajv": {
+                    "version": "8.10.0",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.10.0.tgz",
+                    "integrity": "sha512-bzqAEZOjkrUMl2afH8dknrq5KEk2SrwdBROR+vH1EKVQTqaUbJVPdc/gEdggTMM0Se+s+Ja4ju4TlNcStKl2Hw==",
+                    "requires": {
+                        "fast-deep-equal": "^3.1.1",
+                        "json-schema-traverse": "^1.0.0",
+                        "require-from-string": "^2.0.2",
+                        "uri-js": "^4.2.2"
+                    }
+                },
+                "dot-prop": {
+                    "version": "6.0.1",
+                    "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-6.0.1.tgz",
+                    "integrity": "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==",
+                    "requires": {
+                        "is-obj": "^2.0.0"
+                    }
+                },
+                "json-schema-traverse": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+                    "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+                },
                 "semver": {
-                    "version": "6.3.0",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+                    "version": "7.3.5",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+                    "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+                    "requires": {
+                        "lru-cache": "^6.0.0"
+                    }
                 }
             }
         },
@@ -6501,11 +6559,18 @@
             "dev": true
         },
         "debounce-fn": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/debounce-fn/-/debounce-fn-3.0.1.tgz",
-            "integrity": "sha512-aBoJh5AhpqlRoHZjHmOzZlRx+wz2xVwGL9rjs+Kj0EWUrL4/h4K7OD176thl2Tdoqui/AaA4xhHrNArGLAaI3Q==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/debounce-fn/-/debounce-fn-4.0.0.tgz",
+            "integrity": "sha512-8pYCQiL9Xdcg0UPSD3d+0KMlOjp+KGU5EPwYddgzQ7DATsg4fuUDjQtsYLmWjnk2obnNHgV3vE2Y4jejSOJVBQ==",
             "requires": {
-                "mimic-fn": "^2.1.0"
+                "mimic-fn": "^3.0.0"
+            },
+            "dependencies": {
+                "mimic-fn": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
+                    "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ=="
+                }
             }
         },
         "debug": {
@@ -6841,6 +6906,7 @@
             "version": "5.3.0",
             "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
             "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
+            "dev": true,
             "requires": {
                 "is-obj": "^2.0.0"
             }
@@ -7113,12 +7179,12 @@
             }
         },
         "electron-store": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/electron-store/-/electron-store-5.1.1.tgz",
-            "integrity": "sha512-FLidOVE8JVCdJXHd7xY/JojKJ2r2WNmWt0O/LlX2LuSVV7dkG2RSy2/Gm2LFw8OKDfrNBd9c/s4X1ikMrJEUKg==",
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/electron-store/-/electron-store-8.0.1.tgz",
+            "integrity": "sha512-ZyLvNywiqSpbwC/pp89O/AycVWY/UJIkmtyzF2Bd0Nm/rLmcFc0NTGuLdg6+LE8mS8qsiK5JMoe4PnrecLHH5w==",
             "requires": {
-                "conf": "^6.2.1",
-                "type-fest": "^0.7.1"
+                "conf": "^10.0.3",
+                "type-fest": "^1.0.2"
             }
         },
         "electron-to-chromium": {
@@ -9811,7 +9877,8 @@
         "imurmurhash": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-            "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+            "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+            "dev": true
         },
         "indent-string": {
             "version": "4.0.0",
@@ -16691,6 +16758,11 @@
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
             "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
         },
+        "require-from-string": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
+        },
         "require-main-filename": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
@@ -19025,9 +19097,9 @@
             "dev": true
         },
         "type-fest": {
-            "version": "0.7.1",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.7.1.tgz",
-            "integrity": "sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg=="
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+            "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="
         },
         "typedarray": {
             "version": "0.0.6",
@@ -19039,6 +19111,7 @@
             "version": "3.1.5",
             "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
             "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+            "dev": true,
             "requires": {
                 "is-typedarray": "^1.0.0"
             }
@@ -20370,6 +20443,7 @@
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
             "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
+            "dev": true,
             "requires": {
                 "imurmurhash": "^0.1.4",
                 "is-typedarray": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
         "axios": "0.22.0",
         "chmodr": "1.2.0",
         "electron-log": "4.2.0",
-        "electron-store": "5.1.1",
+        "electron-store": "8.0.1",
         "electron-updater": "4.3.1",
         "eslint-config-airbnb": "18.1.0",
         "eslint-config-airbnb-base": "14.1.0",


### PR DESCRIPTION
The new version of `electron-store` removes the use of `electron.remote`, which is a plus.

Because we use `electron-store` also from the main process (in `src/main/apps.js`), there is nothing further we have to change. If we ever remove that usage from the main process in the future, we would have to add a call to `Store.initRenderer()` in the main process, as described in the release notes of v7: https://github.com/sindresorhus/electron-store/releases/tag/v7.0.0
