### PR TITLE
Detect wrong app names for local apps

### DIFF
--- a/src/main/apps.ts
+++ b/src/main/apps.ts
@@ -135,9 +135,21 @@ export const installLocalApp = async (
         );
     }
 
-    return successfulInstall(
-        (await infoFromInstalledApp(getAppsLocalDir(), appName)) as LocalApp
-    );
+    const app = (await infoFromInstalledApp(
+        getAppsLocalDir(),
+        appName
+    )) as LocalApp;
+
+    if (app.name !== appName) {
+        await fs.remove(appPath);
+        return failureReadingFile(
+            `According to the filename \`${tgzFilePath}\`, the app should ` +
+                `be called \`${appName}\`, but internally it is called ` +
+                `\`${app.name}\`.`
+        );
+    }
+
+    return successfulInstall(app);
 };
 
 export const removeLocalApp = (appName: string) =>


### PR DESCRIPTION
If an app package is dropped where the filename and internal app name do not match, then do not install it:

https://user-images.githubusercontent.com/260705/199466255-01922ecc-cfd1-4515-b88a-cac8c633b63a.mov

If a local app directory exists where the internal app name does not match the directory name, then hide the app:

https://user-images.githubusercontent.com/260705/199466425-0fb51b68-cfd9-4f29-b67c-d72ae0a0021d.mov

Part of https://trello.com/c/AvcUcoIb