### PR TITLE
Update `shared` to 6.1.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,7 +3,6 @@
 ### Added
 
 -   Support the nRF5340 Audio DK (PCA10121).
--   Spinner for loading apps (removed during 3.11).
 
 ### Changed
 
@@ -12,6 +11,7 @@
 
 ### Fixed
 
+-   Returned spinner while loading apps (removed during 3.11.0).
 -   Some issues when programming and erasing devices in the Programmer app.
 
 ## 3.11.0

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,6 +7,7 @@
 
 ### Changed
 
+-   Speed up app launches.
 -   Layout in the launcher: Reduced app icon sizes and by default show 5 apps.
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,28 +36,174 @@
             "dev": true
         },
         "@babel/core": {
-            "version": "7.17.5",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.5.tgz",
-            "integrity": "sha512-/BBMw4EvjmyquN5O+t5eh0+YqB3XXJkYD2cjKpYtWOfFy4lQ4UozNSmxAcWT8r2XtZs0ewG+zrfsqeR15i1ajA==",
+            "version": "7.17.10",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.10.tgz",
+            "integrity": "sha512-liKoppandF3ZcBnIYFjfSDHZLKdLHGJRkoWtG8zQyGJBQfIYobpnVGI5+pLBNtS6psFLDzyq8+h5HiVljW9PNA==",
             "dev": true,
             "requires": {
                 "@ampproject/remapping": "^2.1.0",
                 "@babel/code-frame": "^7.16.7",
-                "@babel/generator": "^7.17.3",
-                "@babel/helper-compilation-targets": "^7.16.7",
-                "@babel/helper-module-transforms": "^7.16.7",
-                "@babel/helpers": "^7.17.2",
-                "@babel/parser": "^7.17.3",
+                "@babel/generator": "^7.17.10",
+                "@babel/helper-compilation-targets": "^7.17.10",
+                "@babel/helper-module-transforms": "^7.17.7",
+                "@babel/helpers": "^7.17.9",
+                "@babel/parser": "^7.17.10",
                 "@babel/template": "^7.16.7",
-                "@babel/traverse": "^7.17.3",
-                "@babel/types": "^7.17.0",
+                "@babel/traverse": "^7.17.10",
+                "@babel/types": "^7.17.10",
                 "convert-source-map": "^1.7.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
-                "json5": "^2.1.2",
+                "json5": "^2.2.1",
                 "semver": "^6.3.0"
             },
             "dependencies": {
+                "@babel/compat-data": {
+                    "version": "7.17.10",
+                    "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.17.10.tgz",
+                    "integrity": "sha512-GZt/TCsG70Ms19gfZO1tM4CVnXsPgEPBCpJu+Qz3L0LUDsY5nZqFZglIoPC1kIYOtNBZlrnFT+klg12vFGZXrw==",
+                    "dev": true
+                },
+                "@babel/generator": {
+                    "version": "7.17.10",
+                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.10.tgz",
+                    "integrity": "sha512-46MJZZo9y3o4kmhBVc7zW7i8dtR1oIK/sdO5NcfcZRhTGYi+KKJRtHNgsU6c4VUcJmUNV/LQdebD/9Dlv4K+Tg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.17.10",
+                        "@jridgewell/gen-mapping": "^0.1.0",
+                        "jsesc": "^2.5.1"
+                    }
+                },
+                "@babel/helper-compilation-targets": {
+                    "version": "7.17.10",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.17.10.tgz",
+                    "integrity": "sha512-gh3RxjWbauw/dFiU/7whjd0qN9K6nPJMqe6+Er7rOavFh0CQUSwhAE3IcTho2rywPJFxej6TUUHDkWcYI6gGqQ==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/compat-data": "^7.17.10",
+                        "@babel/helper-validator-option": "^7.16.7",
+                        "browserslist": "^4.20.2",
+                        "semver": "^6.3.0"
+                    }
+                },
+                "@babel/helper-function-name": {
+                    "version": "7.17.9",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.17.9.tgz",
+                    "integrity": "sha512-7cRisGlVtiVqZ0MW0/yFB4atgpGLWEHUVYnb448hZK4x+vih0YO5UoS11XIYtZYqHd0dIPMdUSv8q5K4LdMnIg==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/template": "^7.16.7",
+                        "@babel/types": "^7.17.0"
+                    }
+                },
+                "@babel/helper-module-transforms": {
+                    "version": "7.17.7",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.17.7.tgz",
+                    "integrity": "sha512-VmZD99F3gNTYB7fJRDTi+u6l/zxY0BE6OIxPSU7a50s6ZUQkHwSDmV92FfM+oCG0pZRVojGYhkR8I0OGeCVREw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-environment-visitor": "^7.16.7",
+                        "@babel/helper-module-imports": "^7.16.7",
+                        "@babel/helper-simple-access": "^7.17.7",
+                        "@babel/helper-split-export-declaration": "^7.16.7",
+                        "@babel/helper-validator-identifier": "^7.16.7",
+                        "@babel/template": "^7.16.7",
+                        "@babel/traverse": "^7.17.3",
+                        "@babel/types": "^7.17.0"
+                    }
+                },
+                "@babel/helper-simple-access": {
+                    "version": "7.17.7",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.17.7.tgz",
+                    "integrity": "sha512-txyMCGroZ96i+Pxr3Je3lzEJjqwaRC9buMUgtomcrLe5Nd0+fk1h0LLA+ixUF5OW7AhHuQ7Es1WcQJZmZsz2XA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.17.0"
+                    }
+                },
+                "@babel/helpers": {
+                    "version": "7.17.9",
+                    "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.9.tgz",
+                    "integrity": "sha512-cPCt915ShDWUEzEp3+UNRktO2n6v49l5RSnG9M5pS24hA+2FAc5si+Pn1i4VVbQQ+jh+bIZhPFQOJOzbrOYY1Q==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/template": "^7.16.7",
+                        "@babel/traverse": "^7.17.9",
+                        "@babel/types": "^7.17.0"
+                    }
+                },
+                "@babel/parser": {
+                    "version": "7.17.10",
+                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.10.tgz",
+                    "integrity": "sha512-n2Q6i+fnJqzOaq2VkdXxy2TCPCWQZHiCo0XqmrCvDWcZQKRyZzYi4Z0yxlBuN0w+r2ZHmre+Q087DSrw3pbJDQ==",
+                    "dev": true
+                },
+                "@babel/traverse": {
+                    "version": "7.17.10",
+                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.10.tgz",
+                    "integrity": "sha512-VmbrTHQteIdUUQNTb+zE12SHS/xQVIShmBPhlNP12hD5poF2pbITW1Z4172d03HegaQWhLffdkRJYtAzp0AGcw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/code-frame": "^7.16.7",
+                        "@babel/generator": "^7.17.10",
+                        "@babel/helper-environment-visitor": "^7.16.7",
+                        "@babel/helper-function-name": "^7.17.9",
+                        "@babel/helper-hoist-variables": "^7.16.7",
+                        "@babel/helper-split-export-declaration": "^7.16.7",
+                        "@babel/parser": "^7.17.10",
+                        "@babel/types": "^7.17.10",
+                        "debug": "^4.1.0",
+                        "globals": "^11.1.0"
+                    }
+                },
+                "@babel/types": {
+                    "version": "7.17.10",
+                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.10.tgz",
+                    "integrity": "sha512-9O26jG0mBYfGkUYCYZRnBwbVLd1UZOICEr2Em6InB6jVfsAv1GKgwXHmrSg+WFWDmeKTA6vyTZiN8tCSM5Oo3A==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-validator-identifier": "^7.16.7",
+                        "to-fast-properties": "^2.0.0"
+                    }
+                },
+                "browserslist": {
+                    "version": "4.20.3",
+                    "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.3.tgz",
+                    "integrity": "sha512-NBhymBQl1zM0Y5dQT/O+xiLP9/rzOIQdKM/eMJBAq7yBgaB6krIYLGejrwVYnSHZdqjscB1SPuAjHwxjvN6Wdg==",
+                    "dev": true,
+                    "requires": {
+                        "caniuse-lite": "^1.0.30001332",
+                        "electron-to-chromium": "^1.4.118",
+                        "escalade": "^3.1.1",
+                        "node-releases": "^2.0.3",
+                        "picocolors": "^1.0.0"
+                    }
+                },
+                "caniuse-lite": {
+                    "version": "1.0.30001338",
+                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001338.tgz",
+                    "integrity": "sha512-1gLHWyfVoRDsHieO+CaeYe7jSo/MT7D7lhaXUiwwbuR5BwQxORs0f1tAwUSQr3YbxRXJvxHM/PA5FfPQRnsPeQ==",
+                    "dev": true
+                },
+                "electron-to-chromium": {
+                    "version": "1.4.136",
+                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.136.tgz",
+                    "integrity": "sha512-GnITX8rHnUrIVnTxU9UlsTnSemHUA2iF+6QrRqxFbp/mf0vfuSc/goEyyQhUX3TUUCE3mv/4BNuXOtaJ4ur0eA==",
+                    "dev": true
+                },
+                "json5": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
+                    "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+                    "dev": true
+                },
+                "node-releases": {
+                    "version": "2.0.4",
+                    "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.4.tgz",
+                    "integrity": "sha512-gbMzqQtTtDz/00jQzZ21PQzdI9PyLYqUSvD0p3naOhX4odFji0ZxYdnVwPTxmSwkmxhcFImpozceidSG+AgoPQ==",
+                    "dev": true
+                },
                 "semver": {
                     "version": "6.3.0",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -826,9 +972,9 @@
             }
         },
         "@babel/plugin-transform-destructuring": {
-            "version": "7.17.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.17.3.tgz",
-            "integrity": "sha512-dDFzegDYKlPqa72xIlbmSkly5MluLoaC1JswABGktyt6NTXSBcUuse/kWE/wvKFWJHPETpi158qJZFS3JmykJg==",
+            "version": "7.17.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.17.7.tgz",
+            "integrity": "sha512-XVh0r5yq9sLR4vZ6eVZe8FKfIcSgaTBxVBRSYokRj2qksf6QerYnTxz9/GTuKTH/n/HwLP7t6gtlybHetJ/6hQ==",
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.16.7"
@@ -913,15 +1059,42 @@
             }
         },
         "@babel/plugin-transform-modules-commonjs": {
-            "version": "7.16.8",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.16.8.tgz",
-            "integrity": "sha512-oflKPvsLT2+uKQopesJt3ApiaIS2HW+hzHFcwRNtyDGieAeC/dIHZX8buJQ2J2X1rxGPy4eRcUijm3qcSPjYcA==",
+            "version": "7.17.9",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.17.9.tgz",
+            "integrity": "sha512-2TBFd/r2I6VlYn0YRTz2JdazS+FoUuQ2rIFHoAxtyP/0G3D82SBLaRq9rnUkpqlLg03Byfl/+M32mpxjO6KaPw==",
             "dev": true,
             "requires": {
-                "@babel/helper-module-transforms": "^7.16.7",
+                "@babel/helper-module-transforms": "^7.17.7",
                 "@babel/helper-plugin-utils": "^7.16.7",
-                "@babel/helper-simple-access": "^7.16.7",
+                "@babel/helper-simple-access": "^7.17.7",
                 "babel-plugin-dynamic-import-node": "^2.3.3"
+            },
+            "dependencies": {
+                "@babel/helper-module-transforms": {
+                    "version": "7.17.7",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.17.7.tgz",
+                    "integrity": "sha512-VmZD99F3gNTYB7fJRDTi+u6l/zxY0BE6OIxPSU7a50s6ZUQkHwSDmV92FfM+oCG0pZRVojGYhkR8I0OGeCVREw==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/helper-environment-visitor": "^7.16.7",
+                        "@babel/helper-module-imports": "^7.16.7",
+                        "@babel/helper-simple-access": "^7.17.7",
+                        "@babel/helper-split-export-declaration": "^7.16.7",
+                        "@babel/helper-validator-identifier": "^7.16.7",
+                        "@babel/template": "^7.16.7",
+                        "@babel/traverse": "^7.17.3",
+                        "@babel/types": "^7.17.0"
+                    }
+                },
+                "@babel/helper-simple-access": {
+                    "version": "7.17.7",
+                    "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.17.7.tgz",
+                    "integrity": "sha512-txyMCGroZ96i+Pxr3Je3lzEJjqwaRC9buMUgtomcrLe5Nd0+fk1h0LLA+ixUF5OW7AhHuQ7Es1WcQJZmZsz2XA==",
+                    "dev": true,
+                    "requires": {
+                        "@babel/types": "^7.17.0"
+                    }
+                }
             }
         },
         "@babel/plugin-transform-modules-systemjs": {
@@ -1264,52 +1437,6 @@
                         "semver": "^6.3.0"
                     }
                 },
-                "@babel/helper-module-transforms": {
-                    "version": "7.17.7",
-                    "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.17.7.tgz",
-                    "integrity": "sha512-VmZD99F3gNTYB7fJRDTi+u6l/zxY0BE6OIxPSU7a50s6ZUQkHwSDmV92FfM+oCG0pZRVojGYhkR8I0OGeCVREw==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/helper-environment-visitor": "^7.16.7",
-                        "@babel/helper-module-imports": "^7.16.7",
-                        "@babel/helper-simple-access": "^7.17.7",
-                        "@babel/helper-split-export-declaration": "^7.16.7",
-                        "@babel/helper-validator-identifier": "^7.16.7",
-                        "@babel/template": "^7.16.7",
-                        "@babel/traverse": "^7.17.3",
-                        "@babel/types": "^7.17.0"
-                    }
-                },
-                "@babel/helper-simple-access": {
-                    "version": "7.17.7",
-                    "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.17.7.tgz",
-                    "integrity": "sha512-txyMCGroZ96i+Pxr3Je3lzEJjqwaRC9buMUgtomcrLe5Nd0+fk1h0LLA+ixUF5OW7AhHuQ7Es1WcQJZmZsz2XA==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/types": "^7.17.0"
-                    }
-                },
-                "@babel/plugin-transform-destructuring": {
-                    "version": "7.17.7",
-                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.17.7.tgz",
-                    "integrity": "sha512-XVh0r5yq9sLR4vZ6eVZe8FKfIcSgaTBxVBRSYokRj2qksf6QerYnTxz9/GTuKTH/n/HwLP7t6gtlybHetJ/6hQ==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/helper-plugin-utils": "^7.16.7"
-                    }
-                },
-                "@babel/plugin-transform-modules-commonjs": {
-                    "version": "7.17.9",
-                    "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.17.9.tgz",
-                    "integrity": "sha512-2TBFd/r2I6VlYn0YRTz2JdazS+FoUuQ2rIFHoAxtyP/0G3D82SBLaRq9rnUkpqlLg03Byfl/+M32mpxjO6KaPw==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/helper-module-transforms": "^7.17.7",
-                        "@babel/helper-plugin-utils": "^7.16.7",
-                        "@babel/helper-simple-access": "^7.17.7",
-                        "babel-plugin-dynamic-import-node": "^2.3.3"
-                    }
-                },
                 "@babel/types": {
                     "version": "7.17.10",
                     "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.10.tgz",
@@ -1334,15 +1461,15 @@
                     }
                 },
                 "caniuse-lite": {
-                    "version": "1.0.30001335",
-                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001335.tgz",
-                    "integrity": "sha512-ddP1Tgm7z2iIxu6QTtbZUv6HJxSaV/PZeSrWFZtbY4JZ69tOeNhBCl3HyRQgeNZKE5AOn1kpV7fhljigy0Ty3w==",
+                    "version": "1.0.30001338",
+                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001338.tgz",
+                    "integrity": "sha512-1gLHWyfVoRDsHieO+CaeYe7jSo/MT7D7lhaXUiwwbuR5BwQxORs0f1tAwUSQr3YbxRXJvxHM/PA5FfPQRnsPeQ==",
                     "dev": true
                 },
                 "electron-to-chromium": {
-                    "version": "1.4.129",
-                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.129.tgz",
-                    "integrity": "sha512-GgtN6bsDtHdtXJtlMYZWGB/uOyjZWjmRDumXTas7dGBaB9zUyCjzHet1DY2KhyHN8R0GLbzZWqm4efeddqqyRQ==",
+                    "version": "1.4.136",
+                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.136.tgz",
+                    "integrity": "sha512-GnITX8rHnUrIVnTxU9UlsTnSemHUA2iF+6QrRqxFbp/mf0vfuSc/goEyyQhUX3TUUCE3mv/4BNuXOtaJ4ur0eA==",
                     "dev": true
                 },
                 "node-releases": {
@@ -1593,22 +1720,28 @@
             }
         },
         "@eslint/eslintrc": {
-            "version": "0.4.3",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
-            "integrity": "sha512-J6KFFz5QCYUJq3pf0mjEcCJVERbzv71PUIDczuh9JkwGEzced6CO5ADLHB1rbf/+oPBtoPfMYNOpGDzCANlbXw==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.2.tgz",
+            "integrity": "sha512-lTVWHs7O2hjBFZunXTZYnYqtB9GakA1lnxIf+gKq2nY5gxkkNi/lQvveW6t8gFdOHTg6nG50Xs95PrLqVpcaLg==",
             "dev": true,
             "requires": {
                 "ajv": "^6.12.4",
-                "debug": "^4.1.1",
-                "espree": "^7.3.0",
+                "debug": "^4.3.2",
+                "espree": "^9.3.1",
                 "globals": "^13.9.0",
-                "ignore": "^4.0.6",
+                "ignore": "^5.2.0",
                 "import-fresh": "^3.2.1",
-                "js-yaml": "^3.13.1",
+                "js-yaml": "^4.1.0",
                 "minimatch": "^3.0.4",
                 "strip-json-comments": "^3.1.1"
             },
             "dependencies": {
+                "argparse": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+                    "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+                    "dev": true
+                },
                 "globals": {
                     "version": "13.13.0",
                     "resolved": "https://registry.npmjs.org/globals/-/globals-13.13.0.tgz",
@@ -1618,11 +1751,14 @@
                         "type-fest": "^0.20.2"
                     }
                 },
