### PR TITLE
Fix: BLE app problem on macOS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "nrfconnect",
-    "version": "3.11.1-pre4",
+    "version": "3.11.1-pre5",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -3434,9 +3434,9 @@
             }
         },
         "@nordicsemiconductor/nrf-device-lib-js": {
-            "version": "0.4.10",
-            "resolved": "https://registry.npmjs.org/@nordicsemiconductor/nrf-device-lib-js/-/nrf-device-lib-js-0.4.10.tgz",
-            "integrity": "sha512-uT5iIF1wgP4gcLsQR0a1sj//+R80AVRBU/3kMJg6jGLJPqbkgrU+tFGXqryW//DW4aPNCtVjnZBxB4/B5R+8sw==",
+            "version": "0.4.11",
+            "resolved": "https://registry.npmjs.org/@nordicsemiconductor/nrf-device-lib-js/-/nrf-device-lib-js-0.4.11.tgz",
+            "integrity": "sha512-BRCb+aaVVqoVEhONOoDgC+ZrnLTFEZ5opIVYQ65ZO11G0nVftcuJHGfKoiKLIOeWyRMsvmCwcaqwBmvDVY5Hjw==",
             "requires": {
                 "cmake-js": "^6.1.0",
                 "fs": "0.0.1-security",
@@ -3492,9 +3492,9 @@
                     "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="
                 },
                 "node-abi": {
-                    "version": "3.15.0",
-                    "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.15.0.tgz",
-                    "integrity": "sha512-Ic6z/j6I9RLm4ov7npo1I48UQr2BEyFCqh6p7S1dhEx9jPO0GPGq/e2Rb7x7DroQrmiVMz/Bw1vJm9sPAl2nxA==",
+                    "version": "3.22.0",
+                    "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.22.0.tgz",
+                    "integrity": "sha512-u4uAs/4Zzmp/jjsD9cyFYDXeISfUWaAVWshPmDZOFOv4Xl4SbzTXm53I04C2uRueYJ+0t5PEtLH/owbn2Npf/w==",
                     "requires": {
                         "semver": "^7.3.5"
                     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nrfconnect",
-    "version": "3.11.1-pre4",
+    "version": "3.11.1-pre5",
     "description": "nRF Connect for Desktop",
     "repository": {
         "type": "git",
@@ -97,7 +97,7 @@
     "dependencies": {
         "@electron/remote": "^2.0.4",
         "@mdi/font": "3.7.95",
-        "@nordicsemiconductor/nrf-device-lib-js": "0.4.10",
+        "@nordicsemiconductor/nrf-device-lib-js": "0.4.11",
         "axios": "0.22.0",
         "chmodr": "1.2.0",
         "electron-store": "8.0.1",


### PR DESCRIPTION
Updates `nrf-device-lib-js` to 0.4.11.