### PR TITLE
Restrict too small app window to prevent crash

### DIFF
--- a/src/main/windows.js
+++ b/src/main/windows.js
@@ -79,6 +79,8 @@ function openAppWindow(app) {
         y,
         width,
         height,
+        minHeight: 500,
+        minWidth: 760,
         show: true,
         backgroundColor: '#fff',
     });


### PR DESCRIPTION
Set minHeight and minWidth because an issue was reported on the PPK app crashing if customer reduced the window size too much.