-                "ignore": {
-                    "version": "4.0.6",
-                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-                    "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
-                    "dev": true
+                "js-yaml": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+                    "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+                    "dev": true,
+                    "requires": {
+                        "argparse": "^2.0.1"
+                    }
                 },
                 "strip-json-comments": {
                     "version": "3.1.1",
@@ -1639,12 +1775,12 @@
             }
         },
         "@humanwhocodes/config-array": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
-            "integrity": "sha512-FagtKFz74XrTl7y6HCzQpwDfXP0yhxe9lHLD1UZxjvZIcbyRz8zTFF/yYNfSfzU414eDwZ1SrO0Qvtyf+wFMQg==",
+            "version": "0.9.5",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.5.tgz",
+            "integrity": "sha512-ObyMyWxZiCu/yTisA7uzx81s40xR2fD5Cg/2Kq7G02ajkNubJf6BopgDTmDyc3U7sXpNKM8cYOw7s7Tyr+DnCw==",
             "dev": true,
             "requires": {
-                "@humanwhocodes/object-schema": "^1.2.0",
+                "@humanwhocodes/object-schema": "^1.2.1",
                 "debug": "^4.1.1",
                 "minimatch": "^3.0.4"
             }
@@ -2183,27 +2319,27 @@
             }
         },
         "@jridgewell/resolve-uri": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.6.tgz",
-            "integrity": "sha512-R7xHtBSNm+9SyvpJkdQl+qrM3Hm2fea3Ef197M3mUug+v+yR+Rhfbs7PBtcBUVnIWJ4JcAdjvij+c8hXS9p5aw==",
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.7.tgz",
+            "integrity": "sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==",
             "dev": true
         },
         "@jridgewell/set-array": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.0.tgz",
-            "integrity": "sha512-SfJxIxNVYLTsKwzB3MoOQ1yxf4w/E6MdkvTgrgAt1bfxjSrLUoHMKrDOykwN14q65waezZIdqDneUIPh4/sKxg==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.1.tgz",
+            "integrity": "sha512-Ct5MqZkLGEXTVmQYbGtx9SVqD2fqwvdubdps5D3djjAkgkKwT918VNOz65pEHFaYTeWcukmJmH5SwsA9Tn2ObQ==",
             "dev": true
         },
         "@jridgewell/sourcemap-codec": {
-            "version": "1.4.11",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.11.tgz",
-            "integrity": "sha512-Fg32GrJo61m+VqYSdRSjRXMjQ06j8YIYfcTqndLYVAaHmroZHLJZCydsWBOTDqXS2v+mjxohBWEMfg97GXmYQg==",
+            "version": "1.4.13",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz",
+            "integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==",
             "dev": true
         },
         "@jridgewell/trace-mapping": {
-            "version": "0.3.9",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-            "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+            "version": "0.3.10",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.10.tgz",
+            "integrity": "sha512-Q0YbBd6OTsXm8Y21+YUSDXupHnodNC2M4O18jtd3iwJ3+vMZNdKGols0a9G6JOK0dcJ3IdUUHoh908ZI6qhk8Q==",
             "dev": true,
             "requires": {
                 "@jridgewell/resolve-uri": "^3.0.3",
@@ -3005,9 +3141,9 @@
             "dev": true
         },
         "@reduxjs/toolkit": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.8.0.tgz",
-            "integrity": "sha512-cdfHWfcvLyhBUDicoFwG1u32JqvwKDxLxDd7zSmSoFw/RhYLOygIRtmaMjPRUUHmVmmAGAvquLLsKKU/677kSQ==",
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-1.8.1.tgz",
+            "integrity": "sha512-Q6mzbTpO9nOYRnkwpDlFOAbQnd3g7zj7CtHAZWz5SzE5lcV97Tf8f3SzOO8BoPOMYBFgfZaqTUZqgGu+a0+Fng==",
             "dev": true,
             "requires": {
                 "immer": "^9.0.7",
@@ -3357,114 +3493,114 @@
             }
         },
         "@swc/core": {
-            "version": "1.2.148",
-            "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.2.148.tgz",
-            "integrity": "sha512-kIuHnJx3WEzmAx+9V5KO6JlGdILMyw75iKwqp5U+zf+kmcB2kWgUh5ofb8YxJY04yxBIurlTxkkRE0SV+cHKaw==",
+            "version": "1.2.175",
+            "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.2.175.tgz",
+            "integrity": "sha512-CCLr8qV0sGsiWnN7xqmmNwqnGlBg3CKZc5+EKIxSWjRAExRV1rFLejW2aesBn2RRyKZRpnwEyOk/GFxjsKBxzw==",
             "dev": true,
             "requires": {
-                "@swc/core-android-arm-eabi": "1.2.148",
-                "@swc/core-android-arm64": "1.2.148",
-                "@swc/core-darwin-arm64": "1.2.148",
-                "@swc/core-darwin-x64": "1.2.148",
-                "@swc/core-freebsd-x64": "1.2.148",
-                "@swc/core-linux-arm-gnueabihf": "1.2.148",
-                "@swc/core-linux-arm64-gnu": "1.2.148",
-                "@swc/core-linux-arm64-musl": "1.2.148",
-                "@swc/core-linux-x64-gnu": "1.2.148",
-                "@swc/core-linux-x64-musl": "1.2.148",
-                "@swc/core-win32-arm64-msvc": "1.2.148",
-                "@swc/core-win32-ia32-msvc": "1.2.148",
-                "@swc/core-win32-x64-msvc": "1.2.148"
+                "@swc/core-android-arm-eabi": "1.2.175",
+                "@swc/core-android-arm64": "1.2.175",
+                "@swc/core-darwin-arm64": "1.2.175",
+                "@swc/core-darwin-x64": "1.2.175",
+                "@swc/core-freebsd-x64": "1.2.175",
+                "@swc/core-linux-arm-gnueabihf": "1.2.175",
+                "@swc/core-linux-arm64-gnu": "1.2.175",
+                "@swc/core-linux-arm64-musl": "1.2.175",
+                "@swc/core-linux-x64-gnu": "1.2.175",
+                "@swc/core-linux-x64-musl": "1.2.175",
+                "@swc/core-win32-arm64-msvc": "1.2.175",
+                "@swc/core-win32-ia32-msvc": "1.2.175",
+                "@swc/core-win32-x64-msvc": "1.2.175"
             }
         },
         "@swc/core-android-arm-eabi": {
-            "version": "1.2.148",
-            "resolved": "https://registry.npmjs.org/@swc/core-android-arm-eabi/-/core-android-arm-eabi-1.2.148.tgz",
-            "integrity": "sha512-lCPV+CvF3cKc2mq0si0dI2AP+1y0p/b9ASn0vWpdhdLUoAht25M68BYUHKMDmywuOeFnAvPdWoQF/ayD+Uk2NQ==",
+            "version": "1.2.175",
+            "resolved": "https://registry.npmjs.org/@swc/core-android-arm-eabi/-/core-android-arm-eabi-1.2.175.tgz",
+            "integrity": "sha512-Uyg19XdczD1IrZe4IZO4qzZ3HCp8MynSCBvtkbyeM2ok7UGse/KjeP+giYEHvock3cvVVkPVaOKoU2gVGhkm7A==",
             "dev": true,
             "optional": true
         },
         "@swc/core-android-arm64": {
-            "version": "1.2.148",
-            "resolved": "https://registry.npmjs.org/@swc/core-android-arm64/-/core-android-arm64-1.2.148.tgz",
-            "integrity": "sha512-p+PFcpDByIopBfncwxOtn+mOEnKrLhCxuNi3CtaiyZa51IeefP/IhV0mtVJy9YeuRp+Bk7WkA/SSXUHA0TqZuA==",
+            "version": "1.2.175",
+            "resolved": "https://registry.npmjs.org/@swc/core-android-arm64/-/core-android-arm64-1.2.175.tgz",
+            "integrity": "sha512-fov7p47Eq2fAj/zZOfNicTkOO3ILblxJMMUPeTHEMsQ4DTFr3SgjZjWKxHiMwiWxitLGR2YoTdCUs1qWcGALcQ==",
             "dev": true,
             "optional": true
         },
         "@swc/core-darwin-arm64": {
-            "version": "1.2.148",
-            "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.2.148.tgz",
-            "integrity": "sha512-1lxLa8i0fcL/70WM+ejJHs5lC0D/Hf+7gH40PSZgrnmDQyZPDcjNYEqXrggvIfAfLab1JgVmKLu1a987nvmdug==",
+            "version": "1.2.175",
+            "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.2.175.tgz",
+            "integrity": "sha512-Rht5U9gDBiVoF3nTOySv2as5TJ+rkBB0ZtY4kG57wJGPet9dQtm3yZsxUSz6EYlo4pRTtXmd+PvMnfmgFwddUA==",
             "dev": true,
             "optional": true
         },
         "@swc/core-darwin-x64": {
-            "version": "1.2.148",
-            "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.2.148.tgz",
-            "integrity": "sha512-DZeCC4DBBbxdvmrOpDZWS/UZGPCRPFextqWxjdkpHhWyNMHVlWxwjINxTZbCZx0RwvZA2he1xFwXbgXZ9hGKzQ==",
+            "version": "1.2.175",
+            "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.2.175.tgz",
+            "integrity": "sha512-W+EMt9Cwusl8bmEwrR3WO6XO3OEXp6D1pTUzPCS5aoESEAmuKtTiTuhUQYhz2KZpJOdWYm4HxPn/UewRxi6cjA==",
             "dev": true,
             "optional": true
         },
         "@swc/core-freebsd-x64": {
-            "version": "1.2.148",
-            "resolved": "https://registry.npmjs.org/@swc/core-freebsd-x64/-/core-freebsd-x64-1.2.148.tgz",
-            "integrity": "sha512-tCwJXQHGYvdVRn9LMEqXzQex+cY9110oVYv/9FFUfyamIpbJZohBjy8s5bgdfkZsTgbi6ecYxy3PrJ63Sb9M8A==",
+            "version": "1.2.175",
+            "resolved": "https://registry.npmjs.org/@swc/core-freebsd-x64/-/core-freebsd-x64-1.2.175.tgz",
+            "integrity": "sha512-fK0HFGYBLInelyKu2Ze/jv3wzaUw6gq5xRL1zf2ZpwEBy92MkuxFixplSxnO7J9gEL7tR8JCpRYm9ir60Wtfgw==",
             "dev": true,
             "optional": true
         },
         "@swc/core-linux-arm-gnueabihf": {
-            "version": "1.2.148",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.2.148.tgz",
-            "integrity": "sha512-rzBbEGnYb8FER/N/86J1Nhvvagb/4h+JV6mHm71k6UTicPuhwFZzAJvCuKVyejT8TRunDkMU5u67Bn6dKVIsMQ==",
+            "version": "1.2.175",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.2.175.tgz",
+            "integrity": "sha512-voAk62+IRz+tEdL1xsxgwxfNxAmYPCqbgIh1YDFHhWhAnPjJIX0RGEatqCTLwM1lOObLtPs1JPLpvm6sa5JfEg==",
             "dev": true,
             "optional": true
         },
         "@swc/core-linux-arm64-gnu": {
-            "version": "1.2.148",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.2.148.tgz",
-            "integrity": "sha512-WFjWyDO3QU5sQI0mkPzd5DnAC+3sjpvBpoClQ8xCzOLZvXrjdfC1O01UGTquUbdpgVVJvazljWRgnW7hRLKxKg==",
+            "version": "1.2.175",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.2.175.tgz",
+            "integrity": "sha512-TjJDnycH0rTY9DIowLVEP+X8Ll6P60LbUzd+yGq9UV9uGv7kB65Kf7LSLteYXDLHP34JPqyqh6O7GeGB4jiEEw==",
             "dev": true,
             "optional": true
         },
         "@swc/core-linux-arm64-musl": {
-            "version": "1.2.148",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.2.148.tgz",
-            "integrity": "sha512-RoTgNIYC3/qiqOKEIFxL2cc8DNnaHd0vp1r/9oS1EWPqnie/mTdrL7LdHQlvgPkOnguGW2BnceTpEfL4G9bLQQ==",
+            "version": "1.2.175",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.2.175.tgz",
+            "integrity": "sha512-FH/yetoJPKBJHGYsu5iBMU382TEXZWhCToJA5iYqXcjye9WqR5Ss2qA2bQtikWGxFNKeNv8yCfGfesUpg7Edzg==",
             "dev": true,
             "optional": true
         },
         "@swc/core-linux-x64-gnu": {
-            "version": "1.2.148",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.2.148.tgz",
-            "integrity": "sha512-TaePcQUtDrPo6bL4f+mKnSkgEsUXjNLcWUawZTD/DaHI2/VQMpkiqyaQTYcObq/QcDma4ude5Jsl4Gt8KtW/Dg==",
+            "version": "1.2.175",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.2.175.tgz",
+            "integrity": "sha512-vdFFRpayifouqu9T+UPuWrxfERABaBDkB+CxUNrWgxE+iOJZCCPl6eFyWEqkVhjPnlmD2aHaVtzeyweIewEh4w==",
             "dev": true,
             "optional": true
         },
         "@swc/core-linux-x64-musl": {
-            "version": "1.2.148",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.2.148.tgz",
-            "integrity": "sha512-8YtF2HNBJtAe+RCyQEE5igrSGxGazYCOAS2HEgT84FTYpr1K7XjCNjhBp4Hk93gzrijWBnEtC9k+fEQlaRE+XQ==",
+            "version": "1.2.175",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.2.175.tgz",
+            "integrity": "sha512-eNgC//N7IJ40HQjSKhi7xPh7mMmK9ks9KAXzVbs+BTXvEXZV/L8753uC6B19FY9UEs27e6sXUG60kEoqtCfH5w==",
             "dev": true,
             "optional": true
         },
         "@swc/core-win32-arm64-msvc": {
-            "version": "1.2.148",
-            "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.2.148.tgz",
-            "integrity": "sha512-rEGjkO6SdyrxbP7EfA9lbCKWclhHKKeLehDtAU0aHoscjiPfc18rEGe+2rEbWE2Vw3HsMxkmg+Qp93/2gSsKOQ==",
+            "version": "1.2.175",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.2.175.tgz",
+            "integrity": "sha512-eOrRfB7eRFMmXBqQ4J50hN4Xu8PsaV4G51oUuhnYZFR5hVnzEjVYHWPCCNxq5DEwBIXDGUa5JbJ0y1e05wLQyw==",
             "dev": true,
             "optional": true
         },
         "@swc/core-win32-ia32-msvc": {
-            "version": "1.2.148",
-            "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.2.148.tgz",
-            "integrity": "sha512-AFpE/FIwSzjT/lpJp405yc+xXUVn88lHxrwzDiAUvAeIXS6kk5xots7ymIWbu7J8k5ROAWAwSVhi7C+fUxa8Pg==",
+            "version": "1.2.175",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.2.175.tgz",
+            "integrity": "sha512-Zr7mdjGiJLWv0a4eczfb8gPSLjrAy/MZWwWUY1gDnA8GeWP9dE/tiqnrMNg4bqXuuZmqLBPEC3hybRuQuWtzBA==",
             "dev": true,
             "optional": true
         },
         "@swc/core-win32-x64-msvc": {
-            "version": "1.2.148",
-            "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.2.148.tgz",
-            "integrity": "sha512-BAKfOXvPTGLo8K8+BheDqyIZHUFdbtw/7wBHhBBIDJK/D4et1dg886uyP1A0Qib2L/jtYMD/XcyRaTEw3VAW7A==",
+            "version": "1.2.175",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.2.175.tgz",
+            "integrity": "sha512-Vx1AwLcbqjEkEhtRmCIdU3SoDp9Mi+fJv0mLgQ33SsZG1QPkTfn4bq4Vu9wJE+D0Em7lPmRiZpdsvx0G7oBH5A==",
             "dev": true,
             "optional": true
         },
