### PR TITLE
Enhance drag & drop to install local apps

### DIFF
--- a/src/ipc/apps.ts
+++ b/src/ipc/apps.ts
@@ -84,6 +84,7 @@ const channel = {
     downloadReleaseNotes: 'apps:download-release-notes',
     installDownloadableApp: 'apps:install-downloadable-app',
     installLocalApp: 'apps:install-local-app',
+    removeLocalApp: 'apps:remove-local-app',
     removeDownloadableApp: 'apps:remove-downloadable-app',
 };
 
@@ -154,10 +155,11 @@ export const failureReadingFile = (errorMessage: string, error?: unknown) =>
         error,
     } as const);
 
-export const appExists = (appPath: string) =>
+export const appExists = (appName: string, appPath: string) =>
     ({
         type: 'failure',
         errorType: 'error because app exists',
+        appName,
         appPath,
     } as const);
 
@@ -171,6 +173,14 @@ type InstallLocalApp = (path: string) => InstallResult;
 export const installLocalApp = invoke<InstallLocalApp>(channel.installLocalApp);
 export const registerInstallLocalApp = handle<InstallLocalApp>(
     channel.installLocalApp
+);
+
+// removeLocalApp
+type RemoveLocalApp = (appName: string) => void;
+
+export const removeLocalApp = invoke<RemoveLocalApp>(channel.removeLocalApp);
+export const registerRemoveLocalApp = handle<RemoveLocalApp>(
+    channel.removeLocalApp
 );
 
 // removeDownloadableApp

--- a/src/ipc/apps.ts
+++ b/src/ipc/apps.ts
@@ -140,7 +140,33 @@ export const registerInstallDownloadableApp = handle<InstallDownloadableApp>(
 
 // installLocalApp
 
-type InstallLocalApp = (path: string) => LocalApp;
+export const successfulInstall = (app: LocalApp) =>
+    ({
+        type: 'success',
+        app,
+    } as const);
+
+export const failureReadingFile = (errorMessage: string, error?: unknown) =>
+    ({
+        type: 'failure',
+        errorType: 'error reading file',
+        errorMessage,
+        error,
+    } as const);
+
+export const failureBecauseAppExists = (appPath: string) =>
+    ({
+        type: 'failure',
+        errorType: 'error because app exists',
+        appPath,
+    } as const);
+
+export type InstallResult =
+    | ReturnType<typeof successfulInstall>
+    | ReturnType<typeof failureReadingFile>
+    | ReturnType<typeof failureBecauseAppExists>;
+
+type InstallLocalApp = (path: string) => InstallResult;
 
 export const installLocalApp = invoke<InstallLocalApp>(channel.installLocalApp);
 export const registerInstallLocalApp = handle<InstallLocalApp>(

--- a/src/ipc/apps.ts
+++ b/src/ipc/apps.ts
@@ -154,7 +154,7 @@ export const failureReadingFile = (errorMessage: string, error?: unknown) =>
         error,
     } as const);
 
