### PR TITLE
Enhance reliability in China

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+## Unreleased
+### Changed
+- Better reliability in China. The app list is not loaded from GitHub any
+  longer but from developer.nordicsemi.com, which should be easier to reach
+  from China.
+
 ## 3.10.0 - 2022-02-02
 ### Added
 - Functionality to turn on extensive logging from the `About` pane to aid in support-cases.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nrfconnect",
-    "version": "3.10.1-pre1",
+    "version": "3.10.1-pre2",
     "description": "nRF Connect for Desktop",
     "repository": {
         "type": "git",

--- a/src/main/config.js
+++ b/src/main/config.js
@@ -80,7 +80,7 @@ function init(argv) {
     sourcesJsonPath =
         argv['sources-json-path'] || path.join(appsExternalDir, 'sources.json');
     appsJsonUrl =
-        'https://raw.githubusercontent.com/NordicSemiconductor/pc-nrfconnect-launcher/master/apps.json';
+        'https://developer.nordicsemi.com/.pc-tools/nrfconnect-apps/apps.json';
     registryUrl = 'https://developer.nordicsemi.com/.pc-tools/nrfconnect-apps/';
     releaseNotesUrl =
         'https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/releases';


### PR DESCRIPTION
The app list is not loaded from GitHub any longer but from developer.nordicsemi.com, which should be easier to reach from China.

This has the consequence though, that we now have to keep https://developer.nordicsemi.com/.pc-tools/nrfconnect-apps/apps.json in sync with https://raw.githubusercontent.com/NordicSemiconductor/pc-nrfconnect-launcher/master/apps.json. The latter still needs to be maintained as long as we want to also support older versions of nRF Connect for Desktop.