@@ -3530,9 +3666,9 @@
             }
         },
         "@testing-library/jest-dom": {
-            "version": "5.16.2",
-            "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.16.2.tgz",
-            "integrity": "sha512-6ewxs1MXWwsBFZXIk4nKKskWANelkdUehchEOokHsN8X7c2eKXGw+77aRV63UU8f/DTSVUPLaGxdrj4lN7D/ug==",
+            "version": "5.16.4",
+            "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.16.4.tgz",
+            "integrity": "sha512-Gy+IoFutbMQcky0k+bqqumXZ1cTGswLsFqmNLzNdSKkU9KGV2u9oXhukCbbJ9/LRPKiqwxEE8VpV/+YZlfkPUA==",
             "dev": true,
             "requires": {
                 "@babel/runtime": "^7.9.2",
@@ -3599,9 +3735,9 @@
             "dev": true
         },
         "@types/adm-zip": {
-            "version": "0.4.34",
-            "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.4.34.tgz",
-            "integrity": "sha512-8ToYLLAYhkRfcmmljrKi22gT2pqu7hGMDtORP1emwIEGmgUTZOsaDjzWFzW5N2frcFRz/50CWt4zA1CxJ73pmQ==",
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.0.tgz",
+            "integrity": "sha512-FCJBJq9ODsQZUNURo5ILAQueuA8WJhRvuihS3ke2iI25mJlfV2LK8jG2Qj2z2AWg8U0FtWWqBHVRetceLskSaw==",
             "dev": true,
             "requires": {
                 "@types/node": "*"
@@ -3751,9 +3887,9 @@
             }
         },
         "@types/jest": {
-            "version": "27.4.1",
-            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.4.1.tgz",
-            "integrity": "sha512-23iPJADSmicDVrWk+HT58LMJtzLAnB2AgIzplQuq/bSrGaxCrlvRFjGbXmamnnk/mAmCdLStiGqggu28ocUyiw==",
+            "version": "27.5.0",
+            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.5.0.tgz",
+            "integrity": "sha512-9RBFx7r4k+msyj/arpfaa0WOOEcaAZNmN+j80KFbFCoSqCJGHTz7YMAMGQW9Xmqm5w6l5c25vbSjMwlikJi5+g==",
             "dev": true,
             "requires": {
                 "jest-matcher-utils": "^27.0.0",
@@ -3865,18 +4001,18 @@
             }
         },
         "@types/react-dom": {
-            "version": "17.0.13",
-            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.13.tgz",
-            "integrity": "sha512-wEP+B8hzvy6ORDv1QBhcQia4j6ea4SFIBttHYpXKPFZRviBvknq0FRh3VrIxeXUmsPkwuXVZrVGG7KUVONmXCQ==",
+            "version": "17.0.16",
+            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.16.tgz",
+            "integrity": "sha512-DWcXf8EbMrO/gWnQU7Z88Ws/p16qxGpPyjTKTpmBSFKeE+HveVubqGO1CVK7FrwlWD5MuOcvh8gtd0/XO38NdQ==",
             "dev": true,
             "requires": {
-                "@types/react": "*"
+                "@types/react": "^17"
             }
         },
         "@types/react-redux": {
-            "version": "7.1.23",
-            "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.23.tgz",
-            "integrity": "sha512-D02o3FPfqQlfu2WeEYwh3x2otYd2Dk1o8wAfsA0B1C2AJEFxE663Ozu7JzuWbznGgW248NaOF6wsqCGNq9d3qw==",
+            "version": "7.1.24",
+            "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.24.tgz",
+            "integrity": "sha512-7FkurKcS1k0FHZEtdbbgN8Oc6b+stGSfZYjQGicofJ0j4U0qIn/jaSvnP2pLwZKiai3/17xqqxkkrxTgN8UNbQ==",
             "dev": true,
             "requires": {
                 "@types/hoist-non-react-statics": "^3.3.0",
@@ -3992,14 +4128,14 @@
             }
         },
         "@typescript-eslint/eslint-plugin": {
-            "version": "5.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.14.0.tgz",
-            "integrity": "sha512-ir0wYI4FfFUDfLcuwKzIH7sMVA+db7WYen47iRSaCGl+HMAZI9fpBwfDo45ZALD3A45ZGyHWDNLhbg8tZrMX4w==",
+            "version": "5.22.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.22.0.tgz",
+            "integrity": "sha512-YCiy5PUzpAeOPGQ7VSGDEY2NeYUV1B0swde2e0HzokRsHBYjSdF6DZ51OuRZxVPHx0032lXGLvOMls91D8FXlg==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/scope-manager": "5.14.0",
-                "@typescript-eslint/type-utils": "5.14.0",
-                "@typescript-eslint/utils": "5.14.0",
+                "@typescript-eslint/scope-manager": "5.22.0",
+                "@typescript-eslint/type-utils": "5.22.0",
+                "@typescript-eslint/utils": "5.22.0",
                 "debug": "^4.3.2",
                 "functional-red-black-tree": "^1.0.1",
                 "ignore": "^5.1.8",
@@ -4020,52 +4156,52 @@
             }
         },
         "@typescript-eslint/parser": {
-            "version": "5.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.14.0.tgz",
-            "integrity": "sha512-aHJN8/FuIy1Zvqk4U/gcO/fxeMKyoSv/rS46UXMXOJKVsLQ+iYPuXNbpbH7cBLcpSbmyyFbwrniLx5+kutu1pw==",
+            "version": "5.22.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.22.0.tgz",
+            "integrity": "sha512-piwC4krUpRDqPaPbFaycN70KCP87+PC5WZmrWs+DlVOxxmF+zI6b6hETv7Quy4s9wbkV16ikMeZgXsvzwI3icQ==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/scope-manager": "5.14.0",
-                "@typescript-eslint/types": "5.14.0",
-                "@typescript-eslint/typescript-estree": "5.14.0",
+                "@typescript-eslint/scope-manager": "5.22.0",
+                "@typescript-eslint/types": "5.22.0",
+                "@typescript-eslint/typescript-estree": "5.22.0",
                 "debug": "^4.3.2"
             }
         },
         "@typescript-eslint/scope-manager": {
-            "version": "5.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.14.0.tgz",
-            "integrity": "sha512-LazdcMlGnv+xUc5R4qIlqH0OWARyl2kaP8pVCS39qSL3Pd1F7mI10DbdXeARcE62sVQE4fHNvEqMWsypWO+yEw==",
+            "version": "5.22.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.22.0.tgz",
+            "integrity": "sha512-yA9G5NJgV5esANJCO0oF15MkBO20mIskbZ8ijfmlKIvQKg0ynVKfHZ15/nhAJN5m8Jn3X5qkwriQCiUntC9AbA==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "5.14.0",
-                "@typescript-eslint/visitor-keys": "5.14.0"
+                "@typescript-eslint/types": "5.22.0",
+                "@typescript-eslint/visitor-keys": "5.22.0"
             }
         },
         "@typescript-eslint/type-utils": {
-            "version": "5.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.14.0.tgz",
-            "integrity": "sha512-d4PTJxsqaUpv8iERTDSQBKUCV7Q5yyXjqXUl3XF7Sd9ogNLuKLkxz82qxokqQ4jXdTPZudWpmNtr/JjbbvUixw==",
+            "version": "5.22.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.22.0.tgz",
+            "integrity": "sha512-iqfLZIsZhK2OEJ4cQ01xOq3NaCuG5FQRKyHicA3xhZxMgaxQazLUHbH/B2k9y5i7l3+o+B5ND9Mf1AWETeMISA==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/utils": "5.14.0",
+                "@typescript-eslint/utils": "5.22.0",
                 "debug": "^4.3.2",
                 "tsutils": "^3.21.0"
             }
         },
         "@typescript-eslint/types": {
-            "version": "5.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.14.0.tgz",
-            "integrity": "sha512-BR6Y9eE9360LNnW3eEUqAg6HxS9Q35kSIs4rp4vNHRdfg0s+/PgHgskvu5DFTM7G5VKAVjuyaN476LCPrdA7Mw==",
+            "version": "5.22.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.22.0.tgz",
+            "integrity": "sha512-T7owcXW4l0v7NTijmjGWwWf/1JqdlWiBzPqzAWhobxft0SiEvMJB56QXmeCQjrPuM8zEfGUKyPQr/L8+cFUBLw==",
             "dev": true
         },
         "@typescript-eslint/typescript-estree": {
-            "version": "5.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.14.0.tgz",
-            "integrity": "sha512-QGnxvROrCVtLQ1724GLTHBTR0lZVu13izOp9njRvMkCBgWX26PKvmMP8k82nmXBRD3DQcFFq2oj3cKDwr0FaUA==",
+            "version": "5.22.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.22.0.tgz",
+            "integrity": "sha512-EyBEQxvNjg80yinGE2xdhpDYm41so/1kOItl0qrjIiJ1kX/L/L8WWGmJg8ni6eG3DwqmOzDqOhe6763bF92nOw==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "5.14.0",
-                "@typescript-eslint/visitor-keys": "5.14.0",
+                "@typescript-eslint/types": "5.22.0",
+                "@typescript-eslint/visitor-keys": "5.22.0",
                 "debug": "^4.3.2",
                 "globby": "^11.0.4",
                 "is-glob": "^4.0.3",
@@ -4085,26 +4221,26 @@
             }
         },
         "@typescript-eslint/utils": {
-            "version": "5.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.14.0.tgz",
-            "integrity": "sha512-EHwlII5mvUA0UsKYnVzySb/5EE/t03duUTweVy8Zqt3UQXBrpEVY144OTceFKaOe4xQXZJrkptCf7PjEBeGK4w==",
+            "version": "5.22.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.22.0.tgz",
+            "integrity": "sha512-HodsGb037iobrWSUMS7QH6Hl1kppikjA1ELiJlNSTYf/UdMEwzgj0WIp+lBNb6WZ3zTwb0tEz51j0Wee3iJ3wQ==",
             "dev": true,
             "requires": {
                 "@types/json-schema": "^7.0.9",
-                "@typescript-eslint/scope-manager": "5.14.0",
-                "@typescript-eslint/types": "5.14.0",
-                "@typescript-eslint/typescript-estree": "5.14.0",
+                "@typescript-eslint/scope-manager": "5.22.0",
+                "@typescript-eslint/types": "5.22.0",
+                "@typescript-eslint/typescript-estree": "5.22.0",
                 "eslint-scope": "^5.1.1",
                 "eslint-utils": "^3.0.0"
             }
         },
         "@typescript-eslint/visitor-keys": {
-            "version": "5.14.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.14.0.tgz",
-            "integrity": "sha512-yL0XxfzR94UEkjBqyymMLgCBdojzEuy/eim7N9/RIcTNxpJudAcqsU8eRyfzBbcEzGoPWfdM3AGak3cN08WOIw==",
+            "version": "5.22.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.22.0.tgz",
+            "integrity": "sha512-DbgTqn2Dv5RFWluG88tn0pP6Ex0ROF+dpDO1TNNZdRtLjUr6bdznjA6f/qNqJLjd2PgguAES2Zgxh/JzwzETDg==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "5.14.0",
+                "@typescript-eslint/types": "5.22.0",
                 "eslint-visitor-keys": "^3.0.0"
             }
         },
@@ -4328,9 +4464,9 @@
             "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
         },
         "acorn": {
-            "version": "7.4.1",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
-            "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+            "version": "8.7.1",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
+            "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
             "dev": true
         },
         "acorn-globals": {
@@ -4341,6 +4477,14 @@
             "requires": {
                 "acorn": "^7.1.1",
                 "acorn-walk": "^7.1.1"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "7.4.1",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+                    "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+                    "dev": true
+                }
             }
         },
         "acorn-jsx": {
@@ -4492,12 +4636,6 @@
                     }
                 }
             }
-        },
-        "ansi-colors": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
-            "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
-            "dev": true
         },
         "ansi-escapes": {
             "version": "4.3.2",
@@ -4749,30 +4887,42 @@
             "dev": true
         },
         "array-includes": {
-            "version": "3.1.4",
-            "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.4.tgz",
-            "integrity": "sha512-ZTNSQkmWumEbiHO2GF4GmWxYVTiQyJy2XOTa15sdQSrvKn7l+180egQMqlrMOUMCyLMD7pmyQe4mMDUT6Behrw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.5.tgz",
+            "integrity": "sha512-iSDYZMMyTPkiFasVqfuAQnWAYcvO/SeBSCGKePoEthjp4LEMTe4uLc7b025o4jAZpHhihh8xPo99TNWUWWkGDQ==",
             "dev": true,
             "requires": {
                 "call-bind": "^1.0.2",
-                "define-properties": "^1.1.3",
-                "es-abstract": "^1.19.1",
+                "define-properties": "^1.1.4",
+                "es-abstract": "^1.19.5",
                 "get-intrinsic": "^1.1.1",
                 "is-string": "^1.0.7"
             },
             "dependencies": {
+                "define-properties": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+                    "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+                    "dev": true,
+                    "requires": {
+                        "has-property-descriptors": "^1.0.0",
+                        "object-keys": "^1.1.1"
+                    }
+                },
                 "es-abstract": {
-                    "version": "1.19.5",
-                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.5.tgz",
-                    "integrity": "sha512-Aa2G2+Rd3b6kxEUKTF4TaW67czBLyAv3z7VOhYRU50YBx+bbsYZ9xQP4lMNazePuFlybXI0V4MruPos7qUo5fA==",
+                    "version": "1.20.0",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.0.tgz",
+                    "integrity": "sha512-URbD8tgRthKD3YcC39vbvSDrX23upXnPcnGAjQfgxXF5ID75YcENawc9ZX/9iTP9ptUyfCLIxTTuMYoRfiOVKA==",
                     "dev": true,
                     "requires": {
                         "call-bind": "^1.0.2",
                         "es-to-primitive": "^1.2.1",
                         "function-bind": "^1.1.1",
+                        "function.prototype.name": "^1.1.5",
                         "get-intrinsic": "^1.1.1",
                         "get-symbol-description": "^1.0.0",
                         "has": "^1.0.3",
+                        "has-property-descriptors": "^1.0.0",
                         "has-symbols": "^1.0.3",
                         "internal-slot": "^1.0.3",
                         "is-callable": "^1.2.4",
@@ -4784,10 +4934,17 @@
                         "object-inspect": "^1.12.0",
                         "object-keys": "^1.1.1",
                         "object.assign": "^4.1.2",
-                        "string.prototype.trimend": "^1.0.4",
-                        "string.prototype.trimstart": "^1.0.4",
-                        "unbox-primitive": "^1.0.1"
+                        "regexp.prototype.flags": "^1.4.1",
+                        "string.prototype.trimend": "^1.0.5",
+                        "string.prototype.trimstart": "^1.0.5",
+                        "unbox-primitive": "^1.0.2"
                     }
+                },
+                "has-bigints": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+                    "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+                    "dev": true
                 },
                 "has-symbols": {
                     "version": "1.0.3",
@@ -4806,6 +4963,40 @@
                     "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
                     "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
                     "dev": true
+                },
+                "string.prototype.trimend": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
+                    "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.2",
+                        "define-properties": "^1.1.4",
+                        "es-abstract": "^1.19.5"
+                    }
+                },
+                "string.prototype.trimstart": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
+                    "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.2",
+                        "define-properties": "^1.1.4",
+                        "es-abstract": "^1.19.5"
+                    }
+                },
+                "unbox-primitive": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+                    "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.2",
+                        "has-bigints": "^1.0.2",
+                        "has-symbols": "^1.0.3",
+                        "which-boxed-primitive": "^1.0.2"
+                    }
                 }
             }
         },
