### PR TITLE
Cleanup entry points

### DIFF
--- a/src/launcher/actions/appsActions.js
+++ b/src/launcher/actions/appsActions.js
@@ -121,7 +121,7 @@ function installDownloadableAppErrorAction() {
     };
 }
 
-function updateInstallProgressAction(message) {
+export function updateInstallProgressAction(message) {
     return {
         type: UPDATE_DOWNLOAD_PROGRESS,
         ...message,

--- a/src/launcher/actions/autoUpdateActions.js
+++ b/src/launcher/actions/autoUpdateActions.js
@@ -8,6 +8,8 @@ import { ErrorDialogActions, logger } from 'pc-nrfconnect-shared';
 
 import { downloadAllAppsJsonFiles } from '../../ipc/apps';
 import { cancelUpdate, checkForUpdate } from '../../ipc/launcherUpdate';
+import { getSetting } from '../../ipc/settings';
+import mainConfig from '../util/mainConfig';
 import * as AppsActions from './appsActions';
 import * as SettingsActions from './settingsActions';
 
@@ -71,6 +73,20 @@ export function checkForCoreUpdates() {
     };
 }
 
+export const checkForCoreUpdatesAtStartup = async dispatch => {
+    const shouldCheckForUpdatesAtStartup = await getSetting(
+        'shouldCheckForUpdatesAtStartup'
+    );
+
+    if (
+        shouldCheckForUpdatesAtStartup &&
+        !mainConfig.isSkipUpdateCore &&
+        process.env.NODE_ENV !== 'development'
+    ) {
+        await dispatch(checkForCoreUpdates());
+    }
+};
+
 export function cancelDownload() {
     return dispatch => {
         cancelUpdate();
@@ -122,6 +138,16 @@ export function downloadLatestAppInfo(options = { rejectIfError: false }) {
             });
     };
 }
+
+export const downloadLatestAppInfoAtStartup = async dispatch => {
+    const shouldCheckForUpdatesAtStartup = await getSetting(
+        'shouldCheckForUpdatesAtStartup'
+    );
+
+    if (shouldCheckForUpdatesAtStartup && !mainConfig().isSkipUpdateApps) {
+        dispatch(downloadLatestAppInfo());
+    }
+};
 
 export function checkForUpdatesManually() {
     return dispatch =>

--- a/src/launcher/index.js
+++ b/src/launcher/index.js
@@ -8,27 +8,16 @@ import 'regenerator-runtime/runtime';
 
 import React from 'react';
 import { render } from 'react-dom';
-import { ErrorDialogActions, usageData } from 'pc-nrfconnect-shared';
 import { applyMiddleware, createStore } from 'redux';
 import { composeWithDevTools } from 'redux-devtools-extension';
 import thunk from 'redux-thunk';
 
-import { registerDownloadProgress } from '../ipc/downloadProgress';
-import {
-    registerUpdateFinished,
-    registerUpdateProgress,
-    registerUpdateStarted,
-} from '../ipc/launcherUpdateProgress';
-import { registerRequestProxyLogin } from '../ipc/proxyLogin';
-import { getSetting } from '../ipc/settings';
-import { registerShowErrorDialog } from '../ipc/showErrorDialog';
 import * as AppsActions from './actions/appsActions';
 import * as AutoUpdateActions from './actions/autoUpdateActions';
-import * as ProxyActions from './actions/proxyActions';
 import * as UsageDataActions from './actions/usageDataActions';
 import RootContainer from './containers/RootContainer';
 import rootReducer from './reducers';
-import mainConfig from './util/mainConfig';
+import registerIpcHandler from './util/registerIpcHandler';
 
 import '../../resources/css/launcher.scss';
 
@@ -37,53 +26,9 @@ const store = createStore(
     composeWithDevTools(applyMiddleware(thunk))
 );
 
-registerDownloadProgress(progress => {
-    store.dispatch({ type: AppsActions.UPDATE_DOWNLOAD_PROGRESS, ...progress });
-});
-
-registerShowErrorDialog(errorMessage => {
-    store.dispatch(ErrorDialogActions.showDialog(errorMessage));
-});
-
-registerRequestProxyLogin((requestId, authInfo) => {
-    store.dispatch(ProxyActions.authenticate(requestId, authInfo));
-});
-
-registerUpdateStarted(() => {
-    store.dispatch(AutoUpdateActions.startDownloadAction());
-});
-registerUpdateProgress(percentage => {
-    store.dispatch(AutoUpdateActions.updateDownloadingAction(percentage));
-});
-registerUpdateFinished(isSuccessful => {
-    if (isSuccessful) {
-        usageData.reset();
-    }
-    store.dispatch(AutoUpdateActions.resetAction());
-});
+registerIpcHandler(store.dispatch);
 
 const rootElement = React.createElement(RootContainer, { store });
-
-function downloadLatestAppInfo(shouldCheckForUpdatesAtStartup) {
-    if (
-        shouldCheckForUpdatesAtStartup !== false &&
-        !mainConfig().isSkipUpdateApps
-    ) {
-        return store.dispatch(AutoUpdateActions.downloadLatestAppInfo());
-    }
-    return Promise.resolve();
-}
-
-function checkForCoreUpdates(shouldCheckForUpdatesAtStartup) {
-    if (
-        shouldCheckForUpdatesAtStartup !== false &&
-        !mainConfig.isSkipUpdateCore &&
-        process.env.NODE_ENV !== 'development'
-    ) {
-        return store.dispatch(AutoUpdateActions.checkForCoreUpdates());
-    }
-    return Promise.resolve();
-}
 
 render(rootElement, document.getElementById('webapp'), async () => {
     await store.dispatch(UsageDataActions.checkUsageDataSetting());
@@ -92,11 +37,7 @@ render(rootElement, document.getElementById('webapp'), async () => {
     await store.dispatch(AppsActions.loadDownloadableApps());
     store.dispatch(await AppsActions.setAppManagementShow());
     store.dispatch(await AppsActions.setAppManagementSource());
-
-    const shouldCheckForUpdatesAtStartup = await getSetting(
-        'shouldCheckForUpdatesAtStartup'
-    );
-    await downloadLatestAppInfo(shouldCheckForUpdatesAtStartup);
-    await checkForCoreUpdates(shouldCheckForUpdatesAtStartup);
+    await store.dispatch(AutoUpdateActions.downloadLatestAppInfoAtStartup());
+    await store.dispatch(AutoUpdateActions.checkForCoreUpdatesAtStartup);
     UsageDataActions.sendEnvInfo();
 });

--- a/src/launcher/util/registerIpcHandler.js
+++ b/src/launcher/util/registerIpcHandler.js
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+// @ts-check
+
+import { ErrorDialogActions, usageData } from 'pc-nrfconnect-shared';
+
+import { registerDownloadProgress } from '../../ipc/downloadProgress';
+import {
+    registerUpdateFinished,
+    registerUpdateProgress,
+    registerUpdateStarted,
+} from '../../ipc/launcherUpdateProgress';
+import { registerRequestProxyLogin } from '../../ipc/proxyLogin';
+import { registerShowErrorDialog } from '../../ipc/showErrorDialog';
+import { updateInstallProgressAction } from '../actions/appsActions';
+import {
+    resetAction,
+    startDownloadAction,
+    updateDownloadingAction,
+} from '../actions/autoUpdateActions';
+import { authenticate } from '../actions/proxyActions';
+
+export default dispatch => {
+    registerDownloadProgress(progress => {
+        dispatch(updateInstallProgressAction(progress));
+    });
+
+    registerShowErrorDialog(errorMessage => {
+        dispatch(ErrorDialogActions.showDialog(errorMessage));
+    });
+
+    registerRequestProxyLogin((requestId, authInfo) => {
+        dispatch(authenticate(requestId, authInfo));
+    });
+
+    registerUpdateStarted(() => {
+        dispatch(startDownloadAction());
+    });
+    registerUpdateProgress(percentage => {
+        dispatch(updateDownloadingAction(percentage));
+    });
+    registerUpdateFinished(isSuccessful => {
+        if (isSuccessful) {
+            usageData.reset();
+        }
+        dispatch(resetAction());
+    });
+};

--- a/src/main/configureElectronApp.ts
+++ b/src/main/configureElectronApp.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2015 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import { app, dialog, Menu } from 'electron';
+
+import { initAppsDirectory } from './apps';
+import { getConfig } from './config';
+import describeError from './describeError';
+import loadDevtools from './devtools';
+import { logger } from './log';
+import menu from './menu';
+import {
+    openDownloadableAppWindow,
+    openLauncherWindow,
+    openLocalAppWindow,
+} from './windows';
+
+const openInitialWindow = async () => {
+    const { startupApp } = getConfig();
+
+    if (startupApp == null) {
+        openLauncherWindow();
+        return;
+    }
+
+    if (startupApp.local) {
+        await openLocalAppWindow(startupApp.name);
+    } else {
+        await openDownloadableAppWindow(startupApp.name, startupApp.sourceName);
+    }
+};
+
+const fatalError = (error: unknown) => {
+    dialog.showMessageBoxSync({
+        type: 'error',
+        title: 'Initialization error',
+        message: 'Error when starting application',
+        detail: describeError(error),
+        buttons: ['OK'],
+    });
+
+    app.quit();
+};
+
+export default () => {
+    app.allowRendererProcessReuse = false;
+
+    app.on('ready', async () => {
+        await loadDevtools();
+
+        Menu.setApplicationMenu(menu());
+
+        try {
+            await initAppsDirectory();
+            await openInitialWindow();
+        } catch (error) {
+            fatalError(error);
+        }
+    });
+
+    app.on('render-process-gone', (_event, wc, details) => {
+        wc.getTitle();
+        logger.error(`Renderer crashed ${wc.getTitle()}`, details);
+    });
+
+    app.on('child-process-gone', (_event, details) => {
+        logger.error(`Child process crashed `, details);
+    });
+
+    app.on('window-all-closed', () => {
+        app.quit();
+    });
+};

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -8,71 +8,15 @@
 import './init';
 
 import { initialize as initializeElectronRemote } from '@electron/remote/main';
-import { app as electronApp, dialog, Menu } from 'electron';
+import { app } from 'electron';
 import { join } from 'path';
 
-import * as apps from './apps';
-import { getConfig } from './config';
-import describeError from './describeError';
-import loadDevtools from './devtools';
+import configureElectronApp from './configureElectronApp';
 import { createTextFile } from './fileUtil';
-import { logger } from './log';
-import { createMenu } from './menu';
 import registerIpcHandler from './registerIpcHandler';
-import * as windows from './windows';
 
 initializeElectronRemote();
-
-const applicationMenu = Menu.buildFromTemplate(createMenu(electronApp));
-
-electronApp.allowRendererProcessReuse = false;
-
-electronApp.on('ready', async () => {
-    await loadDevtools();
-
-    Menu.setApplicationMenu(applicationMenu);
-
-    try {
-        await apps.initAppsDirectory();
-
-        const { startupApp } = getConfig();
-        if (startupApp != null) {
-            if (startupApp.local) {
-                await windows.openLocalAppWindow(startupApp.name);
-            } else {
-                await windows.openDownloadableAppWindow(
-                    startupApp.name,
-                    startupApp.sourceName
-                );
-            }
-        } else {
-            windows.openLauncherWindow();
-        }
-    } catch (error) {
-        await dialog.showMessageBox({
-            type: 'error',
-            title: 'Initialization error',
-            message: 'Error when starting application',
-            detail: describeError(error),
-            buttons: ['OK'],
-        });
-        electronApp.quit();
-    }
-});
-
-electronApp.on('render-process-gone', (_event, wc, details) => {
-    wc.getTitle();
-    logger.error(`Renderer crashed ${wc.getTitle()}`, details);
-});
-
-electronApp.on('child-process-gone', (_event, details) => {
-    logger.error(`Child process crashed `, details);
-});
-
-electronApp.on('window-all-closed', () => {
-    electronApp.quit();
-});
-
+configureElectronApp();
 registerIpcHandler();
 
 /**
@@ -80,9 +24,9 @@ registerIpcHandler();
  * This execPath is stored in a known location, so e.g. VS Code extension can launch it even on
  * Linux where there's no standard installation location.
  */
-if (electronApp.isPackaged) {
+if (app.isPackaged) {
     createTextFile(
-        join(electronApp.getPath('userData'), 'execPath'),
+        join(app.getPath('userData'), 'execPath'),
         process.platform === 'linux' && process.env.APPIMAGE
             ? process.env.APPIMAGE
             : process.execPath

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -8,27 +8,12 @@
 import './init';
 
 import { initialize as initializeElectronRemote } from '@electron/remote/main';
-import { app } from 'electron';
-import { join } from 'path';
 
 import configureElectronApp from './configureElectronApp';
-import { createTextFile } from './fileUtil';
 import registerIpcHandler from './registerIpcHandler';
+import storeExecutablePath from './storeExecutablePath';
 
 initializeElectronRemote();
 configureElectronApp();
 registerIpcHandler();
-
-/**
- * Let's store the full path to the executable if nRFConnect was started from a built package.
- * This execPath is stored in a known location, so e.g. VS Code extension can launch it even on
- * Linux where there's no standard installation location.
- */
-if (app.isPackaged) {
-    createTextFile(
-        join(app.getPath('userData'), 'execPath'),
-        process.platform === 'linux' && process.env.APPIMAGE
-            ? process.env.APPIMAGE
-            : process.execPath
-    ).catch(err => console.log(err.message));
-}
+storeExecutablePath();

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -4,79 +4,82 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-import { App, BrowserWindow, MenuItem } from 'electron';
+import { app, BrowserWindow, Menu, MenuItem } from 'electron';
 
-export const createMenu = (app: App) => [
-    {
-        label: '&File',
-        submenu: [
-            {
-                label: '&Quit',
-                accelerator: 'CmdOrCtrl+Q',
-                click: () => {
-                    app.quit();
+export default () =>
+    Menu.buildFromTemplate([
+        {
+            label: '&File',
+            submenu: [
+                {
+                    label: '&Quit',
+                    accelerator: 'CmdOrCtrl+Q',
+                    click: () => {
+                        app.quit();
+                    },
                 },
-            },
-        ],
-    },
-    {
-        label: 'Edit',
-        submenu: [
-            { label: 'Cut', accelerator: 'CmdOrCtrl+X', role: 'cut' },
-            {
-                label: 'Copy',
-                accelerator: 'CmdOrCtrl+C',
-                role: 'copy',
-            },
-            {
-                label: 'Paste',
-                accelerator: 'CmdOrCtrl+V',
-                role: 'paste',
-            },
-            {
-                label: 'Select All',
-                accelerator: 'CmdOrCtrl+A',
-                role: 'selectAll',
-            },
-        ],
-    },
-    {
-        label: '&View',
-        submenu: [
-            {
-                label: '&Reload',
-                accelerator: 'CmdOrCtrl+R',
-                click: (item: MenuItem, focusedWindow?: BrowserWindow) => {
-                    if (focusedWindow) {
-                        focusedWindow.reload();
-                    }
+            ],
+        },
+        {
+            label: 'Edit',
+            submenu: [
+                { label: 'Cut', accelerator: 'CmdOrCtrl+X', role: 'cut' },
+                {
+                    label: 'Copy',
+                    accelerator: 'CmdOrCtrl+C',
+                    role: 'copy',
                 },
-            },
-            {
-                label: 'Toggle &Full Screen',
-                accelerator:
-                    process.platform === 'darwin' ? 'Ctrl+Command+F' : 'F11',
-                click: (item: MenuItem, focusedWindow?: BrowserWindow) => {
-                    if (focusedWindow) {
-                        focusedWindow.setFullScreen(
-                            !focusedWindow.isFullScreen()
-                        );
-                    }
+                {
+                    label: 'Paste',
+                    accelerator: 'CmdOrCtrl+V',
+                    role: 'paste',
                 },
-            },
-            {
-                label: 'Toggle &Developer Tools',
-                accelerator:
-                    process.platform === 'darwin'
-                        ? 'Alt+Command+I'
-                        : 'Ctrl+Shift+I',
-                visible: true,
-                click: (item: MenuItem, focusedWindow?: BrowserWindow) => {
-                    if (focusedWindow) {
-                        focusedWindow.webContents.toggleDevTools();
-                    }
+                {
+                    label: 'Select All',
+                    accelerator: 'CmdOrCtrl+A',
+                    role: 'selectAll',
                 },
-            },
-        ],
-    },
-];
+            ],
+        },
+        {
+            label: '&View',
+            submenu: [
+                {
+                    label: '&Reload',
+                    accelerator: 'CmdOrCtrl+R',
+                    click: (_item: MenuItem, focusedWindow?: BrowserWindow) => {
+                        if (focusedWindow) {
+                            focusedWindow.reload();
+                        }
+                    },
+                },
+                {
+                    label: 'Toggle &Full Screen',
+                    accelerator:
+                        process.platform === 'darwin'
+                            ? 'Ctrl+Command+F'
+                            : 'F11',
+                    click: (_item: MenuItem, focusedWindow?: BrowserWindow) => {
+                        if (focusedWindow) {
+                            focusedWindow.setFullScreen(
+                                !focusedWindow.isFullScreen()
+                            );
+                        }
+                    },
+                },
+                {
+                    label: 'Toggle &Developer Tools',
+                    accelerator:
+                        process.platform === 'darwin'
+                            ? 'Alt+Command+I'
+                            : 'Ctrl+Shift+I',
+                    visible: true,
+                    click: (_item: MenuItem, focusedWindow?: BrowserWindow) => {
+                        if (focusedWindow) {
+                            focusedWindow.webContents.toggleDevTools();
+                        }
+                    },
+                },
+            ],
+        },
+    ]);

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -22,21 +22,21 @@ export const createMenu = (app: App) => [
     {
         label: 'Edit',
         submenu: [
-            { label: 'Cut', accelerator: 'CmdOrCtrl+X', selector: 'cut:' },
+            { label: 'Cut', accelerator: 'CmdOrCtrl+X', role: 'cut' },
             {
                 label: 'Copy',
                 accelerator: 'CmdOrCtrl+C',
-                selector: 'copy:',
+                role: 'copy',
             },
             {
                 label: 'Paste',
                 accelerator: 'CmdOrCtrl+V',
-                selector: 'paste:',
+                role: 'paste',
             },
             {
                 label: 'Select All',
                 accelerator: 'CmdOrCtrl+A',
-                selector: 'selectAll:',
+                role: 'selectAll',
             },
         ],
     },

--- a/src/main/storeExecutablePath.ts
+++ b/src/main/storeExecutablePath.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2015 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import { app } from 'electron';
+import { join } from 'path';
+
+import { createTextFile } from './fileUtil';
+
+/*
+ * Let's store the full path to the executable if nRFConnect was started from a built package.
+ * This execPath is stored in a known location, so e.g. VS Code extension can launch it even on
+ * Linux where there's no standard installation location.
+ */
+export default () => {
+    if (app.isPackaged) {
+        createTextFile(
+            join(app.getPath('userData'), 'execPath'),
+            process.platform === 'linux' && process.env.APPIMAGE
+                ? process.env.APPIMAGE
+                : process.execPath
+        ).catch(err => console.log(err.message));
+    }
+};


### PR DESCRIPTION
Extract code out of `main/index.ts` and `launcher/index.js` to make the entry points more concise.