### PR TITLE
Feature: Per app locking

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 ## Unreleased
 
+### Changed
+
+-   Installing or upgrading an app does not prevent working with other apps in
+    the list of apps any longer.
+
 ### Removed
 
 -   Removed pc-ble-driver as the Bluetooth Low Energy app now contains it

--- a/src/launcher/features/apps/App/AppProgress.tsx
+++ b/src/launcher/features/apps/App/AppProgress.tsx
@@ -7,17 +7,10 @@
 import React from 'react';
 import ProgressBar from 'react-bootstrap/ProgressBar';
 
-import { DisplayedApp } from '../appsSlice';
+import { DisplayedApp, isInProgress } from '../appsSlice';
 
 const AppProgress: React.FC<{ app: DisplayedApp }> = ({ app }) => {
-    if (
-        !app.isDownloadable ||
-        !(
-            app.progress.isInstalling ||
-            app.progress.isUpgrading ||
-            app.progress.isRemoving
-        )
-    ) {
+    if (!isInProgress(app)) {
         return null;
     }
 

--- a/src/launcher/features/apps/App/CreateShortcut.tsx
+++ b/src/launcher/features/apps/App/CreateShortcut.tsx
@@ -8,17 +8,14 @@ import React from 'react';
 import Dropdown from 'react-bootstrap/Dropdown';
 
 import { createDesktopShortcut } from '../../../../ipc/createDesktopShortcut';
-import { useLauncherSelector } from '../../../util/hooks';
-import { DisplayedApp, getIsAnAppInProgress } from '../appsSlice';
+import { DisplayedApp, isInProgress } from '../appsSlice';
 
 const CreateShortcut: React.FC<{ app: DisplayedApp }> = ({ app }) => {
-    const isAnAppInProgress = useLauncherSelector(getIsAnAppInProgress);
-
     if (!app.isInstalled) return null;
 
     return (
         <Dropdown.Item
-            disabled={isAnAppInProgress}
+            disabled={isInProgress(app)}
             title="Create a desktop shortcut for this app"
             onClick={() => createDesktopShortcut(app)}
         >

--- a/src/launcher/features/apps/App/InstallApp.tsx
+++ b/src/launcher/features/apps/App/InstallApp.tsx
@@ -7,21 +7,19 @@
 import React from 'react';
 import Button from 'react-bootstrap/Button';
 
-import { useLauncherDispatch, useLauncherSelector } from '../../../util/hooks';
+import { useLauncherDispatch } from '../../../util/hooks';
 import { installDownloadableApp } from '../appsEffects';
-import { DisplayedApp, getIsAnAppInProgress } from '../appsSlice';
+import { DisplayedApp, isInProgress } from '../appsSlice';
 
 const InstallApp: React.FC<{ app: DisplayedApp }> = ({ app }) => {
     const dispatch = useLauncherDispatch();
-    const isAnAppInProgress = useLauncherSelector(getIsAnAppInProgress);
-
     if (app.isInstalled) return null;
 
     return (
         <Button
             variant="outline-secondary"
             title={`Install ${app.displayName}`}
-            disabled={isAnAppInProgress}
+            disabled={isInProgress(app)}
             onClick={() => dispatch(installDownloadableApp(app))}
         >
             {app.progress.isInstalling ? 'Installing...' : 'Install'}

--- a/src/launcher/features/apps/App/OpenApp.tsx
+++ b/src/launcher/features/apps/App/OpenApp.tsx
@@ -7,20 +7,19 @@
 import React from 'react';
 import Button from 'react-bootstrap/Button';
 
-import { useLauncherDispatch, useLauncherSelector } from '../../../util/hooks';
+import { useLauncherDispatch } from '../../../util/hooks';
 import { checkEngineAndLaunch } from '../appsEffects';
-import { DisplayedApp, getIsAnAppInProgress } from '../appsSlice';
+import { DisplayedApp, isInProgress } from '../appsSlice';
 
 const OpenApp: React.FC<{ app: DisplayedApp }> = ({ app }) => {
     const dispatch = useLauncherDispatch();
-    const isAnAppInProgress = useLauncherSelector(getIsAnAppInProgress);
 
     if (!app.isInstalled) return null;
 
     return (
         <Button
             title={`Open ${app.displayName}`}
-            disabled={isAnAppInProgress}
+            disabled={isInProgress(app)}
             onClick={() => dispatch(checkEngineAndLaunch(app))}
         >
             Open

--- a/src/launcher/features/apps/App/UninstallApp.tsx
+++ b/src/launcher/features/apps/App/UninstallApp.tsx
@@ -7,20 +7,19 @@
 import React from 'react';
 import Dropdown from 'react-bootstrap/Dropdown';
 
-import { useLauncherDispatch, useLauncherSelector } from '../../../util/hooks';
+import { useLauncherDispatch } from '../../../util/hooks';
 import { removeDownloadableApp } from '../appsEffects';
-import { DisplayedApp, getIsAnAppInProgress } from '../appsSlice';
+import { DisplayedApp, isInProgress } from '../appsSlice';
 
 const UninstallApp: React.FC<{ app: DisplayedApp }> = ({ app }) => {
     const dispatch = useLauncherDispatch();
-    const isAnAppInProgress = useLauncherSelector(getIsAnAppInProgress);
 
     if (!app.isInstalled || !app.isDownloadable) return null;
 
     return (
         <Dropdown.Item
             title={`Remove ${app.displayName}`}
-            disabled={isAnAppInProgress}
+            disabled={isInProgress(app)}
             onClick={() => dispatch(removeDownloadableApp(app))}
         >
             {app.progress.isRemoving ? 'Uninstalling...' : 'Uninstall'}

--- a/src/launcher/features/apps/App/UpdateApp.tsx
+++ b/src/launcher/features/apps/App/UpdateApp.tsx
@@ -7,13 +7,12 @@
 import React from 'react';
 import Button from 'react-bootstrap/Button';
 
-import { useLauncherDispatch, useLauncherSelector } from '../../../util/hooks';
+import { useLauncherDispatch } from '../../../util/hooks';
 import { show as showReleaseNotes } from '../../releaseNotes/releaseNotesDialogSlice';
-import { DisplayedApp, getIsAnAppInProgress } from '../appsSlice';
+import { DisplayedApp, isInProgress } from '../appsSlice';
 
 const UpdateApp: React.FC<{ app: DisplayedApp }> = ({ app }) => {
     const dispatch = useLauncherDispatch();
-    const isAnAppInProgress = useLauncherSelector(getIsAnAppInProgress);
 
     if (!app.isInstalled || !app.isDownloadable || !app.upgradeAvailable)
         return null;
@@ -22,7 +21,7 @@ const UpdateApp: React.FC<{ app: DisplayedApp }> = ({ app }) => {
         <Button
             variant="outline-primary"
             title={`Update ${app.displayName}`}
-            disabled={isAnAppInProgress}
+            disabled={isInProgress(app)}
             onClick={() => dispatch(showReleaseNotes(app))}
         >
             {app.progress.isUpgrading ? 'Updating...' : 'Update'}

--- a/src/launcher/features/apps/appsSlice.ts
+++ b/src/launcher/features/apps/appsSlice.ts
@@ -330,15 +330,18 @@ export const getUpgradeableVisibleApps = (state: RootState) =>
         .filter(app => app.isInstalled && app.upgradeAvailable);
 
 export const getIsAnAppInProgress = (state: RootState) =>
-    state.apps.downloadableApps.find(
-        app =>
-            app.progress.isInstalling ||
-            app.progress.isRemoving ||
-            app.progress.isUpgrading
-    ) != null;
+    state.apps.downloadableApps.find(isInProgress) != null;
 
 export const getConfirmLaunch = (state: RootState) => ({
     isDialogVisible: state.apps.isConfirmLaunchDialogVisible,
     text: state.apps.confirmLaunchText,
     app: state.apps.confirmLaunchApp,
 });
+
+export const isInProgress = (
+    app: DisplayedApp
+): app is DownloadableAppWithProgress =>
+    app.isDownloadable &&
+    (app.progress.isInstalling ||
+        app.progress.isUpgrading ||
+        app.progress.isRemoving);

--- a/src/launcher/features/apps/appsSlice.ts
+++ b/src/launcher/features/apps/appsSlice.ts
@@ -329,9 +329,6 @@ export const getUpgradeableVisibleApps = (state: RootState) =>
         .filter(getAppsFilter(state))
         .filter(app => app.isInstalled && app.upgradeAvailable);
 
-export const getIsAnAppInProgress = (state: RootState) =>
-    state.apps.downloadableApps.find(isInProgress) != null;
-
 export const getConfirmLaunch = (state: RootState) => ({
     isDialogVisible: state.apps.isConfirmLaunchDialogVisible,
     text: state.apps.confirmLaunchText,


### PR DESCRIPTION
Before, all apps were locked (could not be installed, removed, upgraded, or launched) while any app was installed, removed, or upgraded. Now only the app that is actually changed is also locked for the duration of that operation.

The users can now still interact with the other apps, e.g. install two apps at the same time or open one while another is being installed.

So, this was how could look before: 

https://user-images.githubusercontent.com/260705/196710111-db58ce33-12a5-4d41-aecf-83c85fb12e0c.mov

This is how it can be now: 

https://user-images.githubusercontent.com/260705/196710231-eeeaefdd-8d14-4389-94ad-8e8806c94bb1.mov

