### PR TITLE
Cleanup: convert remaining IPC code

### DIFF
--- a/src/ipc/appDetails.ts
+++ b/src/ipc/appDetails.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import { ipcMain, ipcRenderer, WebContents } from 'electron';
+
+import { LaunchableApp } from './apps';
+
+const channel = {
+    request: 'get-app-details',
+    response: 'app-details',
+};
+
+export type AppDetails = LaunchableApp & {
+    coreVersion: string;
+    corePath: string;
+    homeDir: string;
+    tmpDir: string;
+    bundledJlink: string;
+};
+
+// Currently the function to send this IPC message is not called from
+// anywhere, but the same IPC message is sent from apps.
+export const sendFromRenderer = () => ipcRenderer.send(channel.request);
+
+export const registerHandlerFromMain = (
+    getAppDetails: (webContents: WebContents) => AppDetails
+) =>
+    ipcMain.on(channel.request, event => {
+        event.sender.send(channel.response, getAppDetails(event.sender));
+    });

--- a/src/ipc/openWindow.ts
+++ b/src/ipc/openWindow.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import { ipcMain, ipcRenderer } from 'electron';
+
+import { LaunchableApp } from './apps';
+
+const channel = {
+    app: 'open:app',
+    launcher: 'open:launcher',
+};
+
+// open app
+export const sendOpenAppFromRender = (app: LaunchableApp) =>
+    ipcRenderer.send(channel.app, app);
+
+export const registerOpenAppHandlerFromMain = (
+    onOpenApp: typeof sendOpenAppFromRender
+) =>
+    ipcMain.on(
+        channel.app,
+        (_event, ...args: Parameters<typeof sendOpenAppFromRender>) =>
+            onOpenApp(...args)
+    );
+
+// open launcher
+
+// Currently this functions to send this IPC message is not called from
+// anywhere. We do send messages over the same IPC channel by using the
+// corresponding name from some apps and we want to switch using this function
+// in the future.
+export const sendOpenLauncherFromRender = () =>
+    ipcRenderer.send(channel.launcher);
+
+export const registerOpenLauncherHandlerFromMain = (
+    onOpenLauncher: typeof sendOpenLauncherFromRender
+) => ipcMain.on(channel.launcher, onOpenLauncher);

--- a/src/ipc/preventSleep.ts
+++ b/src/ipc/preventSleep.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import { ipcMain, ipcRenderer, powerSaveBlocker } from 'electron';
+
+const channel = {
+    start: 'prevent-sleep:start',
+    end: 'prevent-sleep:end',
+};
+
+// Currently the functions to send these IPC messages are not called from
+// anywhere, but we want to enable apps to prevent sleep, e.g.during long
+// running operations. So this might change in the future.
+
+// Start
+export const invokeStartFromRenderer = (): Promise<number> =>
+    ipcRenderer.invoke(channel.start);
+
+export const registerStartHandlerFromMain = () =>
+    ipcMain.handle(channel.start, () =>
+        powerSaveBlocker.start('prevent-app-suspension')
+    );
+
+// End
+export const sendEndFromRender = (id: number) =>
+    ipcRenderer.send(channel.end, id);
+
+export const registerEndHandlerFromMain = () =>
+    ipcMain.on(channel.end, (_event, id: number) => powerSaveBlocker.stop(id));

--- a/src/launcher/actions/appsActions.js
+++ b/src/launcher/actions/appsActions.js
@@ -5,7 +5,6 @@
  */
 
 import { getCurrentWindow, require as remoteRequire } from '@electron/remote';
-import { ipcRenderer } from 'electron';
 import { join } from 'path';
 import { ErrorDialogActions } from 'pc-nrfconnect-shared';
 
@@ -17,6 +16,7 @@ import {
     invokeRemoveDownloadableAppFromRenderer as removeDownloadableAppInMain,
 } from '../../ipc/apps';
 import { invokeFromRenderer as downloadToFile } from '../../ipc/downloadToFile';