-export const failureBecauseAppExists = (appPath: string) =>
+export const appExists = (appPath: string) =>
     ({
         type: 'failure',
         errorType: 'error because app exists',
@@ -164,7 +164,7 @@ export const failureBecauseAppExists = (appPath: string) =>
 export type InstallResult =
     | ReturnType<typeof successfulInstall>
     | ReturnType<typeof failureReadingFile>
-    | ReturnType<typeof failureBecauseAppExists>;
+    | ReturnType<typeof appExists>;
 
 type InstallLocalApp = (path: string) => InstallResult;
 

--- a/src/launcher/features/apps/appsEffects.ts
+++ b/src/launcher/features/apps/appsEffects.ts
@@ -164,8 +164,10 @@ const buildErrorMessage = (apps: AppWithError[]) => {
 
 export const installLocalApp =
     (appPackagePath: string) => async (dispatch: AppDispatch) => {
-        const localApp = await installLocalAppInMain(appPackagePath);
-        dispatch(addLocalApp(localApp));
+        const installResult = await installLocalAppInMain(appPackagePath);
+        if (installResult.type === 'success') {
+            dispatch(addLocalApp(installResult.app));
+        }
     };
 
 export const installDownloadableApp =

--- a/src/launcher/features/apps/appsEffects.ts
+++ b/src/launcher/features/apps/appsEffects.ts
@@ -19,6 +19,7 @@ import {
     installLocalApp as installLocalAppInMain,
     LaunchableApp,
     removeDownloadableApp as removeDownloadableAppInMain,
+    removeLocalApp as removeLocalAppInMain,
 } from '../../../ipc/apps';
 import { downloadToFile } from '../../../ipc/downloadToFile';
 import { openApp } from '../../../ipc/openWindow';
@@ -42,6 +43,7 @@ import {
     loadLocalAppsSuccess,
     removeDownloadableAppStarted,
     removeDownloadableAppSuccess,
+    removeLocalApp,
     resetAppProgress,
     setAppIconPath,
     setAppReleaseNote,
@@ -176,6 +178,24 @@ export const installLocalApp =
             if (installResult.error != null) {
                 console.warn(describeError(installResult.error));
             }
+        } else if (installResult.errorType === 'error because app exists') {
+            dispatch(
+                ErrorDialogActions.showDialog(
+                    `A local app \`${installResult.appName}\` already exists. ` +
+                        `Overwrite it with the content of \`${appPackagePath}\`?`,
+                    {
+                        Overwrite: async () => {
+                            dispatch(ErrorDialogActions.hideDialog());
+                            await removeLocalAppInMain(installResult.appName);
+                            dispatch(removeLocalApp(installResult.appName));
+                            dispatch(installLocalApp(appPackagePath));
+                        },
+                        Cancel: () => {
+                            dispatch(ErrorDialogActions.hideDialog());
+                        },
+                    }
+                )
+            );
         }
     };
 

--- a/src/launcher/features/apps/appsEffects.ts
+++ b/src/launcher/features/apps/appsEffects.ts
@@ -6,7 +6,7 @@
 
 import { getCurrentWindow, require as remoteRequire } from '@electron/remote';
 import { join } from 'path';
-import { ErrorDialogActions } from 'pc-nrfconnect-shared';
+import { describeError, ErrorDialogActions } from 'pc-nrfconnect-shared';
 
 import {
     AppSpec,
@@ -167,6 +167,15 @@ export const installLocalApp =
         const installResult = await installLocalAppInMain(appPackagePath);
         if (installResult.type === 'success') {
             dispatch(addLocalApp(installResult.app));
+        } else if (installResult.errorType === 'error reading file') {
+            dispatch(
+                ErrorDialogActions.showDialog(
+                    `Error while installing local app:\n\n${installResult.errorMessage}`
+                )
+            );
+            if (installResult.error != null) {
+                console.warn(describeError(installResult.error));
+            }
         }
     };
 

--- a/src/launcher/features/apps/appsSlice.ts
+++ b/src/launcher/features/apps/appsSlice.ts
@@ -107,11 +107,12 @@ const slice = createSlice({
             state.isLoadingLocalApps = false;
         },
         addLocalApp(state, { payload: newApp }: PayloadAction<LocalApp>) {
-            const oldAppsWithoutNewApp = state.localApps.filter(
-                app => app.name !== newApp.name
+            state.localApps.push(newApp);
+        },
+        removeLocalApp(state, { payload: appName }: PayloadAction<string>) {
+            state.localApps = state.localApps.filter(
+                app => app.name !== appName
             );
-
-            state.localApps = [...oldAppsWithoutNewApp, newApp];
         },
 
         // Load Downloadable apps
@@ -283,6 +284,7 @@ export const {
     loadLocalAppsSuccess,
     removeDownloadableAppStarted,
     removeDownloadableAppSuccess,
+    removeLocalApp,
     resetAppProgress,
     setAppIconPath,
     setAppReleaseNote,

--- a/src/launcher/util/DropZoneForLocalApps.test.tsx
+++ b/src/launcher/util/DropZoneForLocalApps.test.tsx
@@ -7,11 +7,14 @@
 import React from 'react';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 
-import { installLocalApp, LocalApp } from '../../ipc/apps';
+import type { LocalApp } from '../../ipc/apps';
+import { installLocalApp } from '../../ipc/apps';
 import { LOCAL } from '../../ipc/sources';
 import testrenderer, { preparedStore } from '../../testrenderer';
 import { getAllApps } from '../features/apps/appsSlice';
 import DropZoneForLocalApps from './DropZoneForLocalApps';
+
+const { successfulInstall } = jest.requireActual('../../ipc/apps');
 
 jest.mock('../../ipc/apps');
 
@@ -51,8 +54,8 @@ describe('DropZoneForLocalApps', () => {
     beforeEach(() => {
         jest.mocked(installLocalApp)
             .mockClear()
-            .mockResolvedValueOnce(installedApp)
-            .mockResolvedValueOnce(anotherInstalledApp);
+            .mockResolvedValueOnce(successfulInstall(installedApp))
+            .mockResolvedValueOnce(successfulInstall(anotherInstalledApp));
     });
 
     it('installs the dropped file', async () => {

--- a/src/launcher/util/DropZoneForLocalApps.test.tsx
+++ b/src/launcher/util/DropZoneForLocalApps.test.tsx
@@ -31,11 +31,16 @@ const installedApp: LocalApp = {
     shortcutIconPath: '',
 };
 
+jest.mocked(installLocalApp).mockResolvedValueOnce(installedApp);
+
 describe('DropZoneForLocalApps', () => {
+    beforeEach(() => {
+        jest.mocked(installLocalApp).mockClear();
+    });
+
     it('installs the dropped file', async () => {
         const path = 'testapp-1.2.3.tgz';
         const store = preparedStore();
-        jest.mocked(installLocalApp).mockResolvedValueOnce(installedApp);
 
         testrenderer(<DropZoneForLocalApps />, store);
 
@@ -50,5 +55,15 @@ describe('DropZoneForLocalApps', () => {
         await waitFor(() =>
             expect(getAllApps(store.getState())).toContain(installedApp)
         );
+    });
+
+    it('installs nothing when dropping no file (e.g. only text)', () => {
+        testrenderer(<DropZoneForLocalApps />);
+
+        fireEvent.drop(screen.getByTestId('app-install-drop-zone'), {
+            dataTransfer: { files: [] },
+        });
+
+        expect(installLocalApp).not.toHaveBeenCalled();
     });
 });

--- a/src/launcher/util/DropZoneForLocalApps.tsx
+++ b/src/launcher/util/DropZoneForLocalApps.tsx
@@ -14,9 +14,10 @@ const DropZoneForLocalApps: React.FC = ({ children }) => {
 
     const installAppPackage = (event: React.DragEvent<HTMLDivElement>) => {
         event.preventDefault();
-        if (event.dataTransfer.files.length > 0) {
-            dispatch(installLocalApp(event.dataTransfer.files[0].path));
-        }
+
+        [...event.dataTransfer.files].forEach(file =>
+            dispatch(installLocalApp(file.path))
+        );
     };
 
     const showAddCursor = (event: React.DragEvent<HTMLDivElement>) => {

--- a/src/launcher/util/DropZoneForLocalApps.tsx
+++ b/src/launcher/util/DropZoneForLocalApps.tsx
@@ -14,7 +14,9 @@ const DropZoneForLocalApps: React.FC = ({ children }) => {
 
     const installAppPackage = (event: React.DragEvent<HTMLDivElement>) => {
         event.preventDefault();
-        dispatch(installLocalApp(event.dataTransfer.files[0].path));
+        if (event.dataTransfer.files.length > 0) {
+            dispatch(installLocalApp(event.dataTransfer.files[0].path));
+        }
     };
 
     const showAddCursor = (event: React.DragEvent<HTMLDivElement>) => {

--- a/src/main/apps.ts
+++ b/src/main/apps.ts
@@ -113,15 +113,15 @@ export const installLocalApp = async (
     const appName = fileUtil.getNameFromNpmPackage(tgzFilePath);
     if (!appName) {
         return failureReadingFile(
-            `Unable to get app name from archive: ${tgzFilePath}. ` +
-                `Expected file name format: {name}-{version}.tgz.`
+            `Unable to get app name from archive: \`${tgzFilePath}\`. ` +
+                `Expected file name format: \`{name}-{version}.tgz.\``
         );
     }
     const appPath = path.join(getAppsLocalDir(), appName);
 
     // Check if app exists
     if (await fs.pathExists(appPath)) {
-        return appExists(appPath);
+        return appExists(appName, appPath);
     }
 
     // Extract app package
@@ -131,7 +131,7 @@ export const installLocalApp = async (
     } catch (error) {
         await fs.remove(appPath);
         return failureReadingFile(
-            `Unable to extract app archive ${tgzFilePath}.`,
+            `Unable to extract app archive \`${tgzFilePath}\`.`,
             error
         );
     }
@@ -140,6 +140,9 @@ export const installLocalApp = async (
         (await infoFromInstalledApp(getAppsLocalDir(), appName)) as LocalApp
     );
 };
+
+export const removeLocalApp = (appName: string) =>
+    fs.remove(path.join(getAppsLocalDir(), appName));
 
 const deleteFileOnSuccess = async (
     result: InstallResult,

--- a/src/main/apps.ts
+++ b/src/main/apps.ts
@@ -15,7 +15,11 @@ import {
     AppSpec,
     AppWithError,
     DownloadableApp,
+    failureBecauseAppExists,
+    failureReadingFile,
+    InstallResult,
     LocalApp,
+    successfulInstall,
     UninstalledDownloadableApp,
     UnversionedDownloadableApp,
 } from '../ipc/apps';
@@ -88,11 +92,8 @@ export const downloadAllAppsJsonFiles = async () => {
     await generateUpdatesJsonFiles();
 };
 
-const confirmAndRemoveOldLocalApp = async (
-    tgzFilePath: string,
-    appPath: string
-) => {
-    const { response } = await dialog.showMessageBox({
+const shouldRemoveExistingApp = (tgzFilePath: string, appPath: string) => {
+    const clickedButton = dialog.showMessageBoxSync({
         type: 'question',
         title: 'Existing app directory',
         message:
@@ -102,49 +103,79 @@ const confirmAndRemoveOldLocalApp = async (
         buttons: ['Remove', 'Cancel'],
     });
 
-    if (response === 0) {
-        await fs.remove(appPath);
-    }
+    return clickedButton === 0;
 };
 
 export const installLocalApp = async (
-    tgzFilePath: string,
-    removeArchiveAfterInstall = false
-) => {
+    tgzFilePath: string
+): Promise<InstallResult> => {
+    // Determine app name and path
     const appName = fileUtil.getNameFromNpmPackage(tgzFilePath);
     if (!appName) {
-        throw new Error(
+        return failureReadingFile(
             `Unable to get app name from archive: ${tgzFilePath}. ` +
                 `Expected file name format: {name}-{version}.tgz.`
         );
     }
     const appPath = path.join(getAppsLocalDir(), appName);
 
+    // Check if app exists
     if (await fs.pathExists(appPath)) {
-        await confirmAndRemoveOldLocalApp(tgzFilePath, appPath);
+        return failureBecauseAppExists(appPath);
     }
 
-    if (!(await fs.pathExists(appPath))) {
-        await mkdir(appPath);
+    // Extract app package
+    await mkdir(appPath);
+    try {
         await fileUtil.extractNpmPackage(appName, tgzFilePath, appPath);
-        if (removeArchiveAfterInstall) {
-            await fileUtil.deleteFile(tgzFilePath);
-        }
+    } catch (error) {
+        await fs.remove(appPath);
+        return failureReadingFile(
+            `Unable to extract app archive ${tgzFilePath}.`,
+            error
+        );
     }
 
-    return infoFromInstalledApp(
-        getAppsLocalDir(),
-        appName
-    ) as unknown as LocalApp;
+    return successfulInstall(
+        (await infoFromInstalledApp(getAppsLocalDir(), appName)) as LocalApp
+    );
 };
 
 const installAllLocalAppArchives = () => {
     const tgzFiles = fileUtil.listFiles(getAppsLocalDir(), /\.tgz$/);
     return tgzFiles.reduce(
         (prev, tgzFile) =>
-            prev.then(() =>
-                installLocalApp(path.join(getAppsLocalDir(), tgzFile), true)
-            ),
+            prev.then(async () => {
+                const tgzFilePath = path.join(getAppsLocalDir(), tgzFile);
+                const result = await installLocalApp(tgzFilePath);
+
+                if (result.type === 'success') {
+                    await fileUtil.deleteFile(tgzFilePath);
+                }
+
+                if (
+                    result.type === 'failure' &&
+                    result.errorType === 'error reading file'
+                ) {
+                    dialog.showErrorBox(
+                        'Failed to install local app',
+                        result.errorMessage
+                    );
+                }
+
+                if (
+                    result.type === 'failure' &&
+                    result.errorType === 'error because app exists' &&
+                    shouldRemoveExistingApp(tgzFilePath, result.appPath)
+                ) {
+                    await fs.remove(result.appPath);
+                    const resultOfRetry = await installLocalApp(tgzFilePath);
+
+                    if (resultOfRetry.type === 'success') {
+                        await fileUtil.deleteFile(tgzFilePath);
+                    }
+                }
+            }),
         Promise.resolve<unknown>(undefined)
     );
 };

--- a/src/main/registerIpcHandler.ts
+++ b/src/main/registerIpcHandler.ts
@@ -13,6 +13,7 @@ import {
     registerInstallDownloadableApp,
     registerInstallLocalApp,
     registerRemoveDownloadableApp,
+    registerRemoveLocalApp,
 } from '../ipc/apps';
 import { registerGetConfig } from '../ipc/config';
 import { registerCreateDesktopShortcut } from '../ipc/createDesktopShortcut';
@@ -51,6 +52,7 @@ import {
     installDownloadableApp,
     installLocalApp,
     removeDownloadableApp,
+    removeLocalApp,
 } from './apps';
 import { getConfig } from './config';
 import createDesktopShortcut from './createDesktopShortcut';
@@ -105,6 +107,7 @@ export default () => {
     registerGetLocalApps(getLocalApps);
     registerInstallDownloadableApp(installDownloadableApp);
     registerInstallLocalApp(installLocalApp);
+    registerRemoveLocalApp(removeLocalApp);
     registerRemoveDownloadableApp(removeDownloadableApp);
 
     registerGetSources(getAllSources);


### PR DESCRIPTION
A bunch of enhancement over the basic implementation:

- Ignore when dropping anything else than files, e.g. text
- Allow dropping multiple files
- Show a helpful error message when a dropped file cannot be installed (e.g. because its filename is not as expected or because it cannot be unpacked as a TGZ archive)
- When dropping a file for which an app is already installed, ask the users whether they want to overwrite the latter or cancel.

Part of https://trello.com/c/AvcUcoIb