### PR TITLE
Fix GitHub URL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14248,8 +14248,8 @@
                     }
                 },
                 "prebuild": {
-                    "version": "git://github.com/NordicPlayground/prebuild.git#33b6468a985f05194a2f96a5de1ffe147e95c222",
-                    "from": "prebuild@git://github.com/NordicPlayground/prebuild.git",
+                    "version": "github:NordicPlayground/prebuild#33b6468a985f05194a2f96a5de1ffe147e95c222",
+                    "from": "github:NordicPlayground/prebuild",
                     "requires": {
                         "cmake-js": "*",
                         "detect-libc": "^1.0.3",


### PR DESCRIPTION
git:// causes an unencrypted connection to be used, which is not supported by GitHub anymore: https://github.blog/2021-09-01-improving-git-protocol-security-github/