+import { sendOpenAppFromRender as openApp } from '../../ipc/openWindow';
 import {
     invokeGetFromRenderer as getSetting,
     sendSetFromRenderer as setSetting,
@@ -461,7 +461,7 @@ export function launch(app) {
         `App version: ${appObj.currentVersion};` +
         ` Engine version: ${appObj.engineVersion};`;
     sendAppUsageData(EventAction.LAUNCH_APP, sharedData, appObj.name);
-    ipcRenderer.send('open-app', appObj);
+    openApp(appObj);
 }
 
 export function checkEngineAndLaunch(app) {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -11,53 +11,14 @@ import { initialize as initializeElectronRemote } from '@electron/remote/main';
 import { app as electronApp, dialog, Menu } from 'electron';
 import { join } from 'path';
 
-import { registerHandlerFromMain as registerAppDetailsHandler } from '../ipc/appDetails';
-import {
-    registerDownloadAllAppsJsonFilesHandlerFromMain as registerDownloadAllAppsJsonFilesHandler,
-    registerDownloadReleaseNotesHandlerFromMain as registerDownloadReleaseNotesHandler,
-    registerGetDownloadableAppsHandlerFromMain as registerGetDownloadableAppsHandler,
-    registerGetLocalAppsHandlerFromMain as registerGetLocalAppsHandler,
-    registerInstallDownloadableAppHandlerFromMain as registerInstallDownloadableAppHandler,
-    registerRemoveDownloadableAppHandlerFromMain as registerRemoveDownloadableAppHandler,
-} from '../ipc/apps';
-import { registerHandlerFromMain as registerCreateDesktopShortcutHandler } from '../ipc/createDesktopShortcut';
-import { registerHandlerFromMain as registerDownloadToFileHandler } from '../ipc/downloadToFile';
-import {
-    registerCancelUpdateHandlerFromMain as registerCancelUpdateHandler,
-    registerCheckForUpdateHandlerFromMain as registerCheckForUpdateHandler,
-    registerStartUpdateHandlerFromMain as registerStartUpdateHandler,
-} from '../ipc/launcherUpdate';
-import {
-    registerOpenAppHandlerFromMain as registerOpenAppHandler,
-    registerOpenLauncherHandlerFromMain as registerOpenLauncherHandler,
-} from '../ipc/openWindow';
-import {
-    registerEndHandlerFromMain as registerEndPreventSleepHandler,
-    registerStartHandlerFromMain as registerStartPreventSleepHandler,
-} from '../ipc/preventSleep';
-import { registerHandlerFromMain as registerProxyLoginCredentialsHandler } from '../ipc/proxyLogin';
-import {
-    registerGetHandlerFromMain as registerGetSettingHandler,
-    registerSetHandlerFromMain as registerSetSettingHandler,
-} from '../ipc/settings';
-import {
-    registerAddHandlerFromMain as registerAddSourceHandler,
-    registerGetHandlerFromMain as registerGetSourcesHandler,
-    registerRemoveHandlerFromMain as registerRemoveSourceHandler,
-} from '../ipc/sources';
 import * as apps from './apps';
-import { cancelUpdate, checkForUpdate, startUpdate } from './autoUpdate';
 import * as config from './config';
-import createDesktopShortcut from './createDesktopShortcut';
 import describeError from './describeError';
 import loadDevtools from './devtools';
 import { createTextFile } from './fileUtil';
 import { logger } from './log';
 import { createMenu } from './menu';
-import { downloadToFile } from './net';
-import { callRegisteredCallback } from './proxyLogins';
-import * as settings from './settings';
-import * as sources from './sources';
+import registerIpcHandler from './registerIpcHandler';
 import * as windows from './windows';
 
 initializeElectronRemote();
@@ -98,12 +59,12 @@ electronApp.on('ready', async () => {
     }
 });
 
-electronApp.on('render-process-gone', (event, wc, details) => {
+electronApp.on('render-process-gone', (_event, wc, details) => {
     wc.getTitle();
     logger.error(`Renderer crashed ${wc.getTitle()}`, details);
 });
 
-electronApp.on('child-process-gone', (event, details) => {
+electronApp.on('child-process-gone', (_event, details) => {
     logger.error(`Child process crashed `, details);
 });
 
@@ -111,36 +72,7 @@ electronApp.on('window-all-closed', () => {
     electronApp.quit();
 });
 
-registerAppDetailsHandler(windows.getAppDetails);
-
-registerDownloadToFileHandler(downloadToFile);
-registerCreateDesktopShortcutHandler(createDesktopShortcut);
-
-registerGetSettingHandler(settings.get);
-registerSetSettingHandler(settings.set);
-
-registerEndPreventSleepHandler();
-registerStartPreventSleepHandler();
-
-registerProxyLoginCredentialsHandler(callRegisteredCallback);
-
-registerCheckForUpdateHandler(checkForUpdate);
-registerStartUpdateHandler(startUpdate);
-registerCancelUpdateHandler(cancelUpdate);
-
-registerOpenAppHandler(windows.openAppWindow);
-registerOpenLauncherHandler(windows.openLauncherWindow);
-
-registerDownloadAllAppsJsonFilesHandler(apps.downloadAllAppsJsonFiles);
-registerGetLocalAppsHandler(apps.getLocalApps);
-registerGetDownloadableAppsHandler(apps.getDownloadableApps);
-registerDownloadReleaseNotesHandler(apps.downloadReleaseNotes);
-registerInstallDownloadableAppHandler(apps.installDownloadableApp);
-registerRemoveDownloadableAppHandler(apps.removeDownloadableApp);
-
-registerGetSourcesHandler(sources.getAllSources);
-registerAddSourceHandler(sources.addSource);
-registerRemoveSourceHandler(sources.removeSource);
+registerIpcHandler();
 
 /**
  * Let's store the full path to the executable if nRFConnect was started from a built package.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -8,7 +8,7 @@
 import './init';
 
 import { initialize as initializeElectronRemote } from '@electron/remote/main';
-import { app as electronApp, dialog, ipcMain, Menu } from 'electron';
+import { app as electronApp, dialog, Menu } from 'electron';
 import { join } from 'path';
 
 import { registerHandlerFromMain as registerAppDetailsHandler } from '../ipc/appDetails';
@@ -27,6 +27,10 @@ import {
     registerCheckForUpdateHandlerFromMain as registerCheckForUpdateHandler,
     registerStartUpdateHandlerFromMain as registerStartUpdateHandler,
 } from '../ipc/launcherUpdate';
+import {
+    registerOpenAppHandlerFromMain as registerOpenAppHandler,
+    registerOpenLauncherHandlerFromMain as registerOpenLauncherHandler,
+} from '../ipc/openWindow';
 import {
     registerEndHandlerFromMain as registerEndPreventSleepHandler,
     registerStartHandlerFromMain as registerStartPreventSleepHandler,
@@ -107,14 +111,6 @@ electronApp.on('window-all-closed', () => {
     electronApp.quit();
 });
 
-ipcMain.on('open-app-launcher', () => {
-    windows.openLauncherWindow();
-});
-
-ipcMain.on('open-app', (event, app) => {
-    windows.openAppWindow(app);
-});
-
 registerAppDetailsHandler(windows.getAppDetails);
 
 registerDownloadToFileHandler(downloadToFile);
@@ -131,6 +127,9 @@ registerProxyLoginCredentialsHandler(callRegisteredCallback);
 registerCheckForUpdateHandler(checkForUpdate);
 registerStartUpdateHandler(startUpdate);
 registerCancelUpdateHandler(cancelUpdate);
+
+registerOpenAppHandler(windows.openAppWindow);
+registerOpenLauncherHandler(windows.openLauncherWindow);
 
 registerDownloadAllAppsJsonFilesHandler(apps.downloadAllAppsJsonFiles);
 registerGetLocalAppsHandler(apps.getLocalApps);

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -11,6 +11,7 @@ import { initialize as initializeElectronRemote } from '@electron/remote/main';
 import { app as electronApp, dialog, ipcMain, Menu } from 'electron';
 import { join } from 'path';
 
+import { registerHandlerFromMain as registerAppDetailsHandler } from '../ipc/appDetails';
 import {
     registerDownloadAllAppsJsonFilesHandlerFromMain as registerDownloadAllAppsJsonFilesHandler,
     registerDownloadReleaseNotesHandlerFromMain as registerDownloadReleaseNotesHandler,
@@ -114,19 +115,7 @@ ipcMain.on('open-app', (event, app) => {
     windows.openAppWindow(app);
 });
 
-ipcMain.on('get-app-details', event => {
-    const appWindow = windows.getAppWindow(event.sender);
-    if (appWindow) {
-        event.sender.send('app-details', {
-            coreVersion: config.getVersion(),
-            corePath: config.getElectronRootPath(),
-            homeDir: config.getHomeDir(),
-            tmpDir: config.getTmpDir(),
-            bundledJlink: config.getBundledJlinkVersion(),
-            ...appWindow.app,
-        });
-    }
-});
+registerAppDetailsHandler(windows.getAppDetails);
 
 registerDownloadToFileHandler(downloadToFile);
 registerCreateDesktopShortcutHandler(createDesktopShortcut);

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -8,13 +8,7 @@
 import './init';
 
 import { initialize as initializeElectronRemote } from '@electron/remote/main';
-import {
-    app as electronApp,
-    dialog,
-    ipcMain,
-    Menu,
-    powerSaveBlocker,
-} from 'electron';
+import { app as electronApp, dialog, ipcMain, Menu } from 'electron';
 import { join } from 'path';
 
 import {
@@ -32,6 +26,10 @@ import {
     registerCheckForUpdateHandlerFromMain as registerCheckForUpdateHandler,
     registerStartUpdateHandlerFromMain as registerStartUpdateHandler,
 } from '../ipc/launcherUpdate';
+import {
+    registerEndHandlerFromMain as registerEndPreventSleepHandler,
+    registerStartHandlerFromMain as registerStartPreventSleepHandler,
+} from '../ipc/preventSleep';
 import { registerHandlerFromMain as registerProxyLoginCredentialsHandler } from '../ipc/proxyLogin';
 import {
     registerGetHandlerFromMain as registerGetSettingHandler,
@@ -130,19 +128,14 @@ ipcMain.on('get-app-details', event => {
     }
 });
 
-ipcMain.handle('prevent-sleep-start', () =>
-    powerSaveBlocker.start('prevent-app-suspension')
-);
-
-ipcMain.on('preventing-sleep-end', (_, id) =>
-    powerSaveBlocker.stop(Number(id))
-);
-
 registerDownloadToFileHandler(downloadToFile);
 registerCreateDesktopShortcutHandler(createDesktopShortcut);
 
 registerGetSettingHandler(settings.get);
 registerSetSettingHandler(settings.set);
+
+registerEndPreventSleepHandler();
+registerStartPreventSleepHandler();
 
 registerProxyLoginCredentialsHandler(callRegisteredCallback);
 

--- a/src/main/registerIpcHandler.ts
+++ b/src/main/registerIpcHandler.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import { registerHandlerFromMain as registerAppDetailsHandler } from '../ipc/appDetails';
+import {
+    registerDownloadAllAppsJsonFilesHandlerFromMain as registerDownloadAllAppsJsonFilesHandler,
+    registerDownloadReleaseNotesHandlerFromMain as registerDownloadReleaseNotesHandler,
+    registerGetDownloadableAppsHandlerFromMain as registerGetDownloadableAppsHandler,
+    registerGetLocalAppsHandlerFromMain as registerGetLocalAppsHandler,
+    registerInstallDownloadableAppHandlerFromMain as registerInstallDownloadableAppHandler,
+    registerRemoveDownloadableAppHandlerFromMain as registerRemoveDownloadableAppHandler,
+} from '../ipc/apps';
+import { registerHandlerFromMain as registerCreateDesktopShortcutHandler } from '../ipc/createDesktopShortcut';
+import { registerHandlerFromMain as registerDownloadToFileHandler } from '../ipc/downloadToFile';
+import {
+    registerCancelUpdateHandlerFromMain as registerCancelUpdateHandler,
+    registerCheckForUpdateHandlerFromMain as registerCheckForUpdateHandler,
+    registerStartUpdateHandlerFromMain as registerStartUpdateHandler,
+} from '../ipc/launcherUpdate';
+import {
+    registerOpenAppHandlerFromMain as registerOpenAppHandler,
+    registerOpenLauncherHandlerFromMain as registerOpenLauncherHandler,
+} from '../ipc/openWindow';
+import {
+    registerEndHandlerFromMain as registerEndPreventSleepHandler,
+    registerStartHandlerFromMain as registerStartPreventSleepHandler,
+} from '../ipc/preventSleep';
+import { registerHandlerFromMain as registerProxyLoginCredentialsHandler } from '../ipc/proxyLogin';
+import {
+    registerGetHandlerFromMain as registerGetSettingHandler,
+    registerSetHandlerFromMain as registerSetSettingHandler,
+} from '../ipc/settings';
+import {
+    registerAddHandlerFromMain as registerAddSourceHandler,
+    registerGetHandlerFromMain as registerGetSourcesHandler,
+    registerRemoveHandlerFromMain as registerRemoveSourceHandler,
+} from '../ipc/sources';
+import {
+    downloadAllAppsJsonFiles,
+    downloadReleaseNotes,
+    getDownloadableApps,
+    getLocalApps,
+    installDownloadableApp,
+    removeDownloadableApp,
+} from './apps';
+import { cancelUpdate, checkForUpdate, startUpdate } from './autoUpdate';
+import createDesktopShortcut from './createDesktopShortcut';
+import { downloadToFile } from './net';
+import { callRegisteredCallback } from './proxyLogins';
+import { get as getSetting, set as setSetting } from './settings';
+import { addSource, getAllSources, removeSource } from './sources';
+import { getAppDetails, openAppWindow, openLauncherWindow } from './windows';
+
+export default () => {
+    registerAppDetailsHandler(getAppDetails);
+
+    registerDownloadToFileHandler(downloadToFile);
+    registerCreateDesktopShortcutHandler(createDesktopShortcut);
+
+    registerGetSettingHandler(getSetting);
+    registerSetSettingHandler(setSetting);
+
+    registerEndPreventSleepHandler();
+    registerStartPreventSleepHandler();
+
+    registerProxyLoginCredentialsHandler(callRegisteredCallback);
+
+    registerCheckForUpdateHandler(checkForUpdate);
+    registerStartUpdateHandler(startUpdate);
+    registerCancelUpdateHandler(cancelUpdate);
+
+    registerOpenAppHandler(openAppWindow);
+    registerOpenLauncherHandler(openLauncherWindow);
+
+    registerDownloadAllAppsJsonFilesHandler(downloadAllAppsJsonFiles);
+    registerGetLocalAppsHandler(getLocalApps);
+    registerGetDownloadableAppsHandler(getDownloadableApps);
+    registerDownloadReleaseNotesHandler(downloadReleaseNotes);
+    registerInstallDownloadableAppHandler(installDownloadableApp);
+    registerRemoveDownloadableAppHandler(removeDownloadableApp);
+
+    registerGetSourcesHandler(getAllSources);
+    registerAddSourceHandler(addSource);
+    registerRemoveSourceHandler(removeSource);
+};

--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -13,6 +13,7 @@ import {
 } from 'electron';
 import path from 'path';
 
+import { AppDetails } from '../ipc/appDetails';
 import { InstalledDownloadableApp, LaunchableApp } from '../ipc/apps';
 import { registerLauncherWindowFromMain as registerLauncherWindow } from '../ipc/sendToLauncherWindow';
 import * as apps from './apps';
@@ -182,7 +183,26 @@ export const openLocalAppWindow = (appName: string) =>
         }
     });
 
-export const getAppWindow = (sender: WebContents) => {
+const getAppWindow = (sender: WebContents) => {
     const parentWindow = BrowserWindow.fromWebContents(sender);
     return appWindows.find(appWin => appWin.browserWindow === parentWindow);
+};
+
+export const getAppDetails = (webContents: WebContents): AppDetails => {
+    const appWindow = getAppWindow(webContents);
+
+    if (appWindow == null) {
+        throw new Error(
+            `No app window found for webContents '${webContents.getTitle()}' ${webContents.getURL()}`
+        );
+    }
+
+    return {
+        coreVersion: config.getVersion(),
+        corePath: config.getElectronRootPath(),
+        homeDir: config.getHomeDir(),
+        tmpDir: config.getTmpDir(),
+        bundledJlink: config.getBundledJlinkVersion(),
+        ...appWindow.app,
+    };
 };


### PR DESCRIPTION
- Move the remaining IPC code into `src/ipc/`.
- Extract the whole code to register all IPC handlers from `src/main/index.ts` into its own file `src/main/registerIpcHandler.ts`.