### PR TITLE
Fix slow npm install

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16516,7 +16516,7 @@
                 "jszip": "^3.7.1",
                 "nan": "^2.14.0",
                 "node-abi": "^3.2.0",
-                "prebuild": "github:NordicPlayground/prebuild",
+                "prebuild": "https://github.com/NordicPlayground/prebuild",
                 "prebuild-install": "^6.0.0",
                 "underscore": "^1.13.1"
             },
@@ -16601,8 +16601,8 @@
                     }
                 },
                 "prebuild": {
-                    "version": "github:NordicPlayground/prebuild#33b6468a985f05194a2f96a5de1ffe147e95c222",
-                    "from": "github:NordicPlayground/prebuild",
+                    "version": "https://github.com/NordicPlayground/prebuild#33b6468a985f05194a2f96a5de1ffe147e95c222",
+                    "from": "https://github.com/NordicPlayground/prebuild",
                     "requires": {
                         "cmake-js": "*",
                         "detect-libc": "^1.0.3",
@@ -16720,8 +16720,8 @@
             }
         },
         "pc-nrfconnect-shared": {
-            "version": "github:NordicSemiconductor/pc-nrfconnect-shared#3ccd7f7ec6b03e012009162f9c04c5f7a62691aa",
-            "from": "github:NordicSemiconductor/pc-nrfconnect-shared#v6.2.2",
+            "version": "https://github.com/NordicSemiconductor/pc-nrfconnect-shared#3ccd7f7ec6b03e012009162f9c04c5f7a62691aa",
+            "from": "https://github.com/NordicSemiconductor/pc-nrfconnect-shared#v6.2.2",
             "dev": true,
             "requires": {
                 "@babel/core": "7.17.10",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
         "electron-devtools-installer": "3.2.0",
         "electron-notarize": "0.3.0",
         "mini-css-extract-plugin": "0.9.0",
-        "pc-nrfconnect-shared": "github:NordicSemiconductor/pc-nrfconnect-shared#v6.2.2",
+        "pc-nrfconnect-shared": "https://github.com/NordicSemiconductor/pc-nrfconnect-shared#v6.2.2",
         "playwright": "^1.16.3",
         "xvfb-maybe": "0.2.1"
     },


### PR DESCRIPTION
Those slow runs of npm install/npm ci are caused by the combination of using npm@6 and github:-URLs for some dependencies: https://twitter.com/colincoller/status/1526369611490508803

When using `github:`, npm (at least in v6, seems to be fixed later) first tries to use a `git:`-URL and it takes some time until that goes into a timeout (and is also retried).

So, this removes all uses of github:, which makes `npm ci` run in less than a minute on my machine (compare to several minutes before.)

GitHub turned off support for git:-URLs for security reasons: https://github.blog/2021-09-01-improving-git-protocol-security-github/ But it was already switched off in March, so I have no clue why this escalates now.