@@ -4859,17 +5050,19 @@
             },
             "dependencies": {
                 "es-abstract": {
-                    "version": "1.19.5",
-                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.5.tgz",
-                    "integrity": "sha512-Aa2G2+Rd3b6kxEUKTF4TaW67czBLyAv3z7VOhYRU50YBx+bbsYZ9xQP4lMNazePuFlybXI0V4MruPos7qUo5fA==",
+                    "version": "1.20.0",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.0.tgz",
+                    "integrity": "sha512-URbD8tgRthKD3YcC39vbvSDrX23upXnPcnGAjQfgxXF5ID75YcENawc9ZX/9iTP9ptUyfCLIxTTuMYoRfiOVKA==",
                     "dev": true,
                     "requires": {
                         "call-bind": "^1.0.2",
                         "es-to-primitive": "^1.2.1",
                         "function-bind": "^1.1.1",
+                        "function.prototype.name": "^1.1.5",
                         "get-intrinsic": "^1.1.1",
                         "get-symbol-description": "^1.0.0",
                         "has": "^1.0.3",
+                        "has-property-descriptors": "^1.0.0",
                         "has-symbols": "^1.0.3",
                         "internal-slot": "^1.0.3",
                         "is-callable": "^1.2.4",
@@ -4881,10 +5074,17 @@
                         "object-inspect": "^1.12.0",
                         "object-keys": "^1.1.1",
                         "object.assign": "^4.1.2",
-                        "string.prototype.trimend": "^1.0.4",
-                        "string.prototype.trimstart": "^1.0.4",
-                        "unbox-primitive": "^1.0.1"
+                        "regexp.prototype.flags": "^1.4.1",
+                        "string.prototype.trimend": "^1.0.5",
+                        "string.prototype.trimstart": "^1.0.5",
+                        "unbox-primitive": "^1.0.2"
                     }
+                },
+                "has-bigints": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+                    "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+                    "dev": true
                 },
                 "has-symbols": {
                     "version": "1.0.3",
@@ -4903,6 +5103,64 @@
                     "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
                     "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
                     "dev": true
+                },
+                "string.prototype.trimend": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
+                    "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.2",
+                        "define-properties": "^1.1.4",
+                        "es-abstract": "^1.19.5"
+                    },
+                    "dependencies": {
+                        "define-properties": {
+                            "version": "1.1.4",
+                            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+                            "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+                            "dev": true,
+                            "requires": {
+                                "has-property-descriptors": "^1.0.0",
+                                "object-keys": "^1.1.1"
+                            }
+                        }
+                    }
+                },
+                "string.prototype.trimstart": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
+                    "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.2",
+                        "define-properties": "^1.1.4",
+                        "es-abstract": "^1.19.5"
+                    },
+                    "dependencies": {
+                        "define-properties": {
+                            "version": "1.1.4",
+                            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+                            "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+                            "dev": true,
+                            "requires": {
+                                "has-property-descriptors": "^1.0.0",
+                                "object-keys": "^1.1.1"
+                            }
+                        }
+                    }
+                },
+                "unbox-primitive": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+                    "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.2",
+                        "has-bigints": "^1.0.2",
+                        "has-symbols": "^1.0.3",
+                        "which-boxed-primitive": "^1.0.2"
+                    }
                 }
             }
         },
@@ -4919,17 +5177,19 @@
             },
             "dependencies": {
                 "es-abstract": {
-                    "version": "1.19.5",
-                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.5.tgz",
-                    "integrity": "sha512-Aa2G2+Rd3b6kxEUKTF4TaW67czBLyAv3z7VOhYRU50YBx+bbsYZ9xQP4lMNazePuFlybXI0V4MruPos7qUo5fA==",
+                    "version": "1.20.0",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.0.tgz",
+                    "integrity": "sha512-URbD8tgRthKD3YcC39vbvSDrX23upXnPcnGAjQfgxXF5ID75YcENawc9ZX/9iTP9ptUyfCLIxTTuMYoRfiOVKA==",
                     "dev": true,
                     "requires": {
                         "call-bind": "^1.0.2",
                         "es-to-primitive": "^1.2.1",
                         "function-bind": "^1.1.1",
+                        "function.prototype.name": "^1.1.5",
                         "get-intrinsic": "^1.1.1",
                         "get-symbol-description": "^1.0.0",
                         "has": "^1.0.3",
+                        "has-property-descriptors": "^1.0.0",
                         "has-symbols": "^1.0.3",
                         "internal-slot": "^1.0.3",
                         "is-callable": "^1.2.4",
@@ -4941,10 +5201,17 @@
                         "object-inspect": "^1.12.0",
                         "object-keys": "^1.1.1",
                         "object.assign": "^4.1.2",
-                        "string.prototype.trimend": "^1.0.4",
-                        "string.prototype.trimstart": "^1.0.4",
-                        "unbox-primitive": "^1.0.1"
+                        "regexp.prototype.flags": "^1.4.1",
+                        "string.prototype.trimend": "^1.0.5",
+                        "string.prototype.trimstart": "^1.0.5",
+                        "unbox-primitive": "^1.0.2"
                     }
+                },
+                "has-bigints": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+                    "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+                    "dev": true
                 },
                 "has-symbols": {
                     "version": "1.0.3",
@@ -4963,6 +5230,64 @@
                     "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
                     "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
                     "dev": true
+                },
+                "string.prototype.trimend": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
+                    "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.2",
+                        "define-properties": "^1.1.4",
+                        "es-abstract": "^1.19.5"
+                    },
+                    "dependencies": {
+                        "define-properties": {
+                            "version": "1.1.4",
+                            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+                            "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+                            "dev": true,
+                            "requires": {
+                                "has-property-descriptors": "^1.0.0",
+                                "object-keys": "^1.1.1"
+                            }
+                        }
+                    }
+                },
+                "string.prototype.trimstart": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
+                    "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.2",
+                        "define-properties": "^1.1.4",
+                        "es-abstract": "^1.19.5"
+                    },
+                    "dependencies": {
+                        "define-properties": {
+                            "version": "1.1.4",
+                            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+                            "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+                            "dev": true,
+                            "requires": {
+                                "has-property-descriptors": "^1.0.0",
+                                "object-keys": "^1.1.1"
+                            }
+                        }
+                    }
+                },
+                "unbox-primitive": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+                    "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.2",
+                        "has-bigints": "^1.0.2",
+                        "has-symbols": "^1.0.3",
+                        "which-boxed-primitive": "^1.0.2"
+                    }
                 }
             }
         },
@@ -4979,17 +5304,19 @@
             },
             "dependencies": {
                 "es-abstract": {
-                    "version": "1.19.5",
-                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.5.tgz",
-                    "integrity": "sha512-Aa2G2+Rd3b6kxEUKTF4TaW67czBLyAv3z7VOhYRU50YBx+bbsYZ9xQP4lMNazePuFlybXI0V4MruPos7qUo5fA==",
+                    "version": "1.20.0",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.0.tgz",
+                    "integrity": "sha512-URbD8tgRthKD3YcC39vbvSDrX23upXnPcnGAjQfgxXF5ID75YcENawc9ZX/9iTP9ptUyfCLIxTTuMYoRfiOVKA==",
                     "dev": true,
                     "requires": {
                         "call-bind": "^1.0.2",
                         "es-to-primitive": "^1.2.1",
                         "function-bind": "^1.1.1",
+                        "function.prototype.name": "^1.1.5",
                         "get-intrinsic": "^1.1.1",
                         "get-symbol-description": "^1.0.0",
                         "has": "^1.0.3",
+                        "has-property-descriptors": "^1.0.0",
                         "has-symbols": "^1.0.3",
                         "internal-slot": "^1.0.3",
                         "is-callable": "^1.2.4",
@@ -5001,10 +5328,17 @@
                         "object-inspect": "^1.12.0",
                         "object-keys": "^1.1.1",
                         "object.assign": "^4.1.2",
-                        "string.prototype.trimend": "^1.0.4",
-                        "string.prototype.trimstart": "^1.0.4",
-                        "unbox-primitive": "^1.0.1"
+                        "regexp.prototype.flags": "^1.4.1",
+                        "string.prototype.trimend": "^1.0.5",
+                        "string.prototype.trimstart": "^1.0.5",
+                        "unbox-primitive": "^1.0.2"
                     }
+                },
+                "has-bigints": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+                    "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+                    "dev": true
                 },
                 "has-symbols": {
                     "version": "1.0.3",
@@ -5023,6 +5357,64 @@
                     "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
                     "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
                     "dev": true
+                },
+                "string.prototype.trimend": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
+                    "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.2",
+                        "define-properties": "^1.1.4",
+                        "es-abstract": "^1.19.5"
+                    },
+                    "dependencies": {
+                        "define-properties": {
+                            "version": "1.1.4",
+                            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+                            "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+                            "dev": true,
+                            "requires": {
+                                "has-property-descriptors": "^1.0.0",
+                                "object-keys": "^1.1.1"
+                            }
+                        }
+                    }
+                },
+                "string.prototype.trimstart": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
+                    "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.2",
+                        "define-properties": "^1.1.4",
+                        "es-abstract": "^1.19.5"
+                    },
+                    "dependencies": {
+                        "define-properties": {
+                            "version": "1.1.4",
+                            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+                            "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+                            "dev": true,
+                            "requires": {
+                                "has-property-descriptors": "^1.0.0",
+                                "object-keys": "^1.1.1"
+                            }
+                        }
+                    }
+                },
+                "unbox-primitive": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+                    "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.2",
+                        "has-bigints": "^1.0.2",
+                        "has-symbols": "^1.0.3",
+                        "which-boxed-primitive": "^1.0.2"
+                    }
                 }
             }
         },
@@ -5039,17 +5431,19 @@
             },
             "dependencies": {
                 "es-abstract": {
-                    "version": "1.19.5",
-                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.5.tgz",
-                    "integrity": "sha512-Aa2G2+Rd3b6kxEUKTF4TaW67czBLyAv3z7VOhYRU50YBx+bbsYZ9xQP4lMNazePuFlybXI0V4MruPos7qUo5fA==",
+                    "version": "1.20.0",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.0.tgz",
+                    "integrity": "sha512-URbD8tgRthKD3YcC39vbvSDrX23upXnPcnGAjQfgxXF5ID75YcENawc9ZX/9iTP9ptUyfCLIxTTuMYoRfiOVKA==",
                     "dev": true,
                     "requires": {
                         "call-bind": "^1.0.2",
                         "es-to-primitive": "^1.2.1",
                         "function-bind": "^1.1.1",
+                        "function.prototype.name": "^1.1.5",
                         "get-intrinsic": "^1.1.1",
                         "get-symbol-description": "^1.0.0",
                         "has": "^1.0.3",
+                        "has-property-descriptors": "^1.0.0",
                         "has-symbols": "^1.0.3",
                         "internal-slot": "^1.0.3",
                         "is-callable": "^1.2.4",
@@ -5061,10 +5455,17 @@
                         "object-inspect": "^1.12.0",
                         "object-keys": "^1.1.1",
                         "object.assign": "^4.1.2",
-                        "string.prototype.trimend": "^1.0.4",
-                        "string.prototype.trimstart": "^1.0.4",
-                        "unbox-primitive": "^1.0.1"
+                        "regexp.prototype.flags": "^1.4.1",
+                        "string.prototype.trimend": "^1.0.5",
+                        "string.prototype.trimstart": "^1.0.5",
+                        "unbox-primitive": "^1.0.2"
                     }
+                },
+                "has-bigints": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+                    "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+                    "dev": true
                 },
                 "has-symbols": {
                     "version": "1.0.3",
@@ -5083,6 +5484,64 @@
                     "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
                     "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
                     "dev": true
+                },
+                "string.prototype.trimend": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
+                    "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.2",
+                        "define-properties": "^1.1.4",
+                        "es-abstract": "^1.19.5"
+                    },
+                    "dependencies": {
+                        "define-properties": {
+                            "version": "1.1.4",
+                            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+                            "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+                            "dev": true,
+                            "requires": {
+                                "has-property-descriptors": "^1.0.0",
+                                "object-keys": "^1.1.1"
+                            }
+                        }
+                    }
+                },
+                "string.prototype.trimstart": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
+                    "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.2",
+                        "define-properties": "^1.1.4",
+                        "es-abstract": "^1.19.5"
+                    },
+                    "dependencies": {
+                        "define-properties": {
+                            "version": "1.1.4",
+                            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+                            "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+                            "dev": true,
+                            "requires": {
+                                "has-property-descriptors": "^1.0.0",
+                                "object-keys": "^1.1.1"
+                            }
+                        }
+                    }
+                },
+                "unbox-primitive": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+                    "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.2",
+                        "has-bigints": "^1.0.2",
+                        "has-symbols": "^1.0.3",
+                        "which-boxed-primitive": "^1.0.2"
+                    }
                 }
             }
         },
@@ -5185,9 +5644,9 @@
             "dev": true
         },
         "astral-regex": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
-            "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+            "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
             "dev": true
         },
         "async": {
@@ -5329,17 +5788,28 @@
             }
         },
         "babel-loader": {
-            "version": "8.2.3",
-            "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.2.3.tgz",
-            "integrity": "sha512-n4Zeta8NC3QAsuyiizu0GkmRcQ6clkV9WFUnUf1iXP//IeSKbWjofW3UHyZVwlOB4y039YQKefawyTn64Zwbuw==",
+            "version": "8.2.5",
+            "resolved": "https://registry.npmjs.org/babel-loader/-/babel-loader-8.2.5.tgz",
+            "integrity": "sha512-OSiFfH89LrEMiWd4pLNqGz4CwJDtbs2ZVc+iGu2HrkRfPxId9F2anQj38IxWpmRfsUY0aBZYi1EFcd3mhtRMLQ==",
             "dev": true,
             "requires": {
                 "find-cache-dir": "^3.3.1",
-                "loader-utils": "^1.4.0",
+                "loader-utils": "^2.0.0",
                 "make-dir": "^3.1.0",
                 "schema-utils": "^2.6.5"
             },
             "dependencies": {
+                "loader-utils": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
+                    "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+                    "dev": true,
+                    "requires": {
+                        "big.js": "^5.2.2",
+                        "emojis-list": "^3.0.0",
+                        "json5": "^2.1.2"
+                    }
+                },
                 "schema-utils": {
                     "version": "2.7.1",
                     "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.1.tgz",
@@ -7154,9 +7624,9 @@
             "dev": true
         },
         "core-js-compat": {
-            "version": "3.22.3",
-            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.22.3.tgz",
-            "integrity": "sha512-wliMbvPI2idgFWpFe7UEyHMvu6HWgW8WA+HnDRtgzoSDYvXFMpoGX1H3tPDDXrcfUSyXafCLDd7hOeMQHEZxGw==",
+            "version": "3.22.4",
+            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.22.4.tgz",
+            "integrity": "sha512-dIWcsszDezkFZrfm1cnB4f/J85gyhiCpxbgBdohWCDtSVuAaChTSpPV7ldOQf/Xds2U5xCIJZOK82G4ZPAIswA==",
             "dev": true,
             "requires": {
                 "browserslist": "^4.20.3",
@@ -7177,15 +7647,15 @@
                     }
                 },
                 "caniuse-lite": {
-                    "version": "1.0.30001335",
-                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001335.tgz",
-                    "integrity": "sha512-ddP1Tgm7z2iIxu6QTtbZUv6HJxSaV/PZeSrWFZtbY4JZ69tOeNhBCl3HyRQgeNZKE5AOn1kpV7fhljigy0Ty3w==",
+                    "version": "1.0.30001338",
+                    "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001338.tgz",
+                    "integrity": "sha512-1gLHWyfVoRDsHieO+CaeYe7jSo/MT7D7lhaXUiwwbuR5BwQxORs0f1tAwUSQr3YbxRXJvxHM/PA5FfPQRnsPeQ==",
                     "dev": true
                 },
                 "electron-to-chromium": {
-                    "version": "1.4.129",
-                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.129.tgz",
-                    "integrity": "sha512-GgtN6bsDtHdtXJtlMYZWGB/uOyjZWjmRDumXTas7dGBaB9zUyCjzHet1DY2KhyHN8R0GLbzZWqm4efeddqqyRQ==",
+                    "version": "1.4.136",
+                    "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.136.tgz",
+                    "integrity": "sha512-GnITX8rHnUrIVnTxU9UlsTnSemHUA2iF+6QrRqxFbp/mf0vfuSc/goEyyQhUX3TUUCE3mv/4BNuXOtaJ4ur0eA==",
                     "dev": true
                 },
                 "node-releases": {
@@ -7203,9 +7673,9 @@
             }
         },
         "core-js-pure": {
-            "version": "3.22.3",
-            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.22.3.tgz",
-            "integrity": "sha512-oN88zz7nmKROMy8GOjs+LN+0LedIvbMdnB5XsTlhcOg1WGARt9l0LFg0zohdoFmCsEZ1h2ZbSQ6azj3M+vhzwQ==",
+            "version": "3.22.4",
+            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.22.4.tgz",
+            "integrity": "sha512-4iF+QZkpzIz0prAFuepmxwJ2h5t4agvE8WPYqs2mjLJMNNwJOnpch76w2Q7bUfCPEv/V7wpvOfog0w273M+ZSw==",
             "dev": true
         },
         "core-util-is": {
@@ -8675,15 +9145,6 @@
                 }
             }
         },
-        "enquirer": {
-            "version": "2.3.6",
-            "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
-            "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
-            "dev": true,
-            "requires": {
-                "ansi-colors": "^4.1.1"
-            }
-        },
         "entities": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
