### PR TITLE
Feature: Show loading infos about downloadable apps

### DIFF
--- a/src/launcher/actions/autoUpdateActions.js
+++ b/src/launcher/actions/autoUpdateActions.js
@@ -86,7 +86,6 @@ export function downloadLatestAppInfo(options = { rejectIfError: false }) {
             .then(() =>
                 dispatch(AppsActions.downloadLatestAppInfoSuccessAction())
             )
-            .then(() => dispatch(AppsActions.loadOfficialApps()))
             .catch(error => {
                 dispatch(AppsActions.downloadLatestAppInfoErrorAction());
                 if (options.rejectIfError) {

--- a/src/launcher/components/AppManagementView.jsx
+++ b/src/launcher/components/AppManagementView.jsx
@@ -12,6 +12,7 @@ import AppManagementFilter from '../containers/AppManagementFilterContainer';
 import ReleaseNotesDialog from '../containers/ReleaseNotesDialogContainer';
 import WithScrollbarContainer from '../containers/WithScrollbarContainer';
 import AppItem from './AppItem';
+import LoadingDownloadableAppsIndicator from './LoadingDownloadableAppsIndicator';
 
 const AppManagementView = ({
     apps,
@@ -29,6 +30,7 @@ const AppManagementView = ({
 }) => (
     <>
         <AppManagementFilter apps={apps} sources={sources} />
+        <LoadingDownloadableAppsIndicator />
         <WithScrollbarContainer hasFilter>
             {apps.map(app => (
                 <AppItem

--- a/src/launcher/components/LoadingDownloadableAppsIndicator.jsx
+++ b/src/launcher/components/LoadingDownloadableAppsIndicator.jsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2015 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { classNames, Spinner } from 'pc-nrfconnect-shared';
+
+import styles from './loadingDownloadableAppsIndicator.module.scss';
+
+export default () => {
+    const isLoadingOfficialApps = useSelector(
+        state => state.apps.isLoadingOfficialApps
+    );
+
+    return (
+        <div
+            className={classNames(
+                styles.indicator,
+                isLoadingOfficialApps ? styles.visible : styles.hidden
+            )}
+        >
+            <Spinner /> Loading infos about downloadable apps …
+        </div>
+    );
+};

--- a/src/launcher/components/__tests__/AppManagementView-test.jsx
+++ b/src/launcher/components/__tests__/AppManagementView-test.jsx
@@ -20,17 +20,31 @@ jest.mock('../../containers/AppManagementFilterContainer', () => 'div');
 jest.mock('../../containers/ReleaseNotesDialogContainer', () => 'div');
 
 import React from 'react';
+import { Provider } from 'react-redux';
 import renderer from 'react-test-renderer';
+import { configureStore } from '@reduxjs/toolkit';
 import { mount } from 'enzyme';
 import { List } from 'immutable';
 
 import getImmutableApp from '../../models';
 import AppManagementView from '../AppManagementView';
 
+const dummyStore = configureStore({
+    reducer: () => ({
+        apps: { isLoadingOfficialApps: false },
+    }),
+});
+
+const mountWithStore = component =>
+    mount(<Provider store={dummyStore}>{component}</Provider>);
+
+const rendererCreateWithStore = component =>
+    renderer.create(<Provider store={dummyStore}>{component}</Provider>);
+
 describe('AppManagementView', () => {
     it('should render without any apps', () => {
         expect(
-            renderer.create(
+            rendererCreateWithStore(
                 <AppManagementView
                     apps={List()}
                     isRetrievingApps={false}
@@ -49,7 +63,7 @@ describe('AppManagementView', () => {
 
     it('should render not-installed, installed, and upgradable apps', () => {
         expect(
-            renderer.create(
+            rendererCreateWithStore(
                 <AppManagementView
                     apps={List([
                         getImmutableApp({
@@ -87,7 +101,7 @@ describe('AppManagementView', () => {
 
     it('should disable buttons and display "Installing..." button text when installing app', () => {
         expect(
-            renderer.create(
+            rendererCreateWithStore(
                 <AppManagementView
                     apps={List([
                         getImmutableApp({
@@ -114,7 +128,7 @@ describe('AppManagementView', () => {
 
     it('should disable buttons and display "Removing..." button text when removing app', () => {
         expect(
-            renderer.create(
+            rendererCreateWithStore(
                 <AppManagementView
                     apps={List([
                         getImmutableApp({
@@ -143,7 +157,7 @@ describe('AppManagementView', () => {
 
     it('should disable buttons and display "Upgrading..." button text when upgrading app', () => {
         expect(
-            renderer.create(
+            rendererCreateWithStore(
                 <AppManagementView
                     apps={List([
                         getImmutableApp({
@@ -179,7 +193,7 @@ describe('AppManagementView', () => {
             url: 'https://foo.bar/dists/beta',
         });
         const onInstall = jest.fn();
-        const wrapper = mount(
+        const wrapper = mountWithStore(
             <AppManagementView
                 apps={List([app])}
                 isRetrievingApps={false}
@@ -210,7 +224,7 @@ describe('AppManagementView', () => {
             source: 'beta',
         });
         const onRemove = jest.fn();
-        const wrapper = mount(
+        const wrapper = mountWithStore(
             <AppManagementView
                 apps={List([app])}
                 isRetrievingApps={false}
@@ -235,7 +249,7 @@ describe('AppManagementView', () => {
 
     it('should render more info links for correctly defined homepage', () => {
         expect(
-            renderer.create(
+            rendererCreateWithStore(
                 <AppManagementView
                     apps={List([
                         getImmutableApp({
@@ -279,7 +293,7 @@ describe('AppManagementView', () => {
             isOfficial: false,
         });
         const onAppSelected = jest.fn();
-        const wrapper = mount(
+        const wrapper = mountWithStore(
             <AppManagementView
                 apps={List([app])}
                 isRetrievingApps={false}

--- a/src/launcher/components/__tests__/__snapshots__/AppManagementView-test.jsx.snap
+++ b/src/launcher/components/__tests__/__snapshots__/AppManagementView-test.jsx.snap
@@ -29,6 +29,17 @@ Array [
     sources={Object {}}
   />,
   <div
+    className=""
+  >
+    <img
+      alt="Loading..."
+      height="16"
+      src="test-file-stub"
+      width="16"
+    />
+     Loading infos about downloadable apps …
+  </div>,
+  <div
     className="with-scrollbar filter-adjusted-height"
   >
     <div
@@ -140,6 +151,17 @@ Array [
     }
     sources={Object {}}
   />,
+  <div
+    className=""
+  >
+    <img
+      alt="Loading..."
+      height="16"
+      src="test-file-stub"
+      width="16"
+    />
+     Loading infos about downloadable apps …
+  </div>,
   <div
     className="with-scrollbar filter-adjusted-height"
   >
@@ -263,6 +285,17 @@ Array [
     }
     sources={Object {}}
   />,
+  <div
+    className=""
+  >
+    <img
+      alt="Loading..."
+      height="16"
+      src="test-file-stub"
+      width="16"
+    />
+     Loading infos about downloadable apps …
+  </div>,
   <div
     className="with-scrollbar filter-adjusted-height"
   >
@@ -424,6 +457,17 @@ Array [
     }
     sources={Object {}}
   />,
+  <div
+    className=""
+  >
+    <img
+      alt="Loading..."
+      height="16"
+      src="test-file-stub"
+      width="16"
+    />
+     Loading infos about downloadable apps …
+  </div>,
   <div
     className="with-scrollbar filter-adjusted-height"
   >
@@ -719,6 +763,17 @@ Array [
     sources={Object {}}
   />,
   <div
+    className=""
+  >
+    <img
+      alt="Loading..."
+      height="16"
+      src="test-file-stub"
+      width="16"
+    />
+     Loading infos about downloadable apps …
+  </div>,
+  <div
     className="with-scrollbar filter-adjusted-height"
   >
     <div
@@ -974,6 +1029,17 @@ Array [
     apps={Immutable.List []}
     sources={Object {}}
   />,
+  <div
+    className=""
+  >
+    <img
+      alt="Loading..."
+      height="16"
+      src="test-file-stub"
+      width="16"
+    />
+     Loading infos about downloadable apps …
+  </div>,
   <div
     className="with-scrollbar filter-adjusted-height"
   >

--- a/src/launcher/components/loadingDownloadableAppsIndicator.module.scss
+++ b/src/launcher/components/loadingDownloadableAppsIndicator.module.scss
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2015 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+@import '~pc-nrfconnect-shared/styles';
+
+.indicator {
+    margin: 0 29px 0 1px;
+    transition: all 1s;
+    background: $white;
+}
+
+.visible {
+    height: 50px;
+    padding: 0.75rem 5.75rem;
+}
+
+.hidden {
+    transform: scaleY(0);
+    height: 0;
+    padding: 0 5.75rem;
+    opacity: 0;
+}


### PR DESCRIPTION
Right after starting nRF Connect for Desktop not all apps are shown yet: While informations about downloadable apps are still loaded from the web, those apps are not yet shown. Especially with network problems it is not obvious why initially not all apps are displayed. This also has caused some user complaints.

This change displays a little notice at the top of the app list while we are downloading app infos.

Note: Besides downloading these infos initially, we are also downloading them again later, e.g. after installing an app. So the indicator also reappears then.

https://user-images.githubusercontent.com/260705/189384540-e978849a-ccf8-4c15-a4d9-98298c545a27.mov

