### PR TITLE
Remove shared from app bundle

### DIFF
--- a/src/app/initApp.js
+++ b/src/app/initApp.js
@@ -4,11 +4,19 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
+import { getGlobal } from '@electron/remote';
 import fs from 'fs';
 import path from 'path';
-import { getUserDataDir, setAppDirs } from 'pc-nrfconnect-shared';
 
 import { mkdirIfNotExists } from '../main/mkdir';
+
+const getUserDataDir = () => getGlobal('userDataDir');
+
+function setAppDirs(newAppDir, newAppDataDir, newAppLogDir) {
+    window.appDir = newAppDir;
+    window.appDataDir = newAppDataDir;
+    window.appLogDir = newAppLogDir;
+}
 
 /**
  * Load an app from the given directory dynamically.

--- a/src/app/module-loader.js
+++ b/src/app/module-loader.js
@@ -55,7 +55,6 @@ hostedModules['@electron/remote'] = require('@electron/remote');
 hostedModules[
     '@nordicsemiconductor/nrf-device-lib-js'
 ] = require('@nordicsemiconductor/nrf-device-lib-js');
-hostedModules['pc-nrfconnect-shared'] = require('pc-nrfconnect-shared');
 hostedModules['react-dom'] = require('react-dom');
 hostedModules['react-redux'] = require('react-redux');
 hostedModules['react'] = require('react');


### PR DESCRIPTION
When all apps are upgraded to shared version 6 (bundled shared), this will remove shared from the bundle that initializes the apps. Causing a big decrease in bundle size and skipping unnecessary code running today when an app is loaded.

The only known remaining app on < 6 is ppk, which will release with an upgraded shared soon hopefully.