@@ -8972,90 +9433,84 @@
             }
         },
         "eslint": {
-            "version": "7.32.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
-            "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
+            "version": "8.14.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.14.0.tgz",
+            "integrity": "sha512-3/CE4aJX7LNEiE3i6FeodHmI/38GZtWCsAtsymScmzYapx8q1nVVb+eLcLSzATmCPXw5pT4TqVs1E0OmxAd9tw==",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "7.12.11",
-                "@eslint/eslintrc": "^0.4.3",
-                "@humanwhocodes/config-array": "^0.5.0",
+                "@eslint/eslintrc": "^1.2.2",
+                "@humanwhocodes/config-array": "^0.9.2",
                 "ajv": "^6.10.0",
                 "chalk": "^4.0.0",
                 "cross-spawn": "^7.0.2",
-                "debug": "^4.0.1",
+                "debug": "^4.3.2",
                 "doctrine": "^3.0.0",
-                "enquirer": "^2.3.5",
                 "escape-string-regexp": "^4.0.0",
-                "eslint-scope": "^5.1.1",
-                "eslint-utils": "^2.1.0",
-                "eslint-visitor-keys": "^2.0.0",
-                "espree": "^7.3.1",
+                "eslint-scope": "^7.1.1",
+                "eslint-utils": "^3.0.0",
+                "eslint-visitor-keys": "^3.3.0",
+                "espree": "^9.3.1",
                 "esquery": "^1.4.0",
                 "esutils": "^2.0.2",
                 "fast-deep-equal": "^3.1.3",
                 "file-entry-cache": "^6.0.1",
                 "functional-red-black-tree": "^1.0.1",
-                "glob-parent": "^5.1.2",
+                "glob-parent": "^6.0.1",
                 "globals": "^13.6.0",
-                "ignore": "^4.0.6",
+                "ignore": "^5.2.0",
                 "import-fresh": "^3.0.0",
                 "imurmurhash": "^0.1.4",
                 "is-glob": "^4.0.0",
-                "js-yaml": "^3.13.1",
+                "js-yaml": "^4.1.0",
                 "json-stable-stringify-without-jsonify": "^1.0.1",
                 "levn": "^0.4.1",
                 "lodash.merge": "^4.6.2",
                 "minimatch": "^3.0.4",
                 "natural-compare": "^1.4.0",
                 "optionator": "^0.9.1",
-                "progress": "^2.0.0",
-                "regexpp": "^3.1.0",
-                "semver": "^7.2.1",
-                "strip-ansi": "^6.0.0",
+                "regexpp": "^3.2.0",
+                "strip-ansi": "^6.0.1",
                 "strip-json-comments": "^3.1.0",
-                "table": "^6.0.9",
                 "text-table": "^0.2.0",
                 "v8-compile-cache": "^2.0.3"
             },
             "dependencies": {
-                "@babel/code-frame": {
-                    "version": "7.12.11",
-                    "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
-                    "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/highlight": "^7.10.4"
-                    }
-                },
                 "ansi-regex": {
                     "version": "5.0.1",
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
                     "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
                     "dev": true
                 },
-                "eslint-utils": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
-                    "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+                "argparse": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+                    "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+                    "dev": true
+                },
+                "eslint-scope": {
+                    "version": "7.1.1",
+                    "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.1.1.tgz",
+                    "integrity": "sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==",
                     "dev": true,
                     "requires": {
-                        "eslint-visitor-keys": "^1.1.0"
-                    },
-                    "dependencies": {
-                        "eslint-visitor-keys": {
-                            "version": "1.3.0",
-                            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-                            "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-                            "dev": true
-                        }
+                        "esrecurse": "^4.3.0",
+                        "estraverse": "^5.2.0"
                     }
                 },
-                "eslint-visitor-keys": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-                    "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+                "estraverse": {
+                    "version": "5.3.0",
+                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+                    "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
                     "dev": true
+                },
+                "glob-parent": {
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+                    "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+                    "dev": true,
+                    "requires": {
+                        "is-glob": "^4.0.3"
+                    }
                 },
                 "globals": {
                     "version": "13.13.0",
@@ -9066,19 +9521,13 @@
                         "type-fest": "^0.20.2"
                     }
                 },
-                "ignore": {
-                    "version": "4.0.6",
-                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-                    "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
-                    "dev": true
-                },
-                "semver": {
-                    "version": "7.3.7",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-                    "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+                "js-yaml": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+                    "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
                     "dev": true,
                     "requires": {
-                        "lru-cache": "^6.0.0"
+                        "argparse": "^2.0.1"
                     }
                 },
                 "strip-ansi": {
@@ -9125,13 +9574,10 @@
             }
         },
         "eslint-config-prettier": {
-            "version": "6.15.0",
-            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.15.0.tgz",
-            "integrity": "sha512-a1+kOYLR8wMGustcgAjdydMsQ2A/2ipRPwRKUmfYaSxc9ZPcrku080Ctl6zrZzZNs/U82MjSv+qKREkoq3bJaw==",
-            "dev": true,
-            "requires": {
-                "get-stdin": "^6.0.0"
-            }
+            "version": "8.5.0",
+            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
+            "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
+            "dev": true
         },
         "eslint-import-resolver-node": {
             "version": "0.3.6",
@@ -9257,9 +9703,9 @@
             }
         },
         "eslint-plugin-import": {
-            "version": "2.25.4",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.25.4.tgz",
-            "integrity": "sha512-/KJBASVFxpu0xg1kIBn9AUa8hQVnszpwgE7Ld0lKAlx7Ie87yzEzCgSkekt+le/YVhiaosO4Y14GDAOc41nfxA==",
+            "version": "2.26.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.26.0.tgz",
+            "integrity": "sha512-hYfi3FXaM8WPLf4S1cikh/r4IxnO6zrhZbEGz2b660EJRbuxgpDS5gkCuYgGWg2xxh2rBuIr4Pvhve/7c31koA==",
             "dev": true,
             "requires": {
                 "array-includes": "^3.1.4",
@@ -9267,14 +9713,14 @@
                 "debug": "^2.6.9",
                 "doctrine": "^2.1.0",
                 "eslint-import-resolver-node": "^0.3.6",
-                "eslint-module-utils": "^2.7.2",
+                "eslint-module-utils": "^2.7.3",
                 "has": "^1.0.3",
-                "is-core-module": "^2.8.0",
+                "is-core-module": "^2.8.1",
                 "is-glob": "^4.0.3",
-                "minimatch": "^3.0.4",
+                "minimatch": "^3.1.2",
                 "object.values": "^1.1.5",
-                "resolve": "^1.20.0",
-                "tsconfig-paths": "^3.12.0"
+                "resolve": "^1.22.0",
+                "tsconfig-paths": "^3.14.1"
             },
             "dependencies": {
                 "debug": {
@@ -9293,6 +9739,15 @@
                     "dev": true,
                     "requires": {
                         "esutils": "^2.0.2"
+                    }
+                },
+                "minimatch": {
+                    "version": "3.1.2",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+                    "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+                    "dev": true,
+                    "requires": {
+                        "brace-expansion": "^1.1.7"
                     }
                 },
                 "ms": {
@@ -9375,9 +9830,9 @@
             }
         },
         "eslint-plugin-react": {
-            "version": "7.29.3",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.29.3.tgz",
-            "integrity": "sha512-MzW6TuCnDOcta67CkpDyRfRsEVx9FNMDV8wZsDqe1luHPdGTrQIUaUXD27Ja3gHsdOIs/cXzNchWGlqm+qRVRg==",
+            "version": "7.29.4",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.29.4.tgz",
+            "integrity": "sha512-CVCXajliVh509PcZYRFyu/BoUEz452+jtQJq2b3Bae4v3xBUWPLCmtmBM+ZinG4MzwmxJgJ2M5rMqhqLVn7MtQ==",
             "dev": true,
             "requires": {
                 "array-includes": "^3.1.4",
@@ -9406,17 +9861,19 @@
                     }
                 },
                 "es-abstract": {
-                    "version": "1.19.5",
-                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.5.tgz",
-                    "integrity": "sha512-Aa2G2+Rd3b6kxEUKTF4TaW67czBLyAv3z7VOhYRU50YBx+bbsYZ9xQP4lMNazePuFlybXI0V4MruPos7qUo5fA==",
+                    "version": "1.20.0",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.0.tgz",
+                    "integrity": "sha512-URbD8tgRthKD3YcC39vbvSDrX23upXnPcnGAjQfgxXF5ID75YcENawc9ZX/9iTP9ptUyfCLIxTTuMYoRfiOVKA==",
                     "dev": true,
                     "requires": {
                         "call-bind": "^1.0.2",
                         "es-to-primitive": "^1.2.1",
                         "function-bind": "^1.1.1",
+                        "function.prototype.name": "^1.1.5",
                         "get-intrinsic": "^1.1.1",
                         "get-symbol-description": "^1.0.0",
                         "has": "^1.0.3",
+                        "has-property-descriptors": "^1.0.0",
                         "has-symbols": "^1.0.3",
                         "internal-slot": "^1.0.3",
                         "is-callable": "^1.2.4",
@@ -9428,15 +9885,22 @@
                         "object-inspect": "^1.12.0",
                         "object-keys": "^1.1.1",
                         "object.assign": "^4.1.2",
-                        "string.prototype.trimend": "^1.0.4",
-                        "string.prototype.trimstart": "^1.0.4",
-                        "unbox-primitive": "^1.0.1"
+                        "regexp.prototype.flags": "^1.4.1",
+                        "string.prototype.trimend": "^1.0.5",
+                        "string.prototype.trimstart": "^1.0.5",
+                        "unbox-primitive": "^1.0.2"
                     }
                 },
                 "estraverse": {
                     "version": "5.3.0",
                     "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
                     "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+                    "dev": true
+                },
+                "has-bigints": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+                    "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
                     "dev": true
                 },
                 "has-symbols": {
@@ -9503,13 +9967,71 @@
                     "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
                     "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
                     "dev": true
+                },
+                "string.prototype.trimend": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
+                    "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.2",
+                        "define-properties": "^1.1.4",
+                        "es-abstract": "^1.19.5"
+                    },
+                    "dependencies": {
+                        "define-properties": {
+                            "version": "1.1.4",
+                            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+                            "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+                            "dev": true,
+                            "requires": {
+                                "has-property-descriptors": "^1.0.0",
+                                "object-keys": "^1.1.1"
+                            }
+                        }
+                    }
+                },
+                "string.prototype.trimstart": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
+                    "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.2",
+                        "define-properties": "^1.1.4",
+                        "es-abstract": "^1.19.5"
+                    },
+                    "dependencies": {
+                        "define-properties": {
+                            "version": "1.1.4",
+                            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+                            "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+                            "dev": true,
+                            "requires": {
+                                "has-property-descriptors": "^1.0.0",
+                                "object-keys": "^1.1.1"
+                            }
+                        }
+                    }
+                },
+                "unbox-primitive": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+                    "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.2",
+                        "has-bigints": "^1.0.2",
+                        "has-symbols": "^1.0.3",
+                        "which-boxed-primitive": "^1.0.2"
+                    }
                 }
             }
         },
         "eslint-plugin-react-hooks": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.3.0.tgz",
-            "integrity": "sha512-XslZy0LnMn+84NEG9jSGR6eGqaZB3133L8xewQo3fQagbQuGt7a63gf+P1NGKZavEYEC3UXaWEAA/AqDkuN6xA==",
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.5.0.tgz",
+            "integrity": "sha512-8k1gRt7D7h03kd+SAAlzXkQwWK22BnK6GKZG+FJA6BAGy22CFvl8kCIXKpVux0cCxMWDQUPqSok0LKaZ0aOcCw==",
             "dev": true
         },
         "eslint-plugin-simple-import-sort": {
@@ -9552,22 +10074,14 @@
             "dev": true
         },
         "espree": {
-            "version": "7.3.1",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
-            "integrity": "sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==",
+            "version": "9.3.1",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.1.tgz",
+            "integrity": "sha512-bvdyLmJMfwkV3NCRl5ZhJf22zBFo1y8bYh3VYb+bfzqNB4Je68P2sSuXyuFquzWLebHpNd2/d5uv7yoP9ISnGQ==",
             "dev": true,
             "requires": {
-                "acorn": "^7.4.0",
+                "acorn": "^8.7.0",
                 "acorn-jsx": "^5.3.1",
-                "eslint-visitor-keys": "^1.3.0"
-            },
-            "dependencies": {
-                "eslint-visitor-keys": {
-                    "version": "1.3.0",
-                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-                    "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-                    "dev": true
-                }
+                "eslint-visitor-keys": "^3.3.0"
             }
         },
         "esprima": {
@@ -10419,17 +10933,19 @@
             },
             "dependencies": {
                 "es-abstract": {
-                    "version": "1.19.5",
-                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.5.tgz",
-                    "integrity": "sha512-Aa2G2+Rd3b6kxEUKTF4TaW67czBLyAv3z7VOhYRU50YBx+bbsYZ9xQP4lMNazePuFlybXI0V4MruPos7qUo5fA==",
+                    "version": "1.20.0",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.0.tgz",
+                    "integrity": "sha512-URbD8tgRthKD3YcC39vbvSDrX23upXnPcnGAjQfgxXF5ID75YcENawc9ZX/9iTP9ptUyfCLIxTTuMYoRfiOVKA==",
                     "dev": true,
                     "requires": {
                         "call-bind": "^1.0.2",
                         "es-to-primitive": "^1.2.1",
                         "function-bind": "^1.1.1",
+                        "function.prototype.name": "^1.1.5",
                         "get-intrinsic": "^1.1.1",
                         "get-symbol-description": "^1.0.0",
                         "has": "^1.0.3",
+                        "has-property-descriptors": "^1.0.0",
                         "has-symbols": "^1.0.3",
                         "internal-slot": "^1.0.3",
                         "is-callable": "^1.2.4",
@@ -10441,10 +10957,17 @@
                         "object-inspect": "^1.12.0",
                         "object-keys": "^1.1.1",
                         "object.assign": "^4.1.2",
-                        "string.prototype.trimend": "^1.0.4",
-                        "string.prototype.trimstart": "^1.0.4",
-                        "unbox-primitive": "^1.0.1"
+                        "regexp.prototype.flags": "^1.4.1",
+                        "string.prototype.trimend": "^1.0.5",
+                        "string.prototype.trimstart": "^1.0.5",
+                        "unbox-primitive": "^1.0.2"
                     }
+                },
+                "has-bigints": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+                    "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+                    "dev": true
                 },
                 "has-symbols": {
                     "version": "1.0.3",
@@ -10463,6 +10986,64 @@
                     "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
                     "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
                     "dev": true
+                },
+                "string.prototype.trimend": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
+                    "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.2",
+                        "define-properties": "^1.1.4",
+                        "es-abstract": "^1.19.5"
+                    },
+                    "dependencies": {
+                        "define-properties": {
+                            "version": "1.1.4",
+                            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+                            "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+                            "dev": true,
+                            "requires": {
+                                "has-property-descriptors": "^1.0.0",
+                                "object-keys": "^1.1.1"
+                            }
+                        }
+                    }
+                },
+                "string.prototype.trimstart": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
+                    "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.2",
+                        "define-properties": "^1.1.4",
+                        "es-abstract": "^1.19.5"
+                    },
+                    "dependencies": {
+                        "define-properties": {
+                            "version": "1.1.4",
+                            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+                            "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+                            "dev": true,
+                            "requires": {
+                                "has-property-descriptors": "^1.0.0",
+                                "object-keys": "^1.1.1"
+                            }
+                        }
+                    }
+                },
+                "unbox-primitive": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+                    "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.2",
+                        "has-bigints": "^1.0.2",
+                        "has-symbols": "^1.0.3",
+                        "which-boxed-primitive": "^1.0.2"
+                    }
                 }
             }
         },
@@ -10515,12 +11096,6 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
             "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
-            "dev": true
-        },
-        "get-stdin": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
-            "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
             "dev": true
         },
         "get-stream": {
@@ -13076,12 +13651,6 @@
                 "xml-name-validator": "^3.0.0"
             },
             "dependencies": {
-                "acorn": {
-                    "version": "8.7.1",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
-                    "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
-                    "dev": true
-                },
                 "form-data": {
                     "version": "3.0.1",
                     "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
@@ -13490,12 +14059,6 @@
             "integrity": "sha1-9GHliPZmg/fq3q3lE+OKaaVloV0=",
             "dev": true
         },
-        "lodash.truncate": {
-            "version": "4.4.2",
-            "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
-            "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
-            "dev": true
-        },
         "lodash.uniq": {
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
@@ -13639,6 +14202,12 @@
                 "eslint": "^6.8.0"
             },
             "dependencies": {
+                "acorn": {
+                    "version": "7.4.1",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+                    "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+                    "dev": true
+                },
                 "ansi-regex": {
                     "version": "4.1.1",
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
@@ -13653,12 +14222,6 @@
                     "requires": {
                         "color-convert": "^1.9.0"
                     }
-                },
-                "astral-regex": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
-                    "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
-                    "dev": true
                 },
                 "chalk": {
                     "version": "2.4.2",
@@ -13706,12 +14269,6 @@
                             "dev": true
                         }
                     }
-                },
-                "emoji-regex": {
-                    "version": "7.0.3",
-                    "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-                    "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-                    "dev": true
                 },
                 "escape-string-regexp": {
                     "version": "1.0.5",
@@ -13837,12 +14394,6 @@
                     "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
                     "dev": true
                 },
-                "is-fullwidth-code-point": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-                    "dev": true
-                },
                 "levn": {
                     "version": "0.3.0",
                     "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -13915,28 +14466,6 @@
                     "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
                     "dev": true
                 },
