### PR TITLE
Attempt to bring window to front.

### DIFF
--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -17,6 +17,8 @@
   ; Put the files to the output directory.
   File "${BUILD_RESOURCES_DIR}\drivers\nrf-device-lib-driver-installer.exe"
 
+  BringToFront
+
   ExecShell 'runas' '"$INSTDIR\nrf-device-lib-driver-installer.exe"'
 
   ; ===============================================================
@@ -39,7 +41,7 @@
   !define JLinkInstaller "JLink_Windows_${BundledJLinkVersion}.exe"
   !define JlinkInstallerResPath "${BUILD_RESOURCES_DIR}\${JLinkInstaller}"
   !define JLinkRegistryRoot "SOFTWARE\Segger\J-Link"
-  
+
   File ${JlinkInstallerResPath}
 
   ; Check if the version exist in the registry


### PR DESCRIPTION
During installation (on windows), there will be prompts to install other software machine-wide (jlink and nrf device lib driver). This causes an issue when users have focused away from the installer, causing the admin-elevation prompts to "hide" on the start-menu, instead of popping up for user consent. Bringing the installer into focus will mitigate this, even though it seems it doesn't always work (possible race condition between bringing window to focus and starting installation.