### PR TITLE
Add missing winston dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "nrfconnect",
-    "version": "3.11.1-pre1",
+    "version": "3.11.1-pre2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -1590,8 +1590,7 @@
         "@colors/colors": {
             "version": "1.5.0",
             "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
-            "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
-            "dev": true
+            "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="
         },
         "@cspotcode/source-map-consumer": {
             "version": "0.8.0",
@@ -1612,7 +1611,6 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.3.tgz",
             "integrity": "sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==",
-            "dev": true,
             "requires": {
                 "colorspace": "1.1.x",
                 "enabled": "2.0.x",
@@ -7313,7 +7311,6 @@
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
             "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
-            "dev": true,
             "requires": {
                 "color-convert": "^1.9.3",
                 "color-string": "^1.6.0"
@@ -7323,7 +7320,6 @@
                     "version": "1.9.3",
                     "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
                     "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-                    "dev": true,
                     "requires": {
                         "color-name": "1.1.3"
                     }
@@ -7331,8 +7327,7 @@
                 "color-name": {
                     "version": "1.1.3",
                     "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-                    "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-                    "dev": true
+                    "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
                 }
             }
         },
@@ -7353,7 +7348,6 @@
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
             "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
-            "dev": true,
             "requires": {
                 "color-name": "^1.0.0",
                 "simple-swizzle": "^0.2.2"
@@ -7375,7 +7369,6 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
             "integrity": "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==",
-            "dev": true,
             "requires": {
                 "color": "^3.1.3",
                 "text-hex": "1.0.x"
@@ -9074,8 +9067,7 @@
         "enabled": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
-            "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
-            "dev": true
+            "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
         },
         "encodeurl": {
             "version": "1.0.2",
@@ -10512,8 +10504,7 @@
         "fecha": {
             "version": "4.2.3",
             "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
-            "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
-            "dev": true
+            "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw=="
         },
         "figgy-pudding": {
             "version": "3.5.2",
@@ -10702,8 +10693,7 @@
         "fn.name": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
-            "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
-            "dev": true
+            "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
         },
         "focus-visible": {
             "version": "5.2.0",
@@ -12265,8 +12255,7 @@
         "is-stream": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-            "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-            "dev": true
+            "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="
         },
         "is-string": {
             "version": "1.0.7",
@@ -13866,8 +13855,7 @@
         "kuler": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
-            "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
-            "dev": true
+            "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
         },
         "language-subtag-registry": {
             "version": "0.3.21",
@@ -14068,7 +14056,6 @@
             "version": "2.4.0",
             "resolved": "https://registry.npmjs.org/logform/-/logform-2.4.0.tgz",
             "integrity": "sha512-CPSJw4ftjf517EhXZGGvTHHkYobo7ZCc0kvwUoOYcjfR2UVrI66RHj8MCrfAdEitdmFqbu2BYdYs8FHHZSb6iw==",
-            "dev": true,
             "requires": {
                 "@colors/colors": "1.5.0",
                 "fecha": "^4.2.0",
@@ -16162,7 +16149,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
             "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
-            "dev": true,
             "requires": {
                 "fn.name": "1.x.x"
             }
@@ -19324,8 +19310,7 @@
         "safe-stable-stringify": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.3.1.tgz",
-            "integrity": "sha512-kYBSfT+troD9cDA85VDnHZ1rpHC50O0g1e6WlGHVCz/g+JS+9WKLj+XwFYyR8UbrZN8ll9HUpDAAddY58MGisg==",
-            "dev": true
+            "integrity": "sha512-kYBSfT+troD9cDA85VDnHZ1rpHC50O0g1e6WlGHVCz/g+JS+9WKLj+XwFYyR8UbrZN8ll9HUpDAAddY58MGisg=="
         },
         "safer-buffer": {
             "version": "2.1.2",
@@ -19665,7 +19650,6 @@
             "version": "0.2.2",
             "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
             "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
-            "dev": true,
             "requires": {
                 "is-arrayish": "^0.3.1"
             },
@@ -19673,8 +19657,7 @@
                 "is-arrayish": {
                     "version": "0.3.2",
                     "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
-                    "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
-                    "dev": true
+                    "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
                 }
             }
         },
@@ -20055,8 +20038,7 @@
         "stack-trace": {
             "version": "0.0.10",
             "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-            "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA=",
-            "dev": true
+            "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
         },
         "stack-utils": {
             "version": "2.0.5",
@@ -21167,8 +21149,7 @@
         "text-hex": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
-            "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
-            "dev": true
+            "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
         },
         "text-table": {
             "version": "0.2.0",
@@ -21381,8 +21362,7 @@
         "triple-beam": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
-            "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw==",
-            "dev": true
+            "integrity": "sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw=="
         },
         "trough": {
             "version": "1.0.5",
@@ -22764,7 +22744,6 @@
             "version": "3.7.2",
             "resolved": "https://registry.npmjs.org/winston/-/winston-3.7.2.tgz",
             "integrity": "sha512-QziIqtojHBoyzUOdQvQiar1DH0Xp9nF1A1y7NVy2DGEsz82SBDtOalS0ulTRGVT14xPX3WRWkCsdcJKqNflKng==",
-            "dev": true,
             "requires": {
                 "@dabh/diagnostics": "^2.0.2",
                 "async": "^3.2.3",
@@ -22781,14 +22760,12 @@
                 "async": {
                     "version": "3.2.3",
                     "resolved": "https://registry.npmjs.org/async/-/async-3.2.3.tgz",
-                    "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==",
-                    "dev": true
+                    "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g=="
                 },
                 "readable-stream": {
                     "version": "3.6.0",
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
                     "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-                    "dev": true,
                     "requires": {
                         "inherits": "^2.0.3",
                         "string_decoder": "^1.1.1",
@@ -22798,14 +22775,12 @@
                 "safe-buffer": {
                     "version": "5.2.1",
                     "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-                    "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-                    "dev": true
+                    "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
                 },
                 "string_decoder": {
                     "version": "1.3.0",
                     "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
                     "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-                    "dev": true,
                     "requires": {
                         "safe-buffer": "~5.2.0"
                     }
@@ -22816,7 +22791,6 @@
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.5.0.tgz",
             "integrity": "sha512-YpZzcUzBedhlTAfJg6vJDlyEai/IFMIVcaEZZyl3UXIl4gmqRpU7AE89AHLkbzLUsv0NVmw7ts+iztqKxxPW1Q==",
-            "dev": true,
             "requires": {
                 "logform": "^2.3.2",
                 "readable-stream": "^3.6.0",
@@ -22827,7 +22801,6 @@
                     "version": "3.6.0",
                     "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
                     "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-                    "dev": true,
                     "requires": {
                         "inherits": "^2.0.3",
                         "string_decoder": "^1.1.1",
@@ -22837,14 +22810,12 @@
                 "safe-buffer": {
                     "version": "5.2.1",
                     "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-                    "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-                    "dev": true
+                    "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
                 },
                 "string_decoder": {
                     "version": "1.3.0",
                     "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
                     "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-                    "dev": true,
                     "requires": {
                         "safe-buffer": "~5.2.0"
                     }

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
         "sudo-prompt": "^9.2.1",
         "targz": "1.0.1",
         "uuid": "8.1.0",
+        "winston": "3.7.2",
         "yargs": "15.3.1"
     },
     "eslintConfig": {


### PR DESCRIPTION
Because we now use `winston` in `src/main/autoUpdate.js` (which we do not bundle), we must now include `winston` as a normal dependency. Otherwise we get an error when launching the built executable.