-                "slice-ansi": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
-                    "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^3.2.0",
-                        "astral-regex": "^1.0.0",
-                        "is-fullwidth-code-point": "^2.0.0"
-                    }
-                },
-                "string-width": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-                    "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-                    "dev": true,
-                    "requires": {
-                        "emoji-regex": "^7.0.1",
-                        "is-fullwidth-code-point": "^2.0.0",
-                        "strip-ansi": "^5.1.0"
-                    }
-                },
                 "strip-ansi": {
                     "version": "5.2.0",
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
@@ -13959,18 +14488,6 @@
                     "dev": true,
                     "requires": {
                         "has-flag": "^3.0.0"
-                    }
-                },
-                "table": {
-                    "version": "5.4.6",
-                    "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
-                    "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
-                    "dev": true,
-                    "requires": {
-                        "ajv": "^6.10.2",
-                        "lodash": "^4.17.14",
-                        "slice-ansi": "^2.1.0",
-                        "string-width": "^3.0.0"
                     }
                 },
                 "type-check": {
@@ -14415,9 +14932,9 @@
             "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
         },
         "nanoid": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
-            "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+            "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
             "dev": true
         },
         "nanomatch": {
@@ -15147,17 +15664,19 @@
             },
             "dependencies": {
                 "es-abstract": {
-                    "version": "1.19.5",
-                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.5.tgz",
-                    "integrity": "sha512-Aa2G2+Rd3b6kxEUKTF4TaW67czBLyAv3z7VOhYRU50YBx+bbsYZ9xQP4lMNazePuFlybXI0V4MruPos7qUo5fA==",
+                    "version": "1.20.0",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.0.tgz",
+                    "integrity": "sha512-URbD8tgRthKD3YcC39vbvSDrX23upXnPcnGAjQfgxXF5ID75YcENawc9ZX/9iTP9ptUyfCLIxTTuMYoRfiOVKA==",
                     "dev": true,
                     "requires": {
                         "call-bind": "^1.0.2",
                         "es-to-primitive": "^1.2.1",
                         "function-bind": "^1.1.1",
+                        "function.prototype.name": "^1.1.5",
                         "get-intrinsic": "^1.1.1",
                         "get-symbol-description": "^1.0.0",
                         "has": "^1.0.3",
+                        "has-property-descriptors": "^1.0.0",
                         "has-symbols": "^1.0.3",
                         "internal-slot": "^1.0.3",
                         "is-callable": "^1.2.4",
@@ -15169,10 +15688,17 @@
                         "object-inspect": "^1.12.0",
                         "object-keys": "^1.1.1",
                         "object.assign": "^4.1.2",
-                        "string.prototype.trimend": "^1.0.4",
-                        "string.prototype.trimstart": "^1.0.4",
-                        "unbox-primitive": "^1.0.1"
+                        "regexp.prototype.flags": "^1.4.1",
+                        "string.prototype.trimend": "^1.0.5",
+                        "string.prototype.trimstart": "^1.0.5",
+                        "unbox-primitive": "^1.0.2"
                     }
+                },
+                "has-bigints": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+                    "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+                    "dev": true
                 },
                 "has-symbols": {
                     "version": "1.0.3",
@@ -15191,6 +15717,64 @@
                     "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
                     "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
                     "dev": true
+                },
+                "string.prototype.trimend": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
+                    "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.2",
+                        "define-properties": "^1.1.4",
+                        "es-abstract": "^1.19.5"
+                    },
+                    "dependencies": {
+                        "define-properties": {
+                            "version": "1.1.4",
+                            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+                            "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+                            "dev": true,
+                            "requires": {
+                                "has-property-descriptors": "^1.0.0",
+                                "object-keys": "^1.1.1"
+                            }
+                        }
+                    }
+                },
+                "string.prototype.trimstart": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
+                    "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.2",
+                        "define-properties": "^1.1.4",
+                        "es-abstract": "^1.19.5"
+                    },
+                    "dependencies": {
+                        "define-properties": {
+                            "version": "1.1.4",
+                            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+                            "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+                            "dev": true,
+                            "requires": {
+                                "has-property-descriptors": "^1.0.0",
+                                "object-keys": "^1.1.1"
+                            }
+                        }
+                    }
+                },
+                "unbox-primitive": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+                    "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.2",
+                        "has-bigints": "^1.0.2",
+                        "has-symbols": "^1.0.3",
+                        "which-boxed-primitive": "^1.0.2"
+                    }
                 }
             }
         },
@@ -15206,17 +15790,19 @@
             },
             "dependencies": {
                 "es-abstract": {
-                    "version": "1.19.5",
-                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.5.tgz",
-                    "integrity": "sha512-Aa2G2+Rd3b6kxEUKTF4TaW67czBLyAv3z7VOhYRU50YBx+bbsYZ9xQP4lMNazePuFlybXI0V4MruPos7qUo5fA==",
+                    "version": "1.20.0",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.0.tgz",
+                    "integrity": "sha512-URbD8tgRthKD3YcC39vbvSDrX23upXnPcnGAjQfgxXF5ID75YcENawc9ZX/9iTP9ptUyfCLIxTTuMYoRfiOVKA==",
                     "dev": true,
                     "requires": {
                         "call-bind": "^1.0.2",
                         "es-to-primitive": "^1.2.1",
                         "function-bind": "^1.1.1",
+                        "function.prototype.name": "^1.1.5",
                         "get-intrinsic": "^1.1.1",
                         "get-symbol-description": "^1.0.0",
                         "has": "^1.0.3",
+                        "has-property-descriptors": "^1.0.0",
                         "has-symbols": "^1.0.3",
                         "internal-slot": "^1.0.3",
                         "is-callable": "^1.2.4",
@@ -15228,10 +15814,17 @@
                         "object-inspect": "^1.12.0",
                         "object-keys": "^1.1.1",
                         "object.assign": "^4.1.2",
-                        "string.prototype.trimend": "^1.0.4",
-                        "string.prototype.trimstart": "^1.0.4",
-                        "unbox-primitive": "^1.0.1"
+                        "regexp.prototype.flags": "^1.4.1",
+                        "string.prototype.trimend": "^1.0.5",
+                        "string.prototype.trimstart": "^1.0.5",
+                        "unbox-primitive": "^1.0.2"
                     }
+                },
+                "has-bigints": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+                    "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+                    "dev": true
                 },
                 "has-symbols": {
                     "version": "1.0.3",
@@ -15250,31 +15843,101 @@
                     "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
                     "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
                     "dev": true
+                },
+                "string.prototype.trimend": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
+                    "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.2",
+                        "define-properties": "^1.1.4",
+                        "es-abstract": "^1.19.5"
+                    },
+                    "dependencies": {
+                        "define-properties": {
+                            "version": "1.1.4",
+                            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+                            "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+                            "dev": true,
+                            "requires": {
+                                "has-property-descriptors": "^1.0.0",
+                                "object-keys": "^1.1.1"
+                            }
+                        }
+                    }
+                },
+                "string.prototype.trimstart": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
+                    "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.2",
+                        "define-properties": "^1.1.4",
+                        "es-abstract": "^1.19.5"
+                    },
+                    "dependencies": {
+                        "define-properties": {
+                            "version": "1.1.4",
+                            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+                            "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+                            "dev": true,
+                            "requires": {
+                                "has-property-descriptors": "^1.0.0",
+                                "object-keys": "^1.1.1"
+                            }
+                        }
+                    }
+                },
+                "unbox-primitive": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+                    "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.2",
+                        "has-bigints": "^1.0.2",
+                        "has-symbols": "^1.0.3",
+                        "which-boxed-primitive": "^1.0.2"
+                    }
                 }
             }
         },
         "object.hasown": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.0.tgz",
-            "integrity": "sha512-MhjYRfj3GBlhSkDHo6QmvgjRLXQ2zndabdf3nX0yTyZK9rPfxb6uRpAac8HXNLy1GpqWtZ81Qh4v3uOls2sRAg==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.1.tgz",
+            "integrity": "sha512-LYLe4tivNQzq4JdaWW6WO3HMZZJWzkkH8fnI6EebWl0VZth2wL2Lovm74ep2/gZzlaTdV62JZHEqHQ2yVn8Q/A==",
             "dev": true,
             "requires": {
-                "define-properties": "^1.1.3",
-                "es-abstract": "^1.19.1"
+                "define-properties": "^1.1.4",
+                "es-abstract": "^1.19.5"
             },
             "dependencies": {
+                "define-properties": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+                    "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+                    "dev": true,
+                    "requires": {
+                        "has-property-descriptors": "^1.0.0",
+                        "object-keys": "^1.1.1"
+                    }
+                },
                 "es-abstract": {
-                    "version": "1.19.5",
-                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.5.tgz",
-                    "integrity": "sha512-Aa2G2+Rd3b6kxEUKTF4TaW67czBLyAv3z7VOhYRU50YBx+bbsYZ9xQP4lMNazePuFlybXI0V4MruPos7qUo5fA==",
+                    "version": "1.20.0",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.0.tgz",
+                    "integrity": "sha512-URbD8tgRthKD3YcC39vbvSDrX23upXnPcnGAjQfgxXF5ID75YcENawc9ZX/9iTP9ptUyfCLIxTTuMYoRfiOVKA==",
                     "dev": true,
                     "requires": {
                         "call-bind": "^1.0.2",
                         "es-to-primitive": "^1.2.1",
                         "function-bind": "^1.1.1",
+                        "function.prototype.name": "^1.1.5",
                         "get-intrinsic": "^1.1.1",
                         "get-symbol-description": "^1.0.0",
                         "has": "^1.0.3",
+                        "has-property-descriptors": "^1.0.0",
                         "has-symbols": "^1.0.3",
                         "internal-slot": "^1.0.3",
                         "is-callable": "^1.2.4",
@@ -15286,10 +15949,17 @@
                         "object-inspect": "^1.12.0",
                         "object-keys": "^1.1.1",
                         "object.assign": "^4.1.2",
-                        "string.prototype.trimend": "^1.0.4",
-                        "string.prototype.trimstart": "^1.0.4",
-                        "unbox-primitive": "^1.0.1"
+                        "regexp.prototype.flags": "^1.4.1",
+                        "string.prototype.trimend": "^1.0.5",
+                        "string.prototype.trimstart": "^1.0.5",
+                        "unbox-primitive": "^1.0.2"
                     }
+                },
+                "has-bigints": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+                    "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+                    "dev": true
                 },
                 "has-symbols": {
                     "version": "1.0.3",
@@ -15308,6 +15978,40 @@
                     "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
                     "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
                     "dev": true
+                },
+                "string.prototype.trimend": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
+                    "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.2",
+                        "define-properties": "^1.1.4",
+                        "es-abstract": "^1.19.5"
+                    }
+                },
+                "string.prototype.trimstart": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
+                    "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.2",
+                        "define-properties": "^1.1.4",
+                        "es-abstract": "^1.19.5"
+                    }
+                },
+                "unbox-primitive": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+                    "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.2",
+                        "has-bigints": "^1.0.2",
+                        "has-symbols": "^1.0.3",
+                        "which-boxed-primitive": "^1.0.2"
+                    }
                 }
             }
         },
@@ -15332,17 +16036,19 @@
             },
             "dependencies": {
                 "es-abstract": {
-                    "version": "1.19.5",
-                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.5.tgz",
-                    "integrity": "sha512-Aa2G2+Rd3b6kxEUKTF4TaW67czBLyAv3z7VOhYRU50YBx+bbsYZ9xQP4lMNazePuFlybXI0V4MruPos7qUo5fA==",
+                    "version": "1.20.0",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.0.tgz",
+                    "integrity": "sha512-URbD8tgRthKD3YcC39vbvSDrX23upXnPcnGAjQfgxXF5ID75YcENawc9ZX/9iTP9ptUyfCLIxTTuMYoRfiOVKA==",
                     "dev": true,
                     "requires": {
                         "call-bind": "^1.0.2",
                         "es-to-primitive": "^1.2.1",
                         "function-bind": "^1.1.1",
+                        "function.prototype.name": "^1.1.5",
                         "get-intrinsic": "^1.1.1",
                         "get-symbol-description": "^1.0.0",
                         "has": "^1.0.3",
+                        "has-property-descriptors": "^1.0.0",
                         "has-symbols": "^1.0.3",
                         "internal-slot": "^1.0.3",
                         "is-callable": "^1.2.4",
@@ -15354,10 +16060,17 @@
                         "object-inspect": "^1.12.0",
                         "object-keys": "^1.1.1",
                         "object.assign": "^4.1.2",
-                        "string.prototype.trimend": "^1.0.4",
-                        "string.prototype.trimstart": "^1.0.4",
-                        "unbox-primitive": "^1.0.1"
+                        "regexp.prototype.flags": "^1.4.1",
+                        "string.prototype.trimend": "^1.0.5",
+                        "string.prototype.trimstart": "^1.0.5",
+                        "unbox-primitive": "^1.0.2"
                     }
+                },
+                "has-bigints": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+                    "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+                    "dev": true
                 },
                 "has-symbols": {
                     "version": "1.0.3",
@@ -15376,6 +16089,64 @@
                     "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
                     "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
                     "dev": true
+                },
+                "string.prototype.trimend": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
+                    "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.2",
+                        "define-properties": "^1.1.4",
+                        "es-abstract": "^1.19.5"
+                    },
+                    "dependencies": {
+                        "define-properties": {
+                            "version": "1.1.4",
+                            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+                            "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+                            "dev": true,
+                            "requires": {
+                                "has-property-descriptors": "^1.0.0",
+                                "object-keys": "^1.1.1"
+                            }
+                        }
+                    }
+                },
+                "string.prototype.trimstart": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
+                    "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.2",
+                        "define-properties": "^1.1.4",
+                        "es-abstract": "^1.19.5"
+                    },
+                    "dependencies": {
+                        "define-properties": {
+                            "version": "1.1.4",
+                            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+                            "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+                            "dev": true,
+                            "requires": {
+                                "has-property-descriptors": "^1.0.0",
+                                "object-keys": "^1.1.1"
+                            }
+                        }
+                    }
+                },
+                "unbox-primitive": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+                    "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.2",
+                        "has-bigints": "^1.0.2",
+                        "has-symbols": "^1.0.3",
+                        "which-boxed-primitive": "^1.0.2"
+                    }
                 }
             }
         },
