### PR TITLE
Fix: Show release notes button

### DIFF
--- a/src/launcher/features/apps/App/ShowReleaseNotes.tsx
+++ b/src/launcher/features/apps/App/ShowReleaseNotes.tsx
@@ -13,7 +13,7 @@ import { DisplayedApp } from '../appsSlice';
 
 const ShowReleaseNotes: React.FC<{ app: DisplayedApp }> = ({ app }) => {
     const dispatch = useLauncherDispatch();
-    if (!app.isDownloadable || app.releaseNote != null) return null;
+    if (!app.isDownloadable || app.releaseNote == null) return null;
 
     return (
         <Dropdown.Item


### PR DESCRIPTION
The button to display the release notes of an app was never shown.

This was caused by the previous split of the `App` component. So it was never released and also must not be mentioned in the changelog.