### PR TITLE
Remove add-module-exports plugin

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2021 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+const sharedBabelConfig = require('pc-nrfconnect-shared/config/babel.config');
+
+module.exports = api => {
+    const config = sharedBabelConfig(api);
+
+    return {
+        ...config,
+        plugins: config.plugins.filter(
+            plugin => plugin !== 'add-module-exports'
+        ),
+    };
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -49,8 +49,20 @@ module.exports = {
                         loader: require.resolve('babel-loader'),
                         options: {
                             cacheDirectory: true,
-                            configFile:
-                                './node_modules/pc-nrfconnect-shared/config/babel.config.js',
+                            presets: [
+                                '@babel/preset-react',
+                                '@babel/preset-typescript',
+                            ],
+                            plugins: [
+                                '@babel/plugin-proposal-class-properties',
+                                '@babel/plugin-transform-destructuring',
+                                '@babel/plugin-transform-modules-commonjs',
+                                '@babel/plugin-transform-parameters',
+                                '@babel/plugin-transform-spread',
+                                '@babel/plugin-proposal-object-rest-spread',
+                                '@babel/plugin-proposal-optional-chaining',
+                                '@babel/plugin-proposal-nullish-coalescing-operator',
+                            ],
                         },
                     },
                 ],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -49,20 +49,7 @@ module.exports = {
                         loader: require.resolve('babel-loader'),
                         options: {
                             cacheDirectory: true,
-                            presets: [
-                                '@babel/preset-react',
-                                '@babel/preset-typescript',
-                            ],
-                            plugins: [
-                                '@babel/plugin-proposal-class-properties',
-                                '@babel/plugin-transform-destructuring',
-                                '@babel/plugin-transform-modules-commonjs',
-                                '@babel/plugin-transform-parameters',
-                                '@babel/plugin-transform-spread',
-                                '@babel/plugin-proposal-object-rest-spread',
-                                '@babel/plugin-proposal-optional-chaining',
-                                '@babel/plugin-proposal-nullish-coalescing-operator',
-                            ],
+                            configFile: './babel.config.js',
                         },
                     },
                 ],


### PR DESCRIPTION
This basically replicates the babel setup from shared, but removes a single plugin "add-module-exports plugin".

This plugin changes what's exported from some modules and causes errors where pre-built dependencies would try to resolve default properties on commonjs-modules which were converted to esm-style export with this package.

It is quite possible that this should just be removed in shared all-together. But I think it's best to rather remove it from the launcher to get launcher in a working state, as it will take some time to test all apps built by shared with this change as well.