@@ -15945,44 +16716,44 @@
             }
         },
         "pc-nrfconnect-shared": {
-            "version": "github:NordicSemiconductor/pc-nrfconnect-shared#756e81a6c9f0db04fe59494330f5f0a95fe0b42c",
-            "from": "github:NordicSemiconductor/pc-nrfconnect-shared#v6.0.5",
+            "version": "github:NordicSemiconductor/pc-nrfconnect-shared#97756631845b2a4310b7e91a666520123ad0ba03",
+            "from": "github:NordicSemiconductor/pc-nrfconnect-shared#v6.1.0",
             "dev": true,
             "requires": {
-                "@babel/core": "7.17.5",
+                "@babel/core": "7.17.10",
                 "@babel/plugin-proposal-class-properties": "7.16.7",
                 "@babel/plugin-proposal-nullish-coalescing-operator": "7.16.7",
                 "@babel/plugin-proposal-object-rest-spread": "7.17.3",
                 "@babel/plugin-proposal-optional-chaining": "7.16.7",
                 "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-                "@babel/plugin-transform-destructuring": "7.17.3",
-                "@babel/plugin-transform-modules-commonjs": "7.16.8",
+                "@babel/plugin-transform-destructuring": "7.17.7",
+                "@babel/plugin-transform-modules-commonjs": "7.17.9",
                 "@babel/plugin-transform-parameters": "7.16.7",
                 "@babel/plugin-transform-spread": "7.16.7",
                 "@babel/preset-react": "7.16.7",
                 "@babel/preset-typescript": "7.16.7",
                 "@electron/remote": "^2.0.4",
                 "@mdi/font": "3.9.97",
-                "@nordicsemiconductor/nrf-device-lib-js": "0.4.6",
-                "@reduxjs/toolkit": "1.8.0",
+                "@nordicsemiconductor/nrf-device-lib-js": "0.4.7",
+                "@reduxjs/toolkit": "1.8.1",
                 "@svgr/webpack": "5.5.0",
-                "@swc/core": "1.2.148",
-                "@testing-library/jest-dom": "5.16.2",
+                "@swc/core": "1.2.175",
+                "@testing-library/jest-dom": "5.16.4",
                 "@testing-library/react": "10.4.9",
-                "@types/adm-zip": "^0.4.34",
+                "@types/adm-zip": "^0.5.0",
                 "@types/date-fns": "^2.6.0",
                 "@types/mousetrap": "1.6.9",
                 "@types/react": "17.0.44",
-                "@types/react-dom": "17.0.13",
-                "@types/react-redux": "7.1.23",
+                "@types/react-dom": "17.0.16",
+                "@types/react-redux": "7.1.24",
                 "@types/serialport": "^8.0.2",
                 "@types/shasum": "1.0.0",
                 "@types/triple-beam": "1.3.2",
-                "@typescript-eslint/eslint-plugin": "5.14.0",
-                "@typescript-eslint/parser": "5.14.0",
+                "@typescript-eslint/eslint-plugin": "5.22.0",
+                "@typescript-eslint/parser": "5.22.0",
                 "adm-zip": "^0.5.5",
                 "babel-eslint": "10.1.0",
-                "babel-loader": "8.2.3",
+                "babel-loader": "8.2.5",
                 "bootstrap": "4.6.1",
                 "camelcase-keys": "6.2.2",
                 "commander": "5.1.0",
@@ -15992,16 +16763,16 @@
                 "enzyme": "3.11.0",
                 "enzyme-adapter-react-16": "1.15.6",
                 "enzyme-to-json": "3.6.2",
-                "eslint": "7.32.0",
-                "eslint-config-airbnb": "18.2.1",
-                "eslint-config-prettier": "^6.11.0",
+                "eslint": "8.14.0",
+                "eslint-config-airbnb": "19.0.4",
+                "eslint-config-prettier": "8.5.0",
                 "eslint-import-resolver-typescript": "2.7.1",
-                "eslint-plugin-import": "2.25.4",
+                "eslint-plugin-import": "2.26.0",
                 "eslint-plugin-jsx-a11y": "6.5.1",
                 "eslint-plugin-md": "^1.0.19",
                 "eslint-plugin-prettier": "^3.1.4",
-                "eslint-plugin-react": "7.29.3",
-                "eslint-plugin-react-hooks": "4.3.0",
+                "eslint-plugin-react": "7.29.4",
+                "eslint-plugin-react-hooks": "4.5.0",
                 "eslint-plugin-simple-import-sort": "7.0.0",
                 "fast-glob": "3.2.11",
                 "file-loader": "6.2.0",
@@ -16014,7 +16785,7 @@
                 "mousetrap": "1.6.5",
                 "npm-run-all2": "5.0.2",
                 "nrf-intel-hex": "^1.3.0",
-                "prettier": "2.5.1",
+                "prettier": "2.6.2",
                 "prettysize": "2.0.0",
                 "protobufjs": "^6.11.2",
                 "react-bootstrap": "1.6.4",
@@ -16023,23 +16794,23 @@
                 "react-markdown": "4.3.1",
                 "react-resize-detector": "6.7.8",
                 "react-test-renderer": "16.14.0",
-                "redux": "4.1.2",
+                "redux": "4.2.0",
                 "redux-devtools-extension": "2.13.9",
                 "redux-thunk": "2.4.1",
                 "rimraf": "3.0.2",
                 "roboto-fontface": "0.10.0",
-                "sass": "1.49.9",
+                "sass": "1.51.0",
                 "sass-loader": "10.2.1",
-                "semver": "7.3.5",
+                "semver": "7.3.7",
                 "shasum": "1.0.2",
                 "style-loader": "2.0.0",
-                "systeminformation": "5.11.6",
-                "ts-node": "10.6.0",
-                "typescript": "4.6.2",
+                "systeminformation": "5.11.14",
+                "ts-node": "10.7.0",
+                "typescript": "4.6.4",
                 "url-loader": "4.1.1",
                 "webpack": "4.46.0",
                 "webpack-cli": "4.9.2",
-                "winston": "3.6.0"
+                "winston": "3.7.2"
             },
             "dependencies": {
                 "@mdi/font": {
@@ -16048,248 +16819,174 @@
                     "integrity": "sha512-yADBl2mzqIssrhLaRvJ2gZPyEQK+fN9uYh/1/cwwuq2lKDx+ITWsOrh1vlHMfw1IICMx9cwBjSoiCf3B8Br8nw==",
                     "dev": true
                 },
-                "@nordicsemiconductor/nrf-device-lib-js": {
-                    "version": "0.4.6",
-                    "resolved": "https://registry.npmjs.org/@nordicsemiconductor/nrf-device-lib-js/-/nrf-device-lib-js-0.4.6.tgz",
-                    "integrity": "sha512-H9Me7p3qIwV9E07AL6xFkznI9XDrX6PrH/6SDZjR8b69XKrH0tkUizZxsxljiIAXERNBHzaSkG4mJHXXWcjrGQ==",
-                    "dev": true,
-                    "requires": {
-                        "cmake-js": "^6.1.0",
-                        "fs": "0.0.1-security",
-                        "lnk": "^1.1.0",
-                        "node-addon-api": "3.0.2",
-                        "node-pre-gyp": "0.15.0",
-                        "path": "^0.12.7",
-                        "prebuild": "^10.0.1",
-                        "prebuild-install": "^7.0.1",
-                        "sander": "^0.6.0"
-                    }
-                },
-                "are-we-there-yet": {
-                    "version": "1.1.7",
-                    "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz",
-                    "integrity": "sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==",
-                    "dev": true,
-                    "requires": {
-                        "delegates": "^1.0.0",
-                        "readable-stream": "^2.0.6"
-                    }
-                },
                 "commander": {
                     "version": "5.1.0",
                     "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
                     "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
                     "dev": true
                 },
-                "decompress-response": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-                    "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+                "es-abstract": {
+                    "version": "1.20.0",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.0.tgz",
+                    "integrity": "sha512-URbD8tgRthKD3YcC39vbvSDrX23upXnPcnGAjQfgxXF5ID75YcENawc9ZX/9iTP9ptUyfCLIxTTuMYoRfiOVKA==",
                     "dev": true,
                     "requires": {
-                        "mimic-response": "^3.1.0"
+                        "call-bind": "^1.0.2",
+                        "es-to-primitive": "^1.2.1",
+                        "function-bind": "^1.1.1",
+                        "function.prototype.name": "^1.1.5",
+                        "get-intrinsic": "^1.1.1",
+                        "get-symbol-description": "^1.0.0",
+                        "has": "^1.0.3",
+                        "has-property-descriptors": "^1.0.0",
+                        "has-symbols": "^1.0.3",
+                        "internal-slot": "^1.0.3",
+                        "is-callable": "^1.2.4",
+                        "is-negative-zero": "^2.0.2",
+                        "is-regex": "^1.1.4",
+                        "is-shared-array-buffer": "^1.0.2",
+                        "is-string": "^1.0.7",
+                        "is-weakref": "^1.0.2",
+                        "object-inspect": "^1.12.0",
+                        "object-keys": "^1.1.1",
+                        "object.assign": "^4.1.2",
+                        "regexp.prototype.flags": "^1.4.1",
+                        "string.prototype.trimend": "^1.0.5",
+                        "string.prototype.trimstart": "^1.0.5",
+                        "unbox-primitive": "^1.0.2"
                     }
                 },
                 "eslint-config-airbnb": {
-                    "version": "18.2.1",
-                    "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-18.2.1.tgz",
-                    "integrity": "sha512-glZNDEZ36VdlZWoxn/bUR1r/sdFKPd1mHPbqUtkctgNG4yT2DLLtJ3D+yCV+jzZCc2V1nBVkmdknOJBZ5Hc0fg==",
+                    "version": "19.0.4",
+                    "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-19.0.4.tgz",
+                    "integrity": "sha512-T75QYQVQX57jiNgpF9r1KegMICE94VYwoFQyMGhrvc+lB8YF2E/M/PYDaQe1AJcWaEgqLE+ErXV1Og/+6Vyzew==",
                     "dev": true,
                     "requires": {
-                        "eslint-config-airbnb-base": "^14.2.1",
+                        "eslint-config-airbnb-base": "^15.0.0",
                         "object.assign": "^4.1.2",
-                        "object.entries": "^1.1.2"
+                        "object.entries": "^1.1.5"
                     }
                 },
                 "eslint-config-airbnb-base": {
-                    "version": "14.2.1",
-                    "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.2.1.tgz",
-                    "integrity": "sha512-GOrQyDtVEc1Xy20U7vsB2yAoB4nBlfH5HZJeatRXHleO+OS5Ot+MWij4Dpltw4/DyIkqUfqz1epfhVR5XWWQPA==",
+                    "version": "15.0.0",
+                    "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-15.0.0.tgz",
+                    "integrity": "sha512-xaX3z4ZZIcFLvh2oUNvcX5oEofXda7giYmuplVxoOg5A7EXJMrUyqRgR+mhDhPK8LZ4PttFOBvCYDbX3sUoUig==",
                     "dev": true,
                     "requires": {
                         "confusing-browser-globals": "^1.0.10",
                         "object.assign": "^4.1.2",
-                        "object.entries": "^1.1.2"
-                    }
-                },
-                "gauge": {
-                    "version": "2.7.4",
-                    "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-                    "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-                    "dev": true,
-                    "requires": {
-                        "aproba": "^1.0.3",
-                        "console-control-strings": "^1.0.0",
-                        "has-unicode": "^2.0.0",
-                        "object-assign": "^4.1.0",
-                        "signal-exit": "^3.0.0",
-                        "string-width": "^1.0.1",
-                        "strip-ansi": "^3.0.1",
-                        "wide-align": "^1.1.0"
-                    }
-                },
-                "isarray": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-                    "dev": true
-                },
-                "mimic-response": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-                    "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-                    "dev": true
-                },
-                "node-abi": {
-                    "version": "3.15.0",
-                    "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.15.0.tgz",
-                    "integrity": "sha512-Ic6z/j6I9RLm4ov7npo1I48UQr2BEyFCqh6p7S1dhEx9jPO0GPGq/e2Rb7x7DroQrmiVMz/Bw1vJm9sPAl2nxA==",
-                    "dev": true,
-                    "requires": {
-                        "semver": "^7.3.5"
-                    }
-                },
-                "node-pre-gyp": {
-                    "version": "0.15.0",
-                    "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.15.0.tgz",
-                    "integrity": "sha512-7QcZa8/fpaU/BKenjcaeFF9hLz2+7S9AqyXFhlH/rilsQ/hPZKK32RtR5EQHJElgu+q5RfbJ34KriI79UWaorA==",
-                    "dev": true,
-                    "requires": {
-                        "detect-libc": "^1.0.2",
-                        "mkdirp": "^0.5.3",
-                        "needle": "^2.5.0",
-                        "nopt": "^4.0.1",
-                        "npm-packlist": "^1.1.6",
-                        "npmlog": "^4.0.2",
-                        "rc": "^1.2.7",
-                        "rimraf": "^2.6.1",
-                        "semver": "^5.3.0",
-                        "tar": "^4.4.2"
+                        "object.entries": "^1.1.5",
+                        "semver": "^6.3.0"
                     },
                     "dependencies": {
-                        "rimraf": {
-                            "version": "2.7.1",
-                            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-                            "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-                            "dev": true,
-                            "requires": {
-                                "glob": "^7.1.3"
-                            }
-                        },
                         "semver": {
-                            "version": "5.7.1",
-                            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-                            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+                            "version": "6.3.0",
+                            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                            "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
                             "dev": true
                         }
                     }
                 },
-                "npmlog": {
-                    "version": "4.1.2",
-                    "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-                    "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-                    "dev": true,
-                    "requires": {
-                        "are-we-there-yet": "~1.1.2",
-                        "console-control-strings": "~1.1.0",
-                        "gauge": "~2.7.3",
-                        "set-blocking": "~2.0.0"
-                    }
+                "has-bigints": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+                    "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+                    "dev": true
                 },
-                "prebuild-install": {
-                    "version": "7.1.0",
-                    "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.0.tgz",
-                    "integrity": "sha512-CNcMgI1xBypOyGqjp3wOc8AAo1nMhZS3Cwd3iHIxOdAUbb+YxdNuM4Z5iIrZ8RLvOsf3F3bl7b7xGq6DjQoNYA==",
-                    "dev": true,
-                    "requires": {
-                        "detect-libc": "^2.0.0",
-                        "expand-template": "^2.0.3",
-                        "github-from-package": "0.0.0",
-                        "minimist": "^1.2.3",
-                        "mkdirp-classic": "^0.5.3",
-                        "napi-build-utils": "^1.0.1",
-                        "node-abi": "^3.3.0",
-                        "npmlog": "^4.0.1",
-                        "pump": "^3.0.0",
-                        "rc": "^1.2.7",
-                        "simple-get": "^4.0.0",
-                        "tar-fs": "^2.0.0",
-                        "tunnel-agent": "^0.6.0"
-                    },
-                    "dependencies": {
-                        "detect-libc": {
-                            "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
-                            "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==",
-                            "dev": true
-                        }
-                    }
+                "has-symbols": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+                    "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+                    "dev": true
                 },
-                "readable-stream": {
-                    "version": "2.3.7",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+                "is-negative-zero": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
+                    "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
+                    "dev": true
+                },
+                "object-inspect": {
+                    "version": "1.12.0",
+                    "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
+                    "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
+                    "dev": true
+                },
+                "object.entries": {
+                    "version": "1.1.5",
+                    "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.5.tgz",
+                    "integrity": "sha512-TyxmjUoZggd4OrrU1W66FMDG6CuqJxsFvymeyXI51+vQLN67zYfZseptRge703kKQdo4uccgAKebXFcRCzk4+g==",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
+                        "call-bind": "^1.0.2",
+                        "define-properties": "^1.1.3",
+                        "es-abstract": "^1.19.1"
                     }
                 },
                 "semver": {
-                    "version": "7.3.5",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-                    "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+                    "version": "7.3.7",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+                    "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
                     "dev": true,
                     "requires": {
                         "lru-cache": "^6.0.0"
                     }
                 },
-                "simple-get": {
-                    "version": "4.0.1",
-                    "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-                    "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+                "string.prototype.trimend": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
+                    "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
                     "dev": true,
                     "requires": {
-                        "decompress-response": "^6.0.0",
-                        "once": "^1.3.1",
-                        "simple-concat": "^1.0.0"
-                    }
-                },
-                "string_decoder": {
-                    "version": "1.1.1",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-                    "dev": true,
-                    "requires": {
-                        "safe-buffer": "~5.1.0"
-                    }
-                },
-                "tar": {
-                    "version": "4.4.19",
-                    "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.19.tgz",
-                    "integrity": "sha512-a20gEsvHnWe0ygBY8JbxoM4w3SJdhc7ZAuxkLqh+nvNQN2IOt0B5lLgM490X5Hl8FF0dl0tOf2ewFYAlIFgzVA==",
-                    "dev": true,
-                    "requires": {
-                        "chownr": "^1.1.4",
-                        "fs-minipass": "^1.2.7",
-                        "minipass": "^2.9.0",
-                        "minizlib": "^1.3.3",
-                        "mkdirp": "^0.5.5",
-                        "safe-buffer": "^5.2.1",
-                        "yallist": "^3.1.1"
+                        "call-bind": "^1.0.2",
+                        "define-properties": "^1.1.4",
+                        "es-abstract": "^1.19.5"
                     },
                     "dependencies": {
-                        "safe-buffer": {
-                            "version": "5.2.1",
-                            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-                            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-                            "dev": true
+                        "define-properties": {
+                            "version": "1.1.4",
+                            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+                            "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+                            "dev": true,
+                            "requires": {
+                                "has-property-descriptors": "^1.0.0",
+                                "object-keys": "^1.1.1"
+                            }
                         }
+                    }
+                },
+                "string.prototype.trimstart": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
+                    "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.2",
+                        "define-properties": "^1.1.4",
+                        "es-abstract": "^1.19.5"
+                    },
+                    "dependencies": {
+                        "define-properties": {
+                            "version": "1.1.4",
+                            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+                            "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+                            "dev": true,
+                            "requires": {
+                                "has-property-descriptors": "^1.0.0",
+                                "object-keys": "^1.1.1"
+                            }
+                        }
+                    }
+                },
+                "unbox-primitive": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+                    "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.2",
+                        "has-bigints": "^1.0.2",
+                        "has-symbols": "^1.0.3",
+                        "which-boxed-primitive": "^1.0.2"
                     }
                 }
             }
@@ -16851,9 +17548,9 @@
             "dev": true
         },
         "prettier": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
-            "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
+            "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
             "dev": true
         },
         "prettier-linter-helpers": {
@@ -17435,9 +18132,9 @@
             }
         },
         "redux": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/redux/-/redux-4.1.2.tgz",
-            "integrity": "sha512-SH8PglcebESbd/shgf6mii6EIoRM0zrQyjcuQ+ojmfxjTtE0z9Y8pa62iA/OJ58qjP6j27uyW4kUF4jl/jd6sw==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.0.tgz",
+            "integrity": "sha512-oSBmcKKIuIR4ME29/AeNUnl5L+hvBq7OaJWzaptTQJAntaPvxIJqfnjbaEiCzzaIz+XmVILfqAM3Ob0aXLPfjA==",
             "dev": true,
             "requires": {
                 "@babel/runtime": "^7.9.2"
@@ -18665,9 +19362,9 @@
             }
         },
         "sass": {
-            "version": "1.49.9",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.49.9.tgz",
-            "integrity": "sha512-YlYWkkHP9fbwaFRZQRXgDi3mXZShslVmmo+FVK3kHLUELHHEYrCmL1x6IUjC7wLS6VuJSAFXRQS/DxdsC4xL1A==",
+            "version": "1.51.0",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.51.0.tgz",
+            "integrity": "sha512-haGdpTgywJTvHC2b91GSq+clTKGbtkkZmVAb82jZQN/wTy6qs8DdFm2lhEQbEwrY0QDRgSQ3xDurqM977C3noA==",
             "dev": true,
             "requires": {
                 "chokidar": ">=3.0.0 <4.0.0",
@@ -18994,20 +19691,44 @@
             "dev": true
         },
         "slice-ansi": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
-            "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+            "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
             "dev": true,
             "requires": {
-                "ansi-styles": "^4.0.0",
-                "astral-regex": "^2.0.0",
-                "is-fullwidth-code-point": "^3.0.0"
+                "ansi-styles": "^3.2.0",
+                "astral-regex": "^1.0.0",
+                "is-fullwidth-code-point": "^2.0.0"
             },
             "dependencies": {
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
+                "color-convert": {
+                    "version": "1.9.3",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+                    "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "1.1.3"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+                    "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+                    "dev": true
+                },
                 "is-fullwidth-code-point": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-                    "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
                     "dev": true
                 }
             }
@@ -19549,17 +20270,19 @@
             },
             "dependencies": {
                 "es-abstract": {
-                    "version": "1.19.5",
-                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.5.tgz",
-                    "integrity": "sha512-Aa2G2+Rd3b6kxEUKTF4TaW67czBLyAv3z7VOhYRU50YBx+bbsYZ9xQP4lMNazePuFlybXI0V4MruPos7qUo5fA==",
+                    "version": "1.20.0",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.0.tgz",
+                    "integrity": "sha512-URbD8tgRthKD3YcC39vbvSDrX23upXnPcnGAjQfgxXF5ID75YcENawc9ZX/9iTP9ptUyfCLIxTTuMYoRfiOVKA==",
                     "dev": true,
                     "requires": {
                         "call-bind": "^1.0.2",
                         "es-to-primitive": "^1.2.1",
                         "function-bind": "^1.1.1",
+                        "function.prototype.name": "^1.1.5",
                         "get-intrinsic": "^1.1.1",
                         "get-symbol-description": "^1.0.0",
                         "has": "^1.0.3",
+                        "has-property-descriptors": "^1.0.0",
                         "has-symbols": "^1.0.3",
                         "internal-slot": "^1.0.3",
                         "is-callable": "^1.2.4",
@@ -19571,10 +20294,17 @@
                         "object-inspect": "^1.12.0",
                         "object-keys": "^1.1.1",
                         "object.assign": "^4.1.2",
-                        "string.prototype.trimend": "^1.0.4",
-                        "string.prototype.trimstart": "^1.0.4",
-                        "unbox-primitive": "^1.0.1"
+                        "regexp.prototype.flags": "^1.4.1",
+                        "string.prototype.trimend": "^1.0.5",
+                        "string.prototype.trimstart": "^1.0.5",
+                        "unbox-primitive": "^1.0.2"
                     }
+                },
+                "has-bigints": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+                    "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+                    "dev": true
                 },
                 "has-symbols": {
                     "version": "1.0.3",
@@ -19593,6 +20323,64 @@
                     "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
                     "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
                     "dev": true
+                },
+                "string.prototype.trimend": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
+                    "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.2",
+                        "define-properties": "^1.1.4",
+                        "es-abstract": "^1.19.5"
+                    },
+                    "dependencies": {
+                        "define-properties": {
+                            "version": "1.1.4",
+                            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+                            "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+                            "dev": true,
+                            "requires": {
+                                "has-property-descriptors": "^1.0.0",
+                                "object-keys": "^1.1.1"
+                            }
+                        }
+                    }
+                },
+                "string.prototype.trimstart": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
+                    "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.2",
+                        "define-properties": "^1.1.4",
+                        "es-abstract": "^1.19.5"
+                    },
+                    "dependencies": {
+                        "define-properties": {
+                            "version": "1.1.4",
+                            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
+                            "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+                            "dev": true,
+                            "requires": {
+                                "has-property-descriptors": "^1.0.0",
+                                "object-keys": "^1.1.1"
+                            }
+                        }
+                    }
+                },
+                "unbox-primitive": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+                    "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.2",
+                        "has-bigints": "^1.0.2",
+                        "has-symbols": "^1.0.3",
+                        "which-boxed-primitive": "^1.0.2"
+                    }
                 }
             }
         },
@@ -19618,17 +20406,19 @@
                     }
                 },
                 "es-abstract": {
-                    "version": "1.19.5",
-                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.5.tgz",
-                    "integrity": "sha512-Aa2G2+Rd3b6kxEUKTF4TaW67czBLyAv3z7VOhYRU50YBx+bbsYZ9xQP4lMNazePuFlybXI0V4MruPos7qUo5fA==",
+                    "version": "1.20.0",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.0.tgz",
+                    "integrity": "sha512-URbD8tgRthKD3YcC39vbvSDrX23upXnPcnGAjQfgxXF5ID75YcENawc9ZX/9iTP9ptUyfCLIxTTuMYoRfiOVKA==",
                     "dev": true,
                     "requires": {
                         "call-bind": "^1.0.2",
                         "es-to-primitive": "^1.2.1",
                         "function-bind": "^1.1.1",
+                        "function.prototype.name": "^1.1.5",
                         "get-intrinsic": "^1.1.1",
                         "get-symbol-description": "^1.0.0",
                         "has": "^1.0.3",
+                        "has-property-descriptors": "^1.0.0",
                         "has-symbols": "^1.0.3",
                         "internal-slot": "^1.0.3",
                         "is-callable": "^1.2.4",
@@ -19640,10 +20430,17 @@
                         "object-inspect": "^1.12.0",
                         "object-keys": "^1.1.1",
                         "object.assign": "^4.1.2",
-                        "string.prototype.trimend": "^1.0.4",
-                        "string.prototype.trimstart": "^1.0.4",
-                        "unbox-primitive": "^1.0.1"
+                        "regexp.prototype.flags": "^1.4.1",
+                        "string.prototype.trimend": "^1.0.5",
+                        "string.prototype.trimstart": "^1.0.5",
+                        "unbox-primitive": "^1.0.2"
                     }
+                },
+                "has-bigints": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+                    "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+                    "dev": true
                 },
                 "has-symbols": {
                     "version": "1.0.3",
@@ -19662,6 +20459,40 @@
                     "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
                     "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
                     "dev": true
+                },
+                "string.prototype.trimend": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.5.tgz",
+                    "integrity": "sha512-I7RGvmjV4pJ7O3kdf+LXFpVfdNOxtCW/2C8f6jNiW4+PQchwxkCDzlk1/7p+Wl4bqFIZeF47qAHXLuHHWKAxog==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.2",
+                        "define-properties": "^1.1.4",
+                        "es-abstract": "^1.19.5"
+                    }
+                },
+                "string.prototype.trimstart": {
+                    "version": "1.0.5",
+                    "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.5.tgz",
+                    "integrity": "sha512-THx16TJCGlsN0o6dl2o6ncWUsdgnLRSA23rRE5pyGBw/mLr3Ej/R2LaqCtgP8VNMGZsvMWnf9ooZPyY2bHvUFg==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.2",
+                        "define-properties": "^1.1.4",
+                        "es-abstract": "^1.19.5"
+                    }
+                },
+                "unbox-primitive": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+                    "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+                    "dev": true,
+                    "requires": {
+                        "call-bind": "^1.0.2",
+                        "has-bigints": "^1.0.2",
+                        "has-symbols": "^1.0.3",
+                        "which-boxed-primitive": "^1.0.2"
+                    }
                 }
             }
         },
@@ -19909,72 +20740,59 @@
             "dev": true
         },
         "systeminformation": {
-            "version": "5.11.6",
-            "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.11.6.tgz",
-            "integrity": "sha512-7KBXgdnIDxABQ93w+GrPSrK/pup73+fM09VGka4A/+FhgzdlRY0JNGGDFmV8BHnFuzP9zwlI3n64yDbp7emasQ==",
+            "version": "5.11.14",
+            "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.11.14.tgz",
+            "integrity": "sha512-m8CJx3fIhKohanB0ExTk5q53uI1J0g5B09p77kU+KxnxRVpADVqTAwCg1PFelqKsj4LHd+qmVnumb511Hg4xow==",
             "dev": true
         },
         "table": {
-            "version": "6.8.0",
-            "resolved": "https://registry.npmjs.org/table/-/table-6.8.0.tgz",
-            "integrity": "sha512-s/fitrbVeEyHKFa7mFdkuQMWlH1Wgw/yEXMt5xACT4ZpzWFluehAxRtUUQKPuWhaLAWhFcVx6w3oC8VKaUfPGA==",
+            "version": "5.4.6",
+            "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
+            "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
             "dev": true,
             "requires": {
-                "ajv": "^8.0.1",
-                "lodash.truncate": "^4.4.2",
-                "slice-ansi": "^4.0.0",
-                "string-width": "^4.2.3",
-                "strip-ansi": "^6.0.1"
+                "ajv": "^6.10.2",
+                "lodash": "^4.17.14",
+                "slice-ansi": "^2.1.0",
+                "string-width": "^3.0.0"
             },
             "dependencies": {
-                "ajv": {
-                    "version": "8.11.0",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-                    "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
-                    "dev": true,
-                    "requires": {
-                        "fast-deep-equal": "^3.1.1",
-                        "json-schema-traverse": "^1.0.0",
-                        "require-from-string": "^2.0.2",
-                        "uri-js": "^4.2.2"
-                    }
-                },
                 "ansi-regex": {
-                    "version": "5.0.1",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-                    "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+                    "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
+                    "dev": true
+                },
+                "emoji-regex": {
+                    "version": "7.0.3",
+                    "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+                    "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
                     "dev": true
                 },
                 "is-fullwidth-code-point": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-                    "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-                    "dev": true
-                },
-                "json-schema-traverse": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-                    "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
                     "dev": true
                 },
                 "string-width": {
-                    "version": "4.2.3",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-                    "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+                    "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
                     "dev": true,
                     "requires": {
-                        "emoji-regex": "^8.0.0",
-                        "is-fullwidth-code-point": "^3.0.0",
-                        "strip-ansi": "^6.0.1"
+                        "emoji-regex": "^7.0.1",
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^5.1.0"
                     }
                 },
                 "strip-ansi": {
-                    "version": "6.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-                    "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+                    "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "^5.0.1"
+                        "ansi-regex": "^4.1.0"
                     }
                 }
             }
@@ -20581,9 +21399,9 @@
             }
         },
         "ts-node": {
-            "version": "10.6.0",
-            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.6.0.tgz",
-            "integrity": "sha512-CJen6+dfOXolxudBQXnVjRVvYTmTWbyz7cn+xq2XTsvnaXbHqr4gXSCNbS2Jj8yTZMuGwUoBESLaOkLascVVvg==",
+            "version": "10.7.0",
+            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.7.0.tgz",
+            "integrity": "sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==",
             "dev": true,
             "requires": {
                 "@cspotcode/source-map-support": "0.7.0",
@@ -20601,12 +21419,6 @@
                 "yn": "3.1.1"
             },
             "dependencies": {
-                "acorn": {
-                    "version": "8.7.1",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
-                    "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
-                    "dev": true
-                },
                 "acorn-walk": {
                     "version": "8.2.0",
                     "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
@@ -20726,9 +21538,9 @@
             }
         },
         "typescript": {
-            "version": "4.6.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
-            "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
+            "version": "4.6.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
+            "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
             "dev": true
         },
         "unbox-primitive": {
@@ -21949,9 +22761,9 @@
             "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
         },
         "winston": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/winston/-/winston-3.6.0.tgz",
-            "integrity": "sha512-9j8T75p+bcN6D00sF/zjFVmPp+t8KMPB1MzbbzYjeN9VWxdsYnTB40TkbNUEXAmILEfChMvAMgidlX64OG3p6w==",
+            "version": "3.7.2",
+            "resolved": "https://registry.npmjs.org/winston/-/winston-3.7.2.tgz",
+            "integrity": "sha512-QziIqtojHBoyzUOdQvQiar1DH0Xp9nF1A1y7NVy2DGEsz82SBDtOalS0ulTRGVT14xPX3WRWkCsdcJKqNflKng==",
             "dev": true,
             "requires": {
                 "@dabh/diagnostics": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
         "electron-devtools-installer": "3.2.0",
         "electron-notarize": "0.3.0",
         "mini-css-extract-plugin": "0.9.0",
-        "pc-nrfconnect-shared": "github:NordicSemiconductor/pc-nrfconnect-shared#v6.0.5",
+        "pc-nrfconnect-shared": "github:NordicSemiconductor/pc-nrfconnect-shared#v6.1.0",
         "playwright": "^1.16.3",
         "xvfb-maybe": "0.2.1"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nrfconnect",
-    "version": "3.11.1-pre1",
+    "version": "3.11.1-pre2",
     "description": "nRF Connect for Desktop",
     "repository": {
         "type": "git",

--- a/src/launcher/models/index.js
+++ b/src/launcher/models/index.js
@@ -48,4 +48,4 @@ function getImmutableApp(app) {
     });
 }
 
-export { getImmutableApp as default };
+export default getImmutableApp;

--- a/src/launcher/reducers/appsReducer.js
+++ b/src/launcher/reducers/appsReducer.js
@@ -94,6 +94,7 @@ function setAppReleaseNote(state, source, name, releaseNote) {
     );
 }
 
+// eslint-disable-next-line default-param-last -- Because this is a reducer, where this is the required signature
 const reducer = (state = initialState, action) => {
     switch (action.type) {
         case AppsActions.LOAD_LOCAL_APPS:

--- a/src/launcher/reducers/autoUpdateReducer.js
+++ b/src/launcher/reducers/autoUpdateReducer.js
@@ -37,6 +37,7 @@ function setPercentDownloadedAsInteger(state, percentDownloaded) {
     return state.set('percentDownloaded', parseInt(percentDownloaded, 10));
 }
 
+// eslint-disable-next-line default-param-last -- Because this is a reducer, where this is the required signature
 const reducer = (state = initialState, action) => {
     switch (action.type) {
         case AutoUpdateActions.AUTO_UPDATE_AVAILABLE:

--- a/src/launcher/reducers/proxyReducer.js
+++ b/src/launcher/reducers/proxyReducer.js
@@ -36,6 +36,7 @@ function setLoginRequestSent(state, username) {
     return hideLoginDialog(state).set('username', username);
 }
 
+// eslint-disable-next-line default-param-last -- Because this is a reducer, where this is the required signature
 const reducer = (state = initialState, action) => {
     switch (action.type) {
         case ProxyActions.PROXY_LOGIN_REQUESTED_BY_SERVER:

--- a/src/launcher/reducers/releaseNotesDialogReducer.js
+++ b/src/launcher/reducers/releaseNotesDialogReducer.js
@@ -14,6 +14,7 @@ const InitialState = Record({
 });
 const initialState = new InitialState();
 
+// eslint-disable-next-line default-param-last -- Because this is a reducer, where this is the required signature
 export default (state = initialState, action) => {
     switch (action.type) {
         case Actions.HIDE_RELEASE_NOTES:

--- a/src/launcher/reducers/settingsReducer.js
+++ b/src/launcher/reducers/settingsReducer.js
@@ -45,6 +45,7 @@ function removeSource(state, name) {
     return state.set('sources', newSources);
 }
 
+// eslint-disable-next-line default-param-last -- Because this is a reducer, where this is the required signature
 const reducer = (state = initialState, action) => {
     switch (action.type) {
         case SettingsActions.SETTINGS_LOAD:

--- a/src/main/net.js
+++ b/src/main/net.js
@@ -43,7 +43,7 @@ function downloadToBuffer(
     url,
     enableProxyLogin,
     headers = {},
-    progressIdentifiers
+    progressIdentifiers = undefined
 ) {
     return new Promise((resolve, reject) => {
         const request = net.request({

--- a/test-e2e/assertions.ts
+++ b/test-e2e/assertions.ts
@@ -8,12 +8,11 @@ import { expect, Page } from '@playwright/test';
 import { ElectronApplication } from 'playwright';
 
 const getTitleOfWindow = (app: ElectronApplication, page: Page) =>
-    new Promise(resolve =>
-        app
-            .browserWindow(page)
+    new Promise(resolve => {
+        app.browserWindow(page)
             .then(browserWindow => browserWindow.getProperty('title'))
-            .then(property => resolve(property.jsonValue()))
-    );
+            .then(property => resolve(property.jsonValue()));
+    });
 
 export const checkTitleOfWindow = async (
     app: ElectronApplication,

--- a/test-e2e/launchFirstApp.ts
+++ b/test-e2e/launchFirstApp.ts
@@ -7,7 +7,9 @@
 import { ElectronApplication } from 'playwright';
 
 const sleep = (millis: number) =>
-    new Promise(resolve => setTimeout(resolve, millis));
+    new Promise(resolve => {
+        setTimeout(resolve, millis);
+    });
 
 const waitForSecondWindow = async (
     app: ElectronApplication,


### PR DESCRIPTION
This makes the launcher ready for release testing 3.11.1.

The update to 6.1.0 makes apps (which not bundle `shared` 6.0.*) display an Audio Kit by its name. It also speeds up app launcher (at least under Windows, not yet testet on other platforms).