### PR TITLE
Serialport main process

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 
 -   Install local apps by dragging a file containing an app package and dropping
     it onto the app list.
+-   Add support for Serial Terminal app
 
 ### Changed
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,6 +6,7 @@
 
 const sharedConfig = require('pc-nrfconnect-shared/config/jest.config')([
     'packageJson',
+    'serialport',
 ]);
 
 sharedConfig.setupFilesAfterEnv.push('<rootDir>/src/test/setupMocks.js');

--- a/package-lock.json
+++ b/package-lock.json
@@ -2264,6 +2264,7 @@
             "version": "10.2.2",
             "resolved": "https://registry.npmjs.org/@serialport/binding-mock/-/binding-mock-10.2.2.tgz",
             "integrity": "sha512-HAFzGhk9OuFMpuor7aT5G1ChPgn5qSsklTFOTUX72Rl6p0xwcSVsRtG/xaGp6bxpN7fI9D/S8THLBWbBgS6ldw==",
+            "dev": true,
             "requires": {
                 "@serialport/bindings-interface": "^1.2.1",
                 "debug": "^4.3.3"
@@ -2273,6 +2274,7 @@
             "version": "10.8.0",
             "resolved": "https://registry.npmjs.org/@serialport/bindings-cpp/-/bindings-cpp-10.8.0.tgz",
             "integrity": "sha512-OMQNJz5kJblbmZN5UgJXLwi2XNtVLxSKmq5VyWuXQVsUIJD4l9UGHnLPqM5LD9u3HPZgDI5w7iYN7gxkQNZJUw==",
+            "dev": true,
             "requires": {
                 "@serialport/bindings-interface": "1.2.2",
                 "@serialport/parser-readline": "^10.2.1",
@@ -2284,44 +2286,52 @@
                 "node-addon-api": {
                     "version": "5.0.0",
                     "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.0.0.tgz",
-                    "integrity": "sha512-CvkDw2OEnme7ybCykJpVcKH+uAOLV2qLqiyla128dN9TkEWfrYmxG6C2boDe5KcNQqZF3orkqzGgOMvZ/JNekA=="
+                    "integrity": "sha512-CvkDw2OEnme7ybCykJpVcKH+uAOLV2qLqiyla128dN9TkEWfrYmxG6C2boDe5KcNQqZF3orkqzGgOMvZ/JNekA==",
+                    "dev": true
                 }
             }
         },
         "@serialport/bindings-interface": {
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/@serialport/bindings-interface/-/bindings-interface-1.2.2.tgz",
-            "integrity": "sha512-CJaUd5bLvtM9c5dmO9rPBHPXTa9R2UwpkJ0wdh9JCYcbrPWsKz+ErvR0hBLeo7NPeiFdjFO4sonRljiw4d2XiA=="
+            "integrity": "sha512-CJaUd5bLvtM9c5dmO9rPBHPXTa9R2UwpkJ0wdh9JCYcbrPWsKz+ErvR0hBLeo7NPeiFdjFO4sonRljiw4d2XiA==",
+            "dev": true
         },
         "@serialport/parser-byte-length": {
             "version": "10.5.0",
             "resolved": "https://registry.npmjs.org/@serialport/parser-byte-length/-/parser-byte-length-10.5.0.tgz",
-            "integrity": "sha512-eHhr4lHKboq1OagyaXAqkemQ1XyoqbLQC8XJbvccm95o476TmEdW5d7AElwZV28kWprPW68ZXdGF2VXCkJgS2w=="
+            "integrity": "sha512-eHhr4lHKboq1OagyaXAqkemQ1XyoqbLQC8XJbvccm95o476TmEdW5d7AElwZV28kWprPW68ZXdGF2VXCkJgS2w==",
+            "dev": true
         },
         "@serialport/parser-cctalk": {
             "version": "10.5.0",
             "resolved": "https://registry.npmjs.org/@serialport/parser-cctalk/-/parser-cctalk-10.5.0.tgz",
-            "integrity": "sha512-Iwsdr03xmCKAiibLSr7b3w6ZUTBNiS+PwbDQXdKU/clutXjuoex83XvsOtYVcNZmwJlVNhAUbkG+FJzWwIa4DA=="
+            "integrity": "sha512-Iwsdr03xmCKAiibLSr7b3w6ZUTBNiS+PwbDQXdKU/clutXjuoex83XvsOtYVcNZmwJlVNhAUbkG+FJzWwIa4DA==",
+            "dev": true
         },
         "@serialport/parser-delimiter": {
             "version": "10.5.0",
             "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-10.5.0.tgz",
-            "integrity": "sha512-/uR/yT3jmrcwnl2FJU/2ySvwgo5+XpksDUR4NF/nwTS5i3CcuKS+FKi/tLzy1k8F+rCx5JzpiK+koqPqOUWArA=="
+            "integrity": "sha512-/uR/yT3jmrcwnl2FJU/2ySvwgo5+XpksDUR4NF/nwTS5i3CcuKS+FKi/tLzy1k8F+rCx5JzpiK+koqPqOUWArA==",
+            "dev": true
         },
         "@serialport/parser-inter-byte-timeout": {
             "version": "10.5.0",
             "resolved": "https://registry.npmjs.org/@serialport/parser-inter-byte-timeout/-/parser-inter-byte-timeout-10.5.0.tgz",
-            "integrity": "sha512-WPvVlSx98HmmUF9jjK6y9mMp3Wnv6JQA0cUxLeZBgS74TibOuYG3fuUxUWGJALgAXotOYMxfXSezJ/vSnQrkhQ=="
+            "integrity": "sha512-WPvVlSx98HmmUF9jjK6y9mMp3Wnv6JQA0cUxLeZBgS74TibOuYG3fuUxUWGJALgAXotOYMxfXSezJ/vSnQrkhQ==",
+            "dev": true
         },
         "@serialport/parser-packet-length": {
             "version": "10.5.0",
             "resolved": "https://registry.npmjs.org/@serialport/parser-packet-length/-/parser-packet-length-10.5.0.tgz",
-            "integrity": "sha512-jkpC/8w4/gUBRa2Teyn7URv1D7T//0lGj27/4u9AojpDVXsR6dtdcTG7b7dNirXDlOrSLvvN7aS5/GNaRlEByw=="
+            "integrity": "sha512-jkpC/8w4/gUBRa2Teyn7URv1D7T//0lGj27/4u9AojpDVXsR6dtdcTG7b7dNirXDlOrSLvvN7aS5/GNaRlEByw==",
+            "dev": true
         },
         "@serialport/parser-readline": {
             "version": "10.5.0",
             "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-10.5.0.tgz",
             "integrity": "sha512-0aXJknodcl94W9zSjvU+sLdXiyEG2rqjQmvBWZCr8wJZjWEtv3RgrnYiWq4i2OTOyC8C/oPK8ZjpBjQptRsoJQ==",
+            "dev": true,
             "requires": {
                 "@serialport/parser-delimiter": "10.5.0"
             }
@@ -2329,27 +2339,32 @@
         "@serialport/parser-ready": {
             "version": "10.5.0",
             "resolved": "https://registry.npmjs.org/@serialport/parser-ready/-/parser-ready-10.5.0.tgz",
-            "integrity": "sha512-QIf65LTvUoxqWWHBpgYOL+soldLIIyD1bwuWelukem2yDZVWwEjR288cLQ558BgYxH4U+jLAQahhqoyN1I7BaA=="
+            "integrity": "sha512-QIf65LTvUoxqWWHBpgYOL+soldLIIyD1bwuWelukem2yDZVWwEjR288cLQ558BgYxH4U+jLAQahhqoyN1I7BaA==",
+            "dev": true
         },
         "@serialport/parser-regex": {
             "version": "10.5.0",
             "resolved": "https://registry.npmjs.org/@serialport/parser-regex/-/parser-regex-10.5.0.tgz",
-            "integrity": "sha512-9jnr9+PCxRoLjtGs7uxwsFqvho+rxuJlW6ZWSB7oqfzshEZWXtTJgJRgac/RuLft4hRlrmRz5XU40i3uoL4HKw=="
+            "integrity": "sha512-9jnr9+PCxRoLjtGs7uxwsFqvho+rxuJlW6ZWSB7oqfzshEZWXtTJgJRgac/RuLft4hRlrmRz5XU40i3uoL4HKw==",
+            "dev": true
         },
         "@serialport/parser-slip-encoder": {
             "version": "10.5.0",
             "resolved": "https://registry.npmjs.org/@serialport/parser-slip-encoder/-/parser-slip-encoder-10.5.0.tgz",
-            "integrity": "sha512-wP8m+uXQdkWSa//3n+VvfjLthlabwd9NiG6kegf0fYweLWio8j4pJRL7t9eTh2Lbc7zdxuO0r8ducFzO0m8CQw=="
+            "integrity": "sha512-wP8m+uXQdkWSa//3n+VvfjLthlabwd9NiG6kegf0fYweLWio8j4pJRL7t9eTh2Lbc7zdxuO0r8ducFzO0m8CQw==",
+            "dev": true
         },
         "@serialport/parser-spacepacket": {
             "version": "10.5.0",
             "resolved": "https://registry.npmjs.org/@serialport/parser-spacepacket/-/parser-spacepacket-10.5.0.tgz",
-            "integrity": "sha512-BEZ/HAEMwOd8xfuJSeI/823IR/jtnThovh7ils90rXD4DPL1ZmrP4abAIEktwe42RobZjIPfA4PaVfyO0Fjfhg=="
+            "integrity": "sha512-BEZ/HAEMwOd8xfuJSeI/823IR/jtnThovh7ils90rXD4DPL1ZmrP4abAIEktwe42RobZjIPfA4PaVfyO0Fjfhg==",
+            "dev": true
         },
         "@serialport/stream": {
             "version": "10.5.0",
             "resolved": "https://registry.npmjs.org/@serialport/stream/-/stream-10.5.0.tgz",
             "integrity": "sha512-gbcUdvq9Kyv2HsnywS7QjnEB28g+6OGB5Z8TLP7X+UPpoMIWoUsoQIq5Kt0ZTgMoWn3JGM2lqwTsSHF+1qhniA==",
+            "dev": true,
             "requires": {
                 "@serialport/bindings-interface": "1.2.2",
                 "debug": "^4.3.2"
@@ -3496,9 +3511,9 @@
             }
         },
         "@types/yargs": {
-            "version": "17.0.14",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.14.tgz",
-            "integrity": "sha512-9Pj7abXoW1RSTcZaL2Hk6G2XyLMlp5ECdVC/Zf2p/KBjC3srijLGgRAXOBjtFrJoIrvxdTKyKDA14bEcbxBaWw==",
+            "version": "17.0.15",
+            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.15.tgz",
+            "integrity": "sha512-ZHc4W2dnEQPfhn06TBEdWaiUHEZAocYaiVMfwOipY5jcJt/251wVrKCBWBetGZWO5CF8tdb7L3DmdxVlZ2BOIg==",
             "dev": true,
             "requires": {
                 "@types/yargs-parser": "*"
@@ -13234,7 +13249,8 @@
         "node-gyp-build": {
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
-            "integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg=="
+            "integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==",
+            "dev": true
         },
         "node-int64": {
             "version": "0.4.0",
@@ -16725,6 +16741,7 @@
             "version": "10.5.0",
             "resolved": "https://registry.npmjs.org/serialport/-/serialport-10.5.0.tgz",
             "integrity": "sha512-7OYLDsu5i6bbv3lU81pGy076xe0JwpK6b49G6RjNvGibstUqQkI+I3/X491yBGtf4gaqUdOgoU1/5KZ/XxL4dw==",
+            "dev": true,
             "requires": {
                 "@serialport/binding-mock": "10.2.2",
                 "@serialport/bindings-cpp": "10.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14334,17 +14334,6 @@
                     "integrity": "sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==",
                     "dev": true
                 },
-                "electron": {
-                    "version": "13.6.9",
-                    "resolved": "https://registry.npmjs.org/electron/-/electron-13.6.9.tgz",
-                    "integrity": "sha512-Es/sBy85NIuqsO9MW41PUCpwIkeinlTQ7g0ainfnmRAM2rmog3GBxVCaoV5dzEjwTF7TKG1Yr/E7Z3qHmlfWAg==",
-                    "dev": true,
-                    "requires": {
-                        "@electron/get": "^1.0.1",
-                        "@types/node": "^14.6.2",
-                        "extract-zip": "^1.0.3"
-                    }
-                },
                 "electron-store": {
                     "version": "8.0.2",
                     "resolved": "https://registry.npmjs.org/electron-store/-/electron-store-8.0.2.tgz",
@@ -19084,11 +19073,7 @@
                     "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
                     "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
                     "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "bindings": "^1.5.0",
-                        "nan": "^2.12.1"
-                    }
+                    "optional": true
                 },
                 "glob-parent": {
                     "version": "3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3178,9 +3178,9 @@
             }
         },
         "@types/jest": {
-            "version": "29.2.3",
-            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.2.3.tgz",
-            "integrity": "sha512-6XwoEbmatfyoCjWRX7z0fKMmgYKe9+/HrviJ5k0X/tjJWHGAezZOfYaxqQKuzG/TvQyr+ktjm4jgbk0s4/oF2w==",
+            "version": "29.2.4",
+            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.2.4.tgz",
+            "integrity": "sha512-PipFB04k2qTRPePduVLTRiPzQfvMeLwUN3Z21hsAKaB/W9IIzgB2pizCL466ftJlcyZqnHoC9ZHpxLGl3fS86A==",
             "dev": true,
             "requires": {
                 "expect": "^29.0.0",
@@ -3220,9 +3220,9 @@
             }
         },
         "@types/lodash": {
-            "version": "4.14.190",
-            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.190.tgz",
-            "integrity": "sha512-5iJ3FBJBvQHQ8sFhEhJfjUP+G+LalhavTkYyrAYqz5MEJG+erSv0k9KJLb6q7++17Lafk1scaTIFXcMJlwK8Mw==",
+            "version": "4.14.191",
+            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.191.tgz",
+            "integrity": "sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==",
             "dev": true
         },
         "@types/lodash.merge": {
@@ -5625,9 +5625,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001434",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001434.tgz",
-            "integrity": "sha512-aOBHrLmTQw//WFa2rcF1If9fa3ypkC1wzqqiKHgfdrXTWcU8C4gKVZT77eQAPWN1APys3+uQ0Df07rKauXGEYA==",
+            "version": "1.0.30001436",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001436.tgz",
+            "integrity": "sha512-ZmWkKsnC2ifEPoWUvSAIGyOYwT+keAaaWPHiQ9DfMqS1t6tfuyFYoWR78TeZtznkEQ64+vGXH9cZrElwR2Mrxg==",
             "dev": true
         },
         "caseless": {
@@ -6810,15 +6810,15 @@
             "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="
         },
         "decimal.js": {
-            "version": "10.4.2",
-            "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.2.tgz",
-            "integrity": "sha512-ic1yEvwT6GuvaYwBLLY6/aFFgjZdySKTE8en/fkU3QICTmRtgtSlFn0u0BXN06InZwtfCelR7j8LRiDI/02iGA==",
+            "version": "10.4.3",
+            "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
+            "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
             "dev": true
         },
         "decode-uri-component": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-            "integrity": "sha512-hjf+xovcEn31w/EUYdTXQh/8smFL/dzYjohQGEIgjyNavaJfBY2p5F527Bo1VPATxv0VYTUC2bOcXvqFwk78Og==",
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+            "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
             "dev": true
         },
         "decompress-response": {
@@ -8193,16 +8193,200 @@
             "optional": true
         },
         "esbuild-sass-plugin": {
-            "version": "2.4.2",
-            "resolved": "https://registry.npmjs.org/esbuild-sass-plugin/-/esbuild-sass-plugin-2.4.2.tgz",
-            "integrity": "sha512-Rsih/IkKDZlBbw73tUhten9gpg6NElDPLzUl/aSSo4A8oqoHTa5PGHq0yrsuxbszSWAppCFBYDVvi8CGGmvU3A==",
+            "version": "2.4.3",
+            "resolved": "https://registry.npmjs.org/esbuild-sass-plugin/-/esbuild-sass-plugin-2.4.3.tgz",
+            "integrity": "sha512-iEfikpoZGoUd46K2nJ195n+4/75n8xYFL5/LDAaaRkXRxzZuZ9AZS4EdW7hTYQwEMkUiBIASHHouuU8Ioovv9Q==",
             "dev": true,
             "requires": {
-                "esbuild": "^0.15.12",
+                "esbuild": "^0.15.17",
                 "resolve": "^1.22.1",
-                "sass": "^1.55.0"
+                "sass": "^1.56.1"
             },
             "dependencies": {
+                "@esbuild/android-arm": {
+                    "version": "0.15.18",
+                    "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.15.18.tgz",
+                    "integrity": "sha512-5GT+kcs2WVGjVs7+boataCkO5Fg0y4kCjzkB5bAip7H4jfnOS3dA6KPiww9W1OEKTKeAcUVhdZGvgI65OXmUnw==",
+                    "dev": true,
+                    "optional": true
+                },
+                "@esbuild/linux-loong64": {
+                    "version": "0.15.18",
+                    "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.15.18.tgz",
+                    "integrity": "sha512-L4jVKS82XVhw2nvzLg/19ClLWg0y27ulRwuP7lcyL6AbUWB5aPglXY3M21mauDQMDfRLs8cQmeT03r/+X3cZYQ==",
+                    "dev": true,
+                    "optional": true
+                },
+                "esbuild": {
+                    "version": "0.15.18",
+                    "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.15.18.tgz",
+                    "integrity": "sha512-x/R72SmW3sSFRm5zrrIjAhCeQSAWoni3CmHEqfQrZIQTM3lVCdehdwuIqaOtfC2slvpdlLa62GYoN8SxT23m6Q==",
+                    "dev": true,
+                    "requires": {
+                        "@esbuild/android-arm": "0.15.18",
+                        "@esbuild/linux-loong64": "0.15.18",
+                        "esbuild-android-64": "0.15.18",
+                        "esbuild-android-arm64": "0.15.18",
+                        "esbuild-darwin-64": "0.15.18",
+                        "esbuild-darwin-arm64": "0.15.18",
+                        "esbuild-freebsd-64": "0.15.18",
+                        "esbuild-freebsd-arm64": "0.15.18",
+                        "esbuild-linux-32": "0.15.18",
+                        "esbuild-linux-64": "0.15.18",
+                        "esbuild-linux-arm": "0.15.18",
+                        "esbuild-linux-arm64": "0.15.18",
+                        "esbuild-linux-mips64le": "0.15.18",
+                        "esbuild-linux-ppc64le": "0.15.18",
+                        "esbuild-linux-riscv64": "0.15.18",
+                        "esbuild-linux-s390x": "0.15.18",
+                        "esbuild-netbsd-64": "0.15.18",
+                        "esbuild-openbsd-64": "0.15.18",
+                        "esbuild-sunos-64": "0.15.18",
+                        "esbuild-windows-32": "0.15.18",
+                        "esbuild-windows-64": "0.15.18",
+                        "esbuild-windows-arm64": "0.15.18"
+                    }
+                },
+                "esbuild-android-64": {
+                    "version": "0.15.18",
+                    "resolved": "https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.15.18.tgz",
+                    "integrity": "sha512-wnpt3OXRhcjfIDSZu9bnzT4/TNTDsOUvip0foZOUBG7QbSt//w3QV4FInVJxNhKc/ErhUxc5z4QjHtMi7/TbgA==",
+                    "dev": true,
+                    "optional": true
+                },
+                "esbuild-android-arm64": {
+                    "version": "0.15.18",
+                    "resolved": "https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.15.18.tgz",
+                    "integrity": "sha512-G4xu89B8FCzav9XU8EjsXacCKSG2FT7wW9J6hOc18soEHJdtWu03L3TQDGf0geNxfLTtxENKBzMSq9LlbjS8OQ==",
+                    "dev": true,
+                    "optional": true
+                },
+                "esbuild-darwin-64": {
+                    "version": "0.15.18",
+                    "resolved": "https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.15.18.tgz",
+                    "integrity": "sha512-2WAvs95uPnVJPuYKP0Eqx+Dl/jaYseZEUUT1sjg97TJa4oBtbAKnPnl3b5M9l51/nbx7+QAEtuummJZW0sBEmg==",
+                    "dev": true,
+                    "optional": true
+                },
+                "esbuild-darwin-arm64": {
+                    "version": "0.15.18",
+                    "resolved": "https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.15.18.tgz",
+                    "integrity": "sha512-tKPSxcTJ5OmNb1btVikATJ8NftlyNlc8BVNtyT/UAr62JFOhwHlnoPrhYWz09akBLHI9nElFVfWSTSRsrZiDUA==",
+                    "dev": true,
+                    "optional": true
+                },
+                "esbuild-freebsd-64": {
+                    "version": "0.15.18",
+                    "resolved": "https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.15.18.tgz",
+                    "integrity": "sha512-TT3uBUxkteAjR1QbsmvSsjpKjOX6UkCstr8nMr+q7zi3NuZ1oIpa8U41Y8I8dJH2fJgdC3Dj3CXO5biLQpfdZA==",
+                    "dev": true,
+                    "optional": true
+                },
+                "esbuild-freebsd-arm64": {
+                    "version": "0.15.18",
+                    "resolved": "https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.15.18.tgz",
+                    "integrity": "sha512-R/oVr+X3Tkh+S0+tL41wRMbdWtpWB8hEAMsOXDumSSa6qJR89U0S/PpLXrGF7Wk/JykfpWNokERUpCeHDl47wA==",
+                    "dev": true,
+                    "optional": true
+                },
+                "esbuild-linux-32": {
+                    "version": "0.15.18",
+                    "resolved": "https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.15.18.tgz",
+                    "integrity": "sha512-lphF3HiCSYtaa9p1DtXndiQEeQDKPl9eN/XNoBf2amEghugNuqXNZA/ZovthNE2aa4EN43WroO0B85xVSjYkbg==",
+                    "dev": true,
+                    "optional": true
+                },
+                "esbuild-linux-64": {
+                    "version": "0.15.18",
+                    "resolved": "https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.15.18.tgz",
+                    "integrity": "sha512-hNSeP97IviD7oxLKFuii5sDPJ+QHeiFTFLoLm7NZQligur8poNOWGIgpQ7Qf8Balb69hptMZzyOBIPtY09GZYw==",
+                    "dev": true,
+                    "optional": true
+                },
+                "esbuild-linux-arm": {
+                    "version": "0.15.18",
+                    "resolved": "https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.15.18.tgz",
+                    "integrity": "sha512-UH779gstRblS4aoS2qpMl3wjg7U0j+ygu3GjIeTonCcN79ZvpPee12Qun3vcdxX+37O5LFxz39XeW2I9bybMVA==",
+                    "dev": true,
+                    "optional": true
+                },
+                "esbuild-linux-arm64": {
+                    "version": "0.15.18",
+                    "resolved": "https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.15.18.tgz",
+                    "integrity": "sha512-54qr8kg/6ilcxd+0V3h9rjT4qmjc0CccMVWrjOEM/pEcUzt8X62HfBSeZfT2ECpM7104mk4yfQXkosY8Quptug==",
+                    "dev": true,
+                    "optional": true
+                },
+                "esbuild-linux-mips64le": {
+                    "version": "0.15.18",
+                    "resolved": "https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.15.18.tgz",
+                    "integrity": "sha512-Mk6Ppwzzz3YbMl/ZZL2P0q1tnYqh/trYZ1VfNP47C31yT0K8t9s7Z077QrDA/guU60tGNp2GOwCQnp+DYv7bxQ==",
+                    "dev": true,
+                    "optional": true
+                },
+                "esbuild-linux-ppc64le": {
+                    "version": "0.15.18",
+                    "resolved": "https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.15.18.tgz",
+                    "integrity": "sha512-b0XkN4pL9WUulPTa/VKHx2wLCgvIAbgwABGnKMY19WhKZPT+8BxhZdqz6EgkqCLld7X5qiCY2F/bfpUUlnFZ9w==",
+                    "dev": true,
+                    "optional": true
+                },
+                "esbuild-linux-riscv64": {
+                    "version": "0.15.18",
+                    "resolved": "https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.15.18.tgz",
+                    "integrity": "sha512-ba2COaoF5wL6VLZWn04k+ACZjZ6NYniMSQStodFKH/Pu6RxzQqzsmjR1t9QC89VYJxBeyVPTaHuBMCejl3O/xg==",
+                    "dev": true,
+                    "optional": true
+                },
+                "esbuild-linux-s390x": {
+                    "version": "0.15.18",
+                    "resolved": "https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.15.18.tgz",
+                    "integrity": "sha512-VbpGuXEl5FCs1wDVp93O8UIzl3ZrglgnSQ+Hu79g7hZu6te6/YHgVJxCM2SqfIila0J3k0csfnf8VD2W7u2kzQ==",
+                    "dev": true,
+                    "optional": true
+                },
+                "esbuild-netbsd-64": {
+                    "version": "0.15.18",
+                    "resolved": "https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.15.18.tgz",
+                    "integrity": "sha512-98ukeCdvdX7wr1vUYQzKo4kQ0N2p27H7I11maINv73fVEXt2kyh4K4m9f35U1K43Xc2QGXlzAw0K9yoU7JUjOg==",
+                    "dev": true,
+                    "optional": true
+                },
+                "esbuild-openbsd-64": {
+                    "version": "0.15.18",
+                    "resolved": "https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.15.18.tgz",
+                    "integrity": "sha512-yK5NCcH31Uae076AyQAXeJzt/vxIo9+omZRKj1pauhk3ITuADzuOx5N2fdHrAKPxN+zH3w96uFKlY7yIn490xQ==",
+                    "dev": true,
+                    "optional": true
+                },
+                "esbuild-sunos-64": {
+                    "version": "0.15.18",
+                    "resolved": "https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.15.18.tgz",
+                    "integrity": "sha512-On22LLFlBeLNj/YF3FT+cXcyKPEI263nflYlAhz5crxtp3yRG1Ugfr7ITyxmCmjm4vbN/dGrb/B7w7U8yJR9yw==",
+                    "dev": true,
+                    "optional": true
+                },
+                "esbuild-windows-32": {
+                    "version": "0.15.18",
+                    "resolved": "https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.15.18.tgz",
+                    "integrity": "sha512-o+eyLu2MjVny/nt+E0uPnBxYuJHBvho8vWsC2lV61A7wwTWC3jkN2w36jtA+yv1UgYkHRihPuQsL23hsCYGcOQ==",
+                    "dev": true,
+                    "optional": true
+                },
+                "esbuild-windows-64": {
+                    "version": "0.15.18",
+                    "resolved": "https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.15.18.tgz",
+                    "integrity": "sha512-qinug1iTTaIIrCorAUjR0fcBk24fjzEedFYhhispP8Oc7SFvs+XeW3YpAKiKp8dRpizl4YYAhxMjlftAMJiaUw==",
+                    "dev": true,
+                    "optional": true
+                },
+                "esbuild-windows-arm64": {
+                    "version": "0.15.18",
+                    "resolved": "https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.15.18.tgz",
+                    "integrity": "sha512-q9bsYzegpZcLziq0zgUi5KqGVtfhjxGbnksaBFYmWLxeV/S1fK4OLdq2DFYnXcLMjlZw2L0jLsk1eGoB522WXQ==",
+                    "dev": true,
+                    "optional": true
+                },
                 "sass": {
                     "version": "1.56.1",
                     "resolved": "https://registry.npmjs.org/sass/-/sass-1.56.1.tgz",
@@ -9162,9 +9346,9 @@
             "dev": true
         },
         "fastq": {
-            "version": "1.13.0",
-            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
-            "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+            "version": "1.14.0",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.14.0.tgz",
+            "integrity": "sha512-eR2D+V9/ExcbF9ls441yIuN6TI2ED1Y2ZcA5BmMtJsOkWOFRJQ0Jt0g1UwqXJJVAb+V+umH5Dfr8oh4EVP7VVg==",
             "dev": true,
             "requires": {
                 "reusify": "^1.0.4"
@@ -9255,9 +9439,9 @@
                     }
                 },
                 "minimatch": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz",
-                    "integrity": "sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==",
+                    "version": "5.1.1",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.1.tgz",
+                    "integrity": "sha512-362NP+zlprccbEt/SkxKfRMHnNY85V74mVnpUpNyr3F35covl09Kec7/sEFLt3RA4oXmewtoaanoIf67SE5Y5g==",
                     "dev": true,
                     "requires": {
                         "brace-expansion": "^2.0.1"
@@ -11995,12 +12179,12 @@
             "dev": true
         },
         "language-tags": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.5.tgz",
-            "integrity": "sha512-qJhlO9cGXi6hBGKoxEG/sKZDAHD5Hnu9Hs4WbOY3pCWXDhw0N8x1NenNzm2EnNLkLkk7J2SdxAkDSbb6ftT+UQ==",
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.6.tgz",
+            "integrity": "sha512-HNkaCgM8wZgE/BZACeotAAgpL9FUjEnhgF0FVQMIgH//zqTPreLYMb3rWYkYAqPoF75Jwuycp1da7uz66cfFQg==",
             "dev": true,
             "requires": {
-                "language-subtag-registry": "~0.3.2"
+                "language-subtag-registry": "^0.3.20"
             }
         },
         "latest-version": {
@@ -14204,8 +14388,8 @@
             }
         },
         "pc-nrfconnect-shared": {
-            "version": "git+https://github.com/NordicSemiconductor/pc-nrfconnect-shared.git#5f9c2cda1f18e99cc53a9b408730e51b32fd3ada",
-            "from": "git+https://github.com/NordicSemiconductor/pc-nrfconnect-shared.git#v6.12.1",
+            "version": "git+https://github.com/NordicSemiconductor/pc-nrfconnect-shared.git#1522956ba69feae747752321c29e016225dd947c",
+            "from": "git+https://github.com/NordicSemiconductor/pc-nrfconnect-shared.git#v6.13.1",
             "dev": true,
             "requires": {
                 "@babel/core": "7.18.9",
@@ -17906,9 +18090,9 @@
             }
         },
         "terser": {
-            "version": "5.16.0",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.0.tgz",
-            "integrity": "sha512-KjTV81QKStSfwbNiwlBXfcgMcOloyuRdb62/iLFPGBcVNF4EXjhdYBhYHmbJpiBrVxZhDvltE11j+LBQUxEEJg==",
+            "version": "5.16.1",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.1.tgz",
+            "integrity": "sha512-xvQfyfA1ayT0qdK47zskQgRZeWLoOQ8JQ6mIgRGVNwZKdQMU+5FkCBjmv4QjcrTzyZquRw2FVtlJSRUmMKQslw==",
             "dev": true,
             "requires": {
                 "@jridgewell/source-map": "^0.3.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14204,8 +14204,8 @@
             }
         },
         "pc-nrfconnect-shared": {
-            "version": "git+https://github.com/NordicSemiconductor/pc-nrfconnect-shared.git#3eeb2e2126b3faeeba2017bc74081003105f3209",
-            "from": "git+https://github.com/NordicSemiconductor/pc-nrfconnect-shared.git#v6.12.0",
+            "version": "git+https://github.com/NordicSemiconductor/pc-nrfconnect-shared.git#5f9c2cda1f18e99cc53a9b408730e51b32fd3ada",
+            "from": "git+https://github.com/NordicSemiconductor/pc-nrfconnect-shared.git#v6.12.1",
             "dev": true,
             "requires": {
                 "@babel/core": "7.18.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2146,19 +2146,19 @@
             }
         },
         "@playwright/test": {
-            "version": "1.28.0",
-            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.28.0.tgz",
-            "integrity": "sha512-vrHs5DFTPwYox5SGKq/7TDn/S4q6RA1zArd7uhO6EyP9hj3XgZBBM12ktMbnDQNxh/fL1IUKsTNLxihmsU38lQ==",
+            "version": "1.28.1",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.28.1.tgz",
+            "integrity": "sha512-xN6spdqrNlwSn9KabIhqfZR7IWjPpFK1835tFNgjrlysaSezuX8PYUwaz38V/yI8TJLG9PkAMEXoHRXYXlpTPQ==",
             "dev": true,
             "requires": {
                 "@types/node": "*",
-                "playwright-core": "1.28.0"
+                "playwright-core": "1.28.1"
             },
             "dependencies": {
                 "playwright-core": {
-                    "version": "1.28.0",
-                    "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.28.0.tgz",
-                    "integrity": "sha512-nJLknd28kPBiCNTbqpu6Wmkrh63OEqJSFw9xOfL9qxfNwody7h6/L3O2dZoWQ6Oxcm0VOHjWmGiCUGkc0X3VZA==",
+                    "version": "1.28.1",
+                    "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.28.1.tgz",
+                    "integrity": "sha512-3PixLnGPno0E8rSBJjtwqTwJe3Yw72QwBBBxNoukIj3lEeBNXwbNiKrNuB1oyQgTBw5QHUhNO3SteEtHaMK6ag==",
                     "dev": true
                 }
             }
@@ -2260,158 +2260,19 @@
                 "dequal": "^2.0.2"
             }
         },
-        "@serialport/binding-abstract": {
-            "version": "8.0.6",
-            "resolved": "https://registry.npmjs.org/@serialport/binding-abstract/-/binding-abstract-8.0.6.tgz",
-            "integrity": "sha512-1swwUVoRyQ9ubxrkJ8JPppykohUpTAP4jkGr36e9NjbVocSPfqeX6tFZFwl/IdUlwJwxGdbKDqq7FvXniCQUMw==",
-            "requires": {
-                "debug": "^4.1.1"
-            }
-        },
         "@serialport/binding-mock": {
-            "version": "8.0.6",
-            "resolved": "https://registry.npmjs.org/@serialport/binding-mock/-/binding-mock-8.0.6.tgz",
-            "integrity": "sha512-BIbY5/PsDDo0QWDNCCxDgpowAdks+aZR8BOsEtK2GoASTTcJCy1fBwPIfH870o7rnbH901wY3C+yuTfdOvSO9A==",
+            "version": "10.2.2",
+            "resolved": "https://registry.npmjs.org/@serialport/binding-mock/-/binding-mock-10.2.2.tgz",
+            "integrity": "sha512-HAFzGhk9OuFMpuor7aT5G1ChPgn5qSsklTFOTUX72Rl6p0xwcSVsRtG/xaGp6bxpN7fI9D/S8THLBWbBgS6ldw==",
             "requires": {
-                "@serialport/binding-abstract": "^8.0.6",
-                "debug": "^4.1.1"
-            }
-        },
-        "@serialport/bindings": {
-            "version": "8.0.8",
-            "resolved": "https://registry.npmjs.org/@serialport/bindings/-/bindings-8.0.8.tgz",
-            "integrity": "sha512-xMJHr7CyOPq+wwC/S2RNI+tY+WZW4gXY3tE8QUOIRp0K7lSyLYOzKdyGUtk2uI0ohDMV3OcB+TEhhffT2S2DHQ==",
-            "requires": {
-                "@serialport/binding-abstract": "^8.0.6",
-                "@serialport/parser-readline": "^8.0.6",
-                "bindings": "^1.5.0",
-                "debug": "^4.1.1",
-                "nan": "^2.14.0",
-                "prebuild-install": "^5.3.0"
-            },
-            "dependencies": {
-                "are-we-there-yet": {
-                    "version": "1.1.7",
-                    "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.7.tgz",
-                    "integrity": "sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==",
-                    "requires": {
-                        "delegates": "^1.0.0",
-                        "readable-stream": "^2.0.6"
-                    }
-                },
-                "decompress-response": {
-                    "version": "4.2.1",
-                    "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
-                    "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
-                    "requires": {
-                        "mimic-response": "^2.0.0"
-                    }
-                },
-                "gauge": {
-                    "version": "2.7.4",
-                    "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-                    "integrity": "sha512-14x4kjc6lkD3ltw589k0NrPD6cCNTD6CWoVUNpB85+DrtONoZn+Rug6xZU5RvSC4+TZPxA5AnBibQYAvZn41Hg==",
-                    "requires": {
-                        "aproba": "^1.0.3",
-                        "console-control-strings": "^1.0.0",
-                        "has-unicode": "^2.0.0",
-                        "object-assign": "^4.1.0",
-                        "signal-exit": "^3.0.0",
-                        "string-width": "^1.0.1",
-                        "strip-ansi": "^3.0.1",
-                        "wide-align": "^1.1.0"
-                    }
-                },
-                "isarray": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                    "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
-                },
-                "mimic-response": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
-                    "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA=="
-                },
-                "node-abi": {
-                    "version": "2.30.1",
-                    "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.30.1.tgz",
-                    "integrity": "sha512-/2D0wOQPgaUWzVSVgRMx+trKJRC2UG4SUc4oCJoXx9Uxjtp0Vy3/kt7zcbxHF8+Z/pK3UloLWzBISg72brfy1w==",
-                    "requires": {
-                        "semver": "^5.4.1"
-                    }
-                },
-                "npmlog": {
-                    "version": "4.1.2",
-                    "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-                    "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-                    "requires": {
-                        "are-we-there-yet": "~1.1.2",
-                        "console-control-strings": "~1.1.0",
-                        "gauge": "~2.7.3",
-                        "set-blocking": "~2.0.0"
-                    }
-                },
-                "prebuild-install": {
-                    "version": "5.3.6",
-                    "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.6.tgz",
-                    "integrity": "sha512-s8Aai8++QQGi4sSbs/M1Qku62PFK49Jm1CbgXklGz4nmHveDq0wzJkg7Na5QbnO1uNH8K7iqx2EQ/mV0MZEmOg==",
-                    "requires": {
-                        "detect-libc": "^1.0.3",
-                        "expand-template": "^2.0.3",
-                        "github-from-package": "0.0.0",
-                        "minimist": "^1.2.3",
-                        "mkdirp-classic": "^0.5.3",
-                        "napi-build-utils": "^1.0.1",
-                        "node-abi": "^2.7.0",
-                        "noop-logger": "^0.1.1",
-                        "npmlog": "^4.0.1",
-                        "pump": "^3.0.0",
-                        "rc": "^1.2.7",
-                        "simple-get": "^3.0.3",
-                        "tar-fs": "^2.0.0",
-                        "tunnel-agent": "^0.6.0",
-                        "which-pm-runs": "^1.0.0"
-                    }
-                },
-                "readable-stream": {
-                    "version": "2.3.7",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
-                    }
-                },
-                "simple-get": {
-                    "version": "3.1.1",
-                    "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.1.tgz",
-                    "integrity": "sha512-CQ5LTKGfCpvE1K0n2us+kuMPbk/q0EKl82s4aheV9oXjFEz6W/Y7oQFVJuU6QG77hRT4Ghb5RURteF5vnWjupA==",
-                    "requires": {
-                        "decompress-response": "^4.2.0",
-                        "once": "^1.3.1",
-                        "simple-concat": "^1.0.0"
-                    }
-                },
-                "string_decoder": {
-                    "version": "1.1.1",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-                    "requires": {
-                        "safe-buffer": "~5.1.0"
-                    }
-                }
+                "@serialport/bindings-interface": "^1.2.1",
+                "debug": "^4.3.3"
             }
         },
         "@serialport/bindings-cpp": {
             "version": "10.8.0",
             "resolved": "https://registry.npmjs.org/@serialport/bindings-cpp/-/bindings-cpp-10.8.0.tgz",
             "integrity": "sha512-OMQNJz5kJblbmZN5UgJXLwi2XNtVLxSKmq5VyWuXQVsUIJD4l9UGHnLPqM5LD9u3HPZgDI5w7iYN7gxkQNZJUw==",
-            "dev": true,
             "requires": {
                 "@serialport/bindings-interface": "1.2.2",
                 "@serialport/parser-readline": "^10.2.1",
@@ -2420,98 +2281,78 @@
                 "node-gyp-build": "^4.3.0"
             },
             "dependencies": {
-                "@serialport/parser-delimiter": {
-                    "version": "10.5.0",
-                    "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-10.5.0.tgz",
-                    "integrity": "sha512-/uR/yT3jmrcwnl2FJU/2ySvwgo5+XpksDUR4NF/nwTS5i3CcuKS+FKi/tLzy1k8F+rCx5JzpiK+koqPqOUWArA==",
-                    "dev": true
-                },
-                "@serialport/parser-readline": {
-                    "version": "10.5.0",
-                    "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-10.5.0.tgz",
-                    "integrity": "sha512-0aXJknodcl94W9zSjvU+sLdXiyEG2rqjQmvBWZCr8wJZjWEtv3RgrnYiWq4i2OTOyC8C/oPK8ZjpBjQptRsoJQ==",
-                    "dev": true,
-                    "requires": {
-                        "@serialport/parser-delimiter": "10.5.0"
-                    }
-                },
                 "node-addon-api": {
                     "version": "5.0.0",
                     "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.0.0.tgz",
-                    "integrity": "sha512-CvkDw2OEnme7ybCykJpVcKH+uAOLV2qLqiyla128dN9TkEWfrYmxG6C2boDe5KcNQqZF3orkqzGgOMvZ/JNekA==",
-                    "dev": true
+                    "integrity": "sha512-CvkDw2OEnme7ybCykJpVcKH+uAOLV2qLqiyla128dN9TkEWfrYmxG6C2boDe5KcNQqZF3orkqzGgOMvZ/JNekA=="
                 }
             }
         },
         "@serialport/bindings-interface": {
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/@serialport/bindings-interface/-/bindings-interface-1.2.2.tgz",
-            "integrity": "sha512-CJaUd5bLvtM9c5dmO9rPBHPXTa9R2UwpkJ0wdh9JCYcbrPWsKz+ErvR0hBLeo7NPeiFdjFO4sonRljiw4d2XiA==",
-            "dev": true
+            "integrity": "sha512-CJaUd5bLvtM9c5dmO9rPBHPXTa9R2UwpkJ0wdh9JCYcbrPWsKz+ErvR0hBLeo7NPeiFdjFO4sonRljiw4d2XiA=="
         },
         "@serialport/parser-byte-length": {
-            "version": "8.0.6",
-            "resolved": "https://registry.npmjs.org/@serialport/parser-byte-length/-/parser-byte-length-8.0.6.tgz",
-            "integrity": "sha512-92mrFxFEvq3gRvSM7ANK/jfbmHslz91a5oYJy/nbSn4H/MCRXjxR2YOkQgVXuN+zLt+iyDoW3pcOP4Sc1nWdqQ=="
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/@serialport/parser-byte-length/-/parser-byte-length-10.5.0.tgz",
+            "integrity": "sha512-eHhr4lHKboq1OagyaXAqkemQ1XyoqbLQC8XJbvccm95o476TmEdW5d7AElwZV28kWprPW68ZXdGF2VXCkJgS2w=="
         },
         "@serialport/parser-cctalk": {
-            "version": "8.0.6",
-            "resolved": "https://registry.npmjs.org/@serialport/parser-cctalk/-/parser-cctalk-8.0.6.tgz",
-            "integrity": "sha512-pqtCYQPgxnxHygiXUPCfgX7sEx+fdR/ObjpscidynEULUq2fFrC5kBkrxRbTfHRtTaU2ii9DyjFq0JVRCbhI0Q=="
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/@serialport/parser-cctalk/-/parser-cctalk-10.5.0.tgz",
+            "integrity": "sha512-Iwsdr03xmCKAiibLSr7b3w6ZUTBNiS+PwbDQXdKU/clutXjuoex83XvsOtYVcNZmwJlVNhAUbkG+FJzWwIa4DA=="
         },
         "@serialport/parser-delimiter": {
-            "version": "8.0.6",
-            "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-8.0.6.tgz",
-            "integrity": "sha512-ogKOcPisPMlVtirkuDu3SFTF0+xT0ijxoH7XjpZiYL41EVi367MwuCnEmXG+dEKKnF0j9EPqOyD2LGSJxaFmhQ=="
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-10.5.0.tgz",
+            "integrity": "sha512-/uR/yT3jmrcwnl2FJU/2ySvwgo5+XpksDUR4NF/nwTS5i3CcuKS+FKi/tLzy1k8F+rCx5JzpiK+koqPqOUWArA=="
         },
         "@serialport/parser-inter-byte-timeout": {
             "version": "10.5.0",
             "resolved": "https://registry.npmjs.org/@serialport/parser-inter-byte-timeout/-/parser-inter-byte-timeout-10.5.0.tgz",
-            "integrity": "sha512-WPvVlSx98HmmUF9jjK6y9mMp3Wnv6JQA0cUxLeZBgS74TibOuYG3fuUxUWGJALgAXotOYMxfXSezJ/vSnQrkhQ==",
-            "dev": true
+            "integrity": "sha512-WPvVlSx98HmmUF9jjK6y9mMp3Wnv6JQA0cUxLeZBgS74TibOuYG3fuUxUWGJALgAXotOYMxfXSezJ/vSnQrkhQ=="
         },
         "@serialport/parser-packet-length": {
             "version": "10.5.0",
             "resolved": "https://registry.npmjs.org/@serialport/parser-packet-length/-/parser-packet-length-10.5.0.tgz",
-            "integrity": "sha512-jkpC/8w4/gUBRa2Teyn7URv1D7T//0lGj27/4u9AojpDVXsR6dtdcTG7b7dNirXDlOrSLvvN7aS5/GNaRlEByw==",
-            "dev": true
+            "integrity": "sha512-jkpC/8w4/gUBRa2Teyn7URv1D7T//0lGj27/4u9AojpDVXsR6dtdcTG7b7dNirXDlOrSLvvN7aS5/GNaRlEByw=="
         },
         "@serialport/parser-readline": {
-            "version": "8.0.6",
-            "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-8.0.6.tgz",
-            "integrity": "sha512-OYBT2mpczh9QUI3MTw8j0A0tIlPVjpVipvuVnjRkYwxrxPeq04RaLFhaDpuRzua5rTKMt89c1y3btYeoDXMjAA==",
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-10.5.0.tgz",
+            "integrity": "sha512-0aXJknodcl94W9zSjvU+sLdXiyEG2rqjQmvBWZCr8wJZjWEtv3RgrnYiWq4i2OTOyC8C/oPK8ZjpBjQptRsoJQ==",
             "requires": {
-                "@serialport/parser-delimiter": "^8.0.6"
+                "@serialport/parser-delimiter": "10.5.0"
             }
         },
         "@serialport/parser-ready": {
-            "version": "8.0.6",
-            "resolved": "https://registry.npmjs.org/@serialport/parser-ready/-/parser-ready-8.0.6.tgz",
-            "integrity": "sha512-xcEqv4rc119WR5JzAuu8UeJOlAwET2PTdNb6aIrrLlmTxhvuBbuRFcsnF3BpH9jUL30Kh7a6QiNXIwVG+WR/1Q=="
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/@serialport/parser-ready/-/parser-ready-10.5.0.tgz",
+            "integrity": "sha512-QIf65LTvUoxqWWHBpgYOL+soldLIIyD1bwuWelukem2yDZVWwEjR288cLQ558BgYxH4U+jLAQahhqoyN1I7BaA=="
         },
         "@serialport/parser-regex": {
-            "version": "8.0.6",
-            "resolved": "https://registry.npmjs.org/@serialport/parser-regex/-/parser-regex-8.0.6.tgz",
-            "integrity": "sha512-J8KY75Azz5ZyExmyM5YfUxbXOWBkZCytKgCCmZ966ttwZS0bUZOuoCaZj2Zp4VILJAiLuxHoqc0foi67Fri5+g=="
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/@serialport/parser-regex/-/parser-regex-10.5.0.tgz",
+            "integrity": "sha512-9jnr9+PCxRoLjtGs7uxwsFqvho+rxuJlW6ZWSB7oqfzshEZWXtTJgJRgac/RuLft4hRlrmRz5XU40i3uoL4HKw=="
         },
         "@serialport/parser-slip-encoder": {
             "version": "10.5.0",
             "resolved": "https://registry.npmjs.org/@serialport/parser-slip-encoder/-/parser-slip-encoder-10.5.0.tgz",
-            "integrity": "sha512-wP8m+uXQdkWSa//3n+VvfjLthlabwd9NiG6kegf0fYweLWio8j4pJRL7t9eTh2Lbc7zdxuO0r8ducFzO0m8CQw==",
-            "dev": true
+            "integrity": "sha512-wP8m+uXQdkWSa//3n+VvfjLthlabwd9NiG6kegf0fYweLWio8j4pJRL7t9eTh2Lbc7zdxuO0r8ducFzO0m8CQw=="
         },
         "@serialport/parser-spacepacket": {
             "version": "10.5.0",
             "resolved": "https://registry.npmjs.org/@serialport/parser-spacepacket/-/parser-spacepacket-10.5.0.tgz",
-            "integrity": "sha512-BEZ/HAEMwOd8xfuJSeI/823IR/jtnThovh7ils90rXD4DPL1ZmrP4abAIEktwe42RobZjIPfA4PaVfyO0Fjfhg==",
-            "dev": true
+            "integrity": "sha512-BEZ/HAEMwOd8xfuJSeI/823IR/jtnThovh7ils90rXD4DPL1ZmrP4abAIEktwe42RobZjIPfA4PaVfyO0Fjfhg=="
         },
         "@serialport/stream": {
-            "version": "8.0.6",
-            "resolved": "https://registry.npmjs.org/@serialport/stream/-/stream-8.0.6.tgz",
-            "integrity": "sha512-ym1PwM0rwLrj90vRBB66I1hwMXbuMw9wGTxqns75U3N/tuNFOH85mxXaYVF2TpI66aM849NoI1jMm50fl9equg==",
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/@serialport/stream/-/stream-10.5.0.tgz",
+            "integrity": "sha512-gbcUdvq9Kyv2HsnywS7QjnEB28g+6OGB5Z8TLP7X+UPpoMIWoUsoQIq5Kt0ZTgMoWn3JGM2lqwTsSHF+1qhniA==",
             "requires": {
-                "debug": "^4.1.1"
+                "@serialport/bindings-interface": "1.2.2",
+                "debug": "^4.3.2"
             }
         },
         "@sinclair/typebox": {
@@ -3364,9 +3205,9 @@
             }
         },
         "@types/lodash": {
-            "version": "4.14.189",
-            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.189.tgz",
-            "integrity": "sha512-kb9/98N6X8gyME9Cf7YaqIMvYGnBSWqEci6tiettE6iJWH1XdJz/PO8LB0GtLCG7x8dU3KWhZT+lA1a35127tA==",
+            "version": "4.14.190",
+            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.190.tgz",
+            "integrity": "sha512-5iJ3FBJBvQHQ8sFhEhJfjUP+G+LalhavTkYyrAYqz5MEJG+erSv0k9KJLb6q7++17Lafk1scaTIFXcMJlwK8Mw==",
             "dev": true
         },
         "@types/lodash.merge": {
@@ -3655,9 +3496,9 @@
             }
         },
         "@types/yargs": {
-            "version": "17.0.13",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.13.tgz",
-            "integrity": "sha512-9sWaruZk2JGxIQU+IhI1fhPYRcQ0UuTNuKuCW9bR5fp7qi2Llf7WDzNa17Cy7TKnh3cdxDOiyTu6gaLS0eDatg==",
+            "version": "17.0.14",
+            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.14.tgz",
+            "integrity": "sha512-9Pj7abXoW1RSTcZaL2Hk6G2XyLMlp5ECdVC/Zf2p/KBjC3srijLGgRAXOBjtFrJoIrvxdTKyKDA14bEcbxBaWw==",
             "dev": true,
             "requires": {
                 "@types/yargs-parser": "*"
@@ -5101,14 +4942,6 @@
             "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
             "dev": true
         },
-        "bindings": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-            "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-            "requires": {
-                "file-uri-to-path": "1.0.0"
-            }
-        },
         "bl": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/bl/-/bl-3.0.1.tgz",
@@ -6003,9 +5836,9 @@
             "dev": true
         },
         "ci-info": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.6.2.tgz",
-            "integrity": "sha512-lVZdhvbEudris15CLytp2u6Y0p5EKfztae9Fqa189MfNmln9F33XuH69v5fvNfiRN5/0eAUz2yJL3mo+nhaRKg==",
+            "version": "3.7.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.7.0.tgz",
+            "integrity": "sha512-2CpRNYmImPx+RXKLq6jko/L07phmS9I02TyqkcNU20GCF/GgaWvc58hPtjxDX8lPpkdwc9sNh72V9k00S7ezog==",
             "dev": true
         },
         "cipher-base": {
@@ -9387,11 +9220,6 @@
                 "loader-utils": "^2.0.0",
                 "schema-utils": "^3.0.0"
             }
-        },
-        "file-uri-to-path": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
         },
         "filelist": {
             "version": "1.0.4",
@@ -13205,11 +13033,6 @@
             "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
             "dev": true
         },
-        "nan": {
-            "version": "2.17.0",
-            "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
-            "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ=="
-        },
         "nanoid": {
             "version": "3.3.4",
             "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
@@ -13411,8 +13234,7 @@
         "node-gyp-build": {
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
-            "integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==",
-            "dev": true
+            "integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg=="
         },
         "node-int64": {
             "version": "0.4.0",
@@ -14484,65 +14306,6 @@
                 "winston": "3.8.1"
             },
             "dependencies": {
-                "@serialport/binding-mock": {
-                    "version": "10.2.2",
-                    "resolved": "https://registry.npmjs.org/@serialport/binding-mock/-/binding-mock-10.2.2.tgz",
-                    "integrity": "sha512-HAFzGhk9OuFMpuor7aT5G1ChPgn5qSsklTFOTUX72Rl6p0xwcSVsRtG/xaGp6bxpN7fI9D/S8THLBWbBgS6ldw==",
-                    "dev": true,
-                    "requires": {
-                        "@serialport/bindings-interface": "^1.2.1",
-                        "debug": "^4.3.3"
-                    }
-                },
-                "@serialport/parser-byte-length": {
-                    "version": "10.5.0",
-                    "resolved": "https://registry.npmjs.org/@serialport/parser-byte-length/-/parser-byte-length-10.5.0.tgz",
-                    "integrity": "sha512-eHhr4lHKboq1OagyaXAqkemQ1XyoqbLQC8XJbvccm95o476TmEdW5d7AElwZV28kWprPW68ZXdGF2VXCkJgS2w==",
-                    "dev": true
-                },
-                "@serialport/parser-cctalk": {
-                    "version": "10.5.0",
-                    "resolved": "https://registry.npmjs.org/@serialport/parser-cctalk/-/parser-cctalk-10.5.0.tgz",
-                    "integrity": "sha512-Iwsdr03xmCKAiibLSr7b3w6ZUTBNiS+PwbDQXdKU/clutXjuoex83XvsOtYVcNZmwJlVNhAUbkG+FJzWwIa4DA==",
-                    "dev": true
-                },
-                "@serialport/parser-delimiter": {
-                    "version": "10.5.0",
-                    "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-10.5.0.tgz",
-                    "integrity": "sha512-/uR/yT3jmrcwnl2FJU/2ySvwgo5+XpksDUR4NF/nwTS5i3CcuKS+FKi/tLzy1k8F+rCx5JzpiK+koqPqOUWArA==",
-                    "dev": true
-                },
-                "@serialport/parser-readline": {
-                    "version": "10.5.0",
-                    "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-10.5.0.tgz",
-                    "integrity": "sha512-0aXJknodcl94W9zSjvU+sLdXiyEG2rqjQmvBWZCr8wJZjWEtv3RgrnYiWq4i2OTOyC8C/oPK8ZjpBjQptRsoJQ==",
-                    "dev": true,
-                    "requires": {
-                        "@serialport/parser-delimiter": "10.5.0"
-                    }
-                },
-                "@serialport/parser-ready": {
-                    "version": "10.5.0",
-                    "resolved": "https://registry.npmjs.org/@serialport/parser-ready/-/parser-ready-10.5.0.tgz",
-                    "integrity": "sha512-QIf65LTvUoxqWWHBpgYOL+soldLIIyD1bwuWelukem2yDZVWwEjR288cLQ558BgYxH4U+jLAQahhqoyN1I7BaA==",
-                    "dev": true
-                },
-                "@serialport/parser-regex": {
-                    "version": "10.5.0",
-                    "resolved": "https://registry.npmjs.org/@serialport/parser-regex/-/parser-regex-10.5.0.tgz",
-                    "integrity": "sha512-9jnr9+PCxRoLjtGs7uxwsFqvho+rxuJlW6ZWSB7oqfzshEZWXtTJgJRgac/RuLft4hRlrmRz5XU40i3uoL4HKw==",
-                    "dev": true
-                },
-                "@serialport/stream": {
-                    "version": "10.5.0",
-                    "resolved": "https://registry.npmjs.org/@serialport/stream/-/stream-10.5.0.tgz",
-                    "integrity": "sha512-gbcUdvq9Kyv2HsnywS7QjnEB28g+6OGB5Z8TLP7X+UPpoMIWoUsoQIq5Kt0ZTgMoWn3JGM2lqwTsSHF+1qhniA==",
-                    "dev": true,
-                    "requires": {
-                        "@serialport/bindings-interface": "1.2.2",
-                        "debug": "^4.3.2"
-                    }
-                },
                 "@types/semver": {
                     "version": "7.3.10",
                     "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.10.tgz",
@@ -14554,6 +14317,17 @@
                     "resolved": "https://registry.npmjs.org/commander/-/commander-9.4.1.tgz",
                     "integrity": "sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==",
                     "dev": true
+                },
+                "electron": {
+                    "version": "13.6.9",
+                    "resolved": "https://registry.npmjs.org/electron/-/electron-13.6.9.tgz",
+                    "integrity": "sha512-Es/sBy85NIuqsO9MW41PUCpwIkeinlTQ7g0ainfnmRAM2rmog3GBxVCaoV5dzEjwTF7TKG1Yr/E7Z3qHmlfWAg==",
+                    "dev": true,
+                    "requires": {
+                        "@electron/get": "^1.0.1",
+                        "@types/node": "^14.6.2",
+                        "extract-zip": "^1.0.3"
+                    }
                 },
                 "electron-store": {
                     "version": "8.0.2",
@@ -14581,28 +14355,6 @@
                     "dev": true,
                     "requires": {
                         "lru-cache": "^6.0.0"
-                    }
-                },
-                "serialport": {
-                    "version": "10.5.0",
-                    "resolved": "https://registry.npmjs.org/serialport/-/serialport-10.5.0.tgz",
-                    "integrity": "sha512-7OYLDsu5i6bbv3lU81pGy076xe0JwpK6b49G6RjNvGibstUqQkI+I3/X491yBGtf4gaqUdOgoU1/5KZ/XxL4dw==",
-                    "dev": true,
-                    "requires": {
-                        "@serialport/binding-mock": "10.2.2",
-                        "@serialport/bindings-cpp": "10.8.0",
-                        "@serialport/parser-byte-length": "10.5.0",
-                        "@serialport/parser-cctalk": "10.5.0",
-                        "@serialport/parser-delimiter": "10.5.0",
-                        "@serialport/parser-inter-byte-timeout": "10.5.0",
-                        "@serialport/parser-packet-length": "10.5.0",
-                        "@serialport/parser-readline": "10.5.0",
-                        "@serialport/parser-ready": "10.5.0",
-                        "@serialport/parser-regex": "10.5.0",
-                        "@serialport/parser-slip-encoder": "10.5.0",
-                        "@serialport/parser-spacepacket": "10.5.0",
-                        "@serialport/stream": "10.5.0",
-                        "debug": "^4.3.3"
                     }
                 },
                 "type-fest": {
@@ -14726,18 +14478,18 @@
             }
         },
         "playwright": {
-            "version": "1.28.0",
-            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.28.0.tgz",
-            "integrity": "sha512-kyOXGc5y1mgi+hgEcCIyE1P1+JumLrxS09nFHo5sdJNzrucxPRAGwM4A2X3u3SDOfdgJqx61yIoR6Av+5plJPg==",
+            "version": "1.28.1",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.28.1.tgz",
+            "integrity": "sha512-92Sz6XBlfHlb9tK5UCDzIFAuIkHHpemA9zwUaqvo+w7sFMSmVMGmvKcbptof/eJObq63PGnMhM75x7qxhTR78Q==",
             "dev": true,
             "requires": {
-                "playwright-core": "1.28.0"
+                "playwright-core": "1.28.1"
             },
             "dependencies": {
                 "playwright-core": {
-                    "version": "1.28.0",
-                    "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.28.0.tgz",
-                    "integrity": "sha512-nJLknd28kPBiCNTbqpu6Wmkrh63OEqJSFw9xOfL9qxfNwody7h6/L3O2dZoWQ6Oxcm0VOHjWmGiCUGkc0X3VZA==",
+                    "version": "1.28.1",
+                    "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.28.1.tgz",
+                    "integrity": "sha512-3PixLnGPno0E8rSBJjtwqTwJe3Yw72QwBBBxNoukIj3lEeBNXwbNiKrNuB1oyQgTBw5QHUhNO3SteEtHaMK6ag==",
                     "dev": true
                 }
             }
@@ -16970,20 +16722,24 @@
             }
         },
         "serialport": {
-            "version": "8.0.8",
-            "resolved": "https://registry.npmjs.org/serialport/-/serialport-8.0.8.tgz",
-            "integrity": "sha512-GEaMYbAk9chfGyxoVC27PHnKMUMOQOCAg+9umOhAgk88vH0H6DbQ9/Tj3lRwoj7lE+TLra75P/0l1RXMfX4yQg==",
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/serialport/-/serialport-10.5.0.tgz",
+            "integrity": "sha512-7OYLDsu5i6bbv3lU81pGy076xe0JwpK6b49G6RjNvGibstUqQkI+I3/X491yBGtf4gaqUdOgoU1/5KZ/XxL4dw==",
             "requires": {
-                "@serialport/binding-mock": "^8.0.6",
-                "@serialport/bindings": "^8.0.8",
-                "@serialport/parser-byte-length": "^8.0.6",
-                "@serialport/parser-cctalk": "^8.0.6",
-                "@serialport/parser-delimiter": "^8.0.6",
-                "@serialport/parser-readline": "^8.0.6",
-                "@serialport/parser-ready": "^8.0.6",
-                "@serialport/parser-regex": "^8.0.6",
-                "@serialport/stream": "^8.0.6",
-                "debug": "^4.1.1"
+                "@serialport/binding-mock": "10.2.2",
+                "@serialport/bindings-cpp": "10.8.0",
+                "@serialport/parser-byte-length": "10.5.0",
+                "@serialport/parser-cctalk": "10.5.0",
+                "@serialport/parser-delimiter": "10.5.0",
+                "@serialport/parser-inter-byte-timeout": "10.5.0",
+                "@serialport/parser-packet-length": "10.5.0",
+                "@serialport/parser-readline": "10.5.0",
+                "@serialport/parser-ready": "10.5.0",
+                "@serialport/parser-regex": "10.5.0",
+                "@serialport/parser-slip-encoder": "10.5.0",
+                "@serialport/parser-spacepacket": "10.5.0",
+                "@serialport/stream": "10.5.0",
+                "debug": "^4.3.3"
             }
         },
         "set-blocking": {
@@ -20137,11 +19893,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
             "integrity": "sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q=="
-        },
-        "which-pm-runs": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.1.0.tgz",
-            "integrity": "sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA=="
         },
         "which-typed-array": {
             "version": "1.1.9",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
         "electron-builder": "^22.14.13",
         "electron-devtools-installer": "3.2.0",
         "electron-notarize": "0.3.0",
-        "pc-nrfconnect-shared": "git+https://github.com/NordicSemiconductor/pc-nrfconnect-shared.git#v6.12.1",
+        "pc-nrfconnect-shared": "git+https://github.com/NordicSemiconductor/pc-nrfconnect-shared.git#v6.13.1",
         "playwright": "^1.16.3",
         "xvfb-maybe": "0.2.1"
     },

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
         "fs-extra": "9.0.0",
         "lodash.merge": "4.6.2",
         "mustache": "4.0.1",
-        "serialport": "8.0.8",
+        "serialport": "10.4.0",
         "shasum": "1.0.2",
         "short-uuid": "4.2.0",
         "sudo-prompt": "^9.2.1",

--- a/package.json
+++ b/package.json
@@ -115,7 +115,6 @@
         "fs-extra": "9.0.0",
         "lodash.merge": "4.6.2",
         "mustache": "4.0.1",
-        "serialport": "10.4.0",
         "shasum": "1.0.2",
         "short-uuid": "4.2.0",
         "sudo-prompt": "^9.2.1",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
         "electron-builder": "^22.14.13",
         "electron-devtools-installer": "3.2.0",
         "electron-notarize": "0.3.0",
-        "pc-nrfconnect-shared": "git+https://github.com/NordicSemiconductor/pc-nrfconnect-shared.git#v6.12.0",
+        "pc-nrfconnect-shared": "git+https://github.com/NordicSemiconductor/pc-nrfconnect-shared.git#v6.12.1",
         "playwright": "^1.16.3",
         "xvfb-maybe": "0.2.1"
     },

--- a/scripts/esbuild.js
+++ b/scripts/esbuild.js
@@ -9,7 +9,11 @@ require('esbuild')
         bundle: true,
         color: true,
         entryPoints: ['src/main/index.ts'],
-        external: ['electron', /node_modules\/(?!pc-nrfconnect-shared\/)/],
+        external: [
+            'electron',
+            'serialport',
+            /node_modules\/(?!pc-nrfconnect-shared\/)/,
+        ],
         logLevel: 'info',
         outfile: 'dist/main.js',
         platform: 'node',

--- a/scripts/esbuild.js
+++ b/scripts/esbuild.js
@@ -9,7 +9,7 @@ require('esbuild')
         bundle: true,
         color: true,
         entryPoints: ['src/main/index.ts'],
-        external: ['electron', './node_modules/*'],
+        external: ['electron', /node_modules\/(?!pc-nrfconnect-shared\/)/],
         logLevel: 'info',
         outfile: 'dist/main.js',
         platform: 'node',

--- a/src/ipc/README.md
+++ b/src/ipc/README.md
@@ -15,7 +15,7 @@ There are a few conventions we follow with the code here in `src/ipc/`:
     channel (e.g. `checkForUpdate`) and another to register a handler for the
     messages on that same channel (e.g. `registerCheckForUpdate`).
 
-    Usually these two functions utelise a shared signature which is defined in a
+    Usually these two functions utilize a shared signature which is defined in a
     type above them. Usually the functions are defined by invoking functions
     from `infrastructure/mainToRenderer.ts` or
     `infrastructure/rendererToMain.ts` which also use that type.

--- a/src/main/log.ts
+++ b/src/main/log.ts
@@ -14,9 +14,9 @@ const logFormat = format.combine(
     format.timestamp(),
     format.printf(
         ({ timestamp, level, message, ...extra }) =>
-            `${timestamp} ${level.toUpperCase()} ${message} ${JSON.stringify(
-                extra
-            )}`
+            `${timestamp} ${level.toUpperCase()} ${message} ${
+                extra.length > 0 ? JSON.stringify(extra) : ''
+            }`
     )
 );
 

--- a/src/main/serialport.test.ts
+++ b/src/main/serialport.test.ts
@@ -112,27 +112,30 @@ describe('Two renderers', () => {
             openOrAdd(rendererTwo, defaultOptions, false)
         ).resolves.toBeUndefined();
 
-        const [error, didClose] = closeSerialPort(testPortPath, rendererOne);
+        const [error, didClose] = await closeSerialPort(
+            testPortPath,
+            rendererOne
+        );
         expect(error).toBeUndefined();
         expect(didClose).toBe(false);
         // Having closed with one renderer, should still keep port open
         // as long as there are renderers that are subcribed to the port.
         expect(isOpen(testPortPath)).toBe(true);
         // Closing the same serialport several times does nothing...
-        closeSerialPort(testPortPath, rendererOne);
-        closeSerialPort(testPortPath, rendererOne);
+        await closeSerialPort(testPortPath, rendererOne);
+        await closeSerialPort(testPortPath, rendererOne);
         expect(isOpen(testPortPath)).toBe(true);
 
-        expect(closeSerialPort(testPortPath, rendererTwo)).toEqual([
+        expect(await closeSerialPort(testPortPath, rendererTwo)).toEqual([
             undefined,
             true,
         ]);
         // Having closed the port with all renderers, the port should be closed
         expect(isOpen(testPortPath)).toBe(false);
         // Closing the same serialport several times after it is closed, still does nothing...
-        closeSerialPort(testPortPath, rendererTwo); // Returns an error... maybe it should throw?
-        closeSerialPort(testPortPath, rendererTwo);
-        closeSerialPort(testPortPath, rendererTwo);
+        await closeSerialPort(testPortPath, rendererTwo); // Returns an error... maybe it should throw?
+        await closeSerialPort(testPortPath, rendererTwo);
+        await closeSerialPort(testPortPath, rendererTwo);
         expect(isOpen(testPortPath)).toBe(false);
     });
 

--- a/src/main/serialport.test.ts
+++ b/src/main/serialport.test.ts
@@ -1,0 +1,229 @@
+/*
+ * Copyright (c) 2015 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import { MockBinding } from '@serialport/binding-mock';
+import { SerialPortStream as MockSerialPortStream } from '@serialport/stream';
+import { SERIALPORT_CHANNEL } from 'pc-nrfconnect-shared/main';
+
+import {
+    closeSerialPort,
+    getSettings,
+    isOpen,
+    openOrAdd,
+    Renderer,
+    update,
+    writeToSerialport,
+} from './serialport';
+
+const testPortPath = '/dev/ROBOT';
+
+const defaultOptions = { path: testPortPath, baudRate: 115200 };
+
+MockBinding.createPort(testPortPath, { echo: true, record: true });
+
+jest.mock('serialport', () => {
+    const MockSerialPort = new Proxy(MockSerialPortStream, {
+        construct(Target, args) {
+            const [options] = args;
+            return new Target({
+                path: testPortPath,
+                binding: MockBinding,
+                ...options,
+            });
+        },
+    });
+    return {
+        SerialPort: MockSerialPort,
+    };
+});
+
+let rendererId = 0;
+const createMockSender = (): Renderer => ({
+    // eslint-disable-next-line no-plusplus
+    id: rendererId++,
+    on: jest.fn(),
+    send: jest.fn(),
+});
+
+const flushMacroTaskQueue = () =>
+    new Promise(resolve => {
+        setTimeout(resolve);
+    });
+
+describe('Single renderer', () => {
+    let renderer: Renderer;
+
+    beforeEach(() => {
+        renderer = createMockSender();
+    });
+
+    afterEach(() => {
+        closeSerialPort(testPortPath, renderer);
+    });
+
+    test('writes to a port', async () => {
+        await openOrAdd(renderer, defaultOptions, false);
+
+        writeToSerialport(testPortPath, renderer, 'OK');
+        await flushMacroTaskQueue();
+
+        expect(renderer.send).toHaveBeenCalledWith(
+            SERIALPORT_CHANNEL.ON_DATA,
+            Buffer.from('OK')
+        );
+    });
+
+    test('writing to the port before it is open should throw', async () => {
+        const openPromise = openOrAdd(renderer, defaultOptions, false);
+        expect(() => writeToSerialport(testPortPath, renderer, 'Test')).toThrow(
+            'PORT_NOT_OPEN'
+        );
+        // Must wait for the port to actually open, in order to again close it.
+        await openPromise;
+    });
+});
+
+describe('Two renderers', () => {
+    let rendererOne: Renderer;
+    let rendererTwo: Renderer;
+
+    beforeEach(() => {
+        rendererOne = createMockSender();
+        rendererTwo = createMockSender();
+    });
+
+    afterEach(() => {
+        // if (isOpen(testPortPath)) {
+        closeSerialPort(testPortPath, rendererOne);
+        closeSerialPort(testPortPath, rendererTwo);
+        // }
+    });
+
+    test('opening one serialport with two renderers should work', async () => {
+        await expect(
+            openOrAdd(rendererOne, defaultOptions, false)
+        ).resolves.toBeUndefined();
+
+        await expect(
+            openOrAdd(rendererTwo, defaultOptions, false)
+        ).resolves.toBeUndefined();
+
+        const [error, didClose] = closeSerialPort(testPortPath, rendererOne);
+        expect(error).toBeUndefined();
+        expect(didClose).toBe(false);
+        // Having closed with one renderer, should still keep port open
+        // as long as there are renderers that are subcribed to the port.
+        expect(isOpen(testPortPath)).toBe(true);
+        // Closing the same serialport several times does nothing...
+        closeSerialPort(testPortPath, rendererOne);
+        closeSerialPort(testPortPath, rendererOne);
+        expect(isOpen(testPortPath)).toBe(true);
+
+        expect(closeSerialPort(testPortPath, rendererTwo)).toEqual([
+            undefined,
+            true,
+        ]);
+        // Having closed the port with all renderers, the port should be closed
+        expect(isOpen(testPortPath)).toBe(false);
+        // Closing the same serialport several times after it is closed, still does nothing...
+        closeSerialPort(testPortPath, rendererTwo); // Returns an error... maybe it should throw?
+        closeSerialPort(testPortPath, rendererTwo);
+        closeSerialPort(testPortPath, rendererTwo);
+        expect(isOpen(testPortPath)).toBe(false);
+    });
+
+    test('baudRate may be updated whilst port is open, and is renderer-independent', async () => {
+        await expect(
+            openOrAdd(rendererOne, defaultOptions, false)
+        ).resolves.toBeUndefined();
+
+        await expect(
+            openOrAdd(rendererTwo, defaultOptions, false)
+        ).resolves.toBeUndefined();
+
+        const baudRatesToTest = [
+            57600, 38400, 19200, 9600, 4800, 2400, 1800, 1200, 600, 300, 200,
+            150, 134, 110, 75, 50, 115200,
+        ];
+
+        // eslint-disable-next-line no-restricted-syntax
+        for (const rate of baudRatesToTest) {
+            // eslint-disable-next-line no-await-in-loop
+            expect(await update(testPortPath, rate)).toBeUndefined();
+            expect(getSettings(testPortPath)).toBe(rate);
+        }
+    });
+
+    test('opening the same port at the same time should throw', async () => {
+        const promise = openOrAdd(rendererOne, defaultOptions, false);
+        await expect(
+            openOrAdd(rendererTwo, defaultOptions, false)
+        ).rejects.toThrow('PORT_IS_ALREADY_BEING_OPENED');
+
+        // Wait for the first open to finish.
+        await promise;
+    });
+
+    test('with the second renderer providing the overwrite flag decides if the port options should be overwritten', async () => {
+        await expect(
+            openOrAdd(rendererOne, defaultOptions, false)
+        ).resolves.toBeUndefined();
+
+        await expect(
+            openOrAdd(
+                rendererTwo,
+                { path: testPortPath, baudRate: 9600 },
+                false
+            )
+        ).rejects.toThrow('FAILED_DIFFERENT_SETTINGS');
+
+        await expect(
+            openOrAdd(rendererTwo, { path: testPortPath, baudRate: 9600 }, true)
+        ).resolves.toBeUndefined();
+    });
+});
+
+describe('Two renderers with one serialport open:', () => {
+    let rendererOne: Renderer;
+    let rendererTwo: Renderer;
+
+    beforeEach(async () => {
+        rendererOne = createMockSender();
+        rendererTwo = createMockSender();
+        await openOrAdd(rendererOne, defaultOptions, false);
+        await openOrAdd(rendererTwo, defaultOptions, false);
+    });
+
+    afterEach(() => {
+        // if (isOpen(testPortPath)) {
+        closeSerialPort(testPortPath, rendererOne);
+        closeSerialPort(testPortPath, rendererTwo);
+        // }
+    });
+
+    test('write from renderer A will also notify renderer B', async () => {
+        const terminalData = 'TestData';
+        writeToSerialport(testPortPath, rendererOne, terminalData);
+
+        await flushMacroTaskQueue();
+
+        expect(rendererTwo.send).toBeCalled();
+        expect(rendererTwo.send).toHaveBeenCalledWith(
+            'serialport:on-write',
+            terminalData
+        );
+    });
+});
+
+// Single renderer writes to a port
+// Single renderer disconnects by user
+// Single renderer disconnects by device
+// Single renderer destroyed
+
+// Multiple renderers open a port
+// Multiple renderers, one disconnects, other renderer still reads
+// Multiple renderers disconnects by device
+// Multiple renderers, one renderer is destroyed

--- a/src/main/serialport.test.ts
+++ b/src/main/serialport.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { MockBinding } from '@serialport/binding-mock';
+import { UpdateOptions } from '@serialport/bindings-cpp';
 import { SerialPortStream as MockSerialPortStream } from '@serialport/stream';
 import { SERIALPORT_CHANNEL } from 'pc-nrfconnect-shared/main';
 
@@ -151,8 +152,10 @@ describe('Two renderers', () => {
 
         // eslint-disable-next-line no-restricted-syntax
         for (const rate of baudRatesToTest) {
-            // eslint-disable-next-line no-await-in-loop
-            expect(await update(testPortPath, rate)).toBeUndefined();
+            expect(
+                // eslint-disable-next-line no-await-in-loop
+                await update(testPortPath, { baudRate: rate } as UpdateOptions)
+            ).toBeUndefined();
             expect(getSettings(testPortPath)).toBe(rate);
         }
     });

--- a/src/main/serialport.test.ts
+++ b/src/main/serialport.test.ts
@@ -23,7 +23,7 @@ import {
 
 const testPortPath = '/dev/ROBOT';
 
-const defaultOptions = { path: testPortPath, baudRate: 115200 };
+const defaultOptions = { path: testPortPath, baudRate: 115200, xany: true };
 const defaultOverwriteOptions: OverwriteOptions = {
     overwrite: false,
     settingsLocked: false,
@@ -188,6 +188,15 @@ describe('Two renderers', () => {
             )
         ).rejects.toThrow('FAILED_DIFFERENT_SETTINGS');
 
+        // remove property (xon) is also different
+        await expect(
+            openOrAdd(
+                rendererTwo,
+                { path: testPortPath, baudRate: 115200 },
+                defaultOverwriteOptions
+            )
+        ).rejects.toThrow('FAILED_DIFFERENT_SETTINGS');
+
         await expect(
             openOrAdd(
                 rendererTwo,
@@ -206,7 +215,7 @@ describe('Two renderers', () => {
         await expect(
             openOrAdd(
                 rendererTwo,
-                { ...defaultOptions, stopBits: 2, parity: 'odd' },
+                { ...defaultOptions, stopBits: 2 },
                 defaultOverwriteOptions
             )
         ).rejects.toThrow('FAILED_SETTINGS_LOCKED');

--- a/src/main/serialport.ts
+++ b/src/main/serialport.ts
@@ -4,7 +4,11 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-import type { AutoDetectTypes, SetOptions } from '@serialport/bindings-cpp';
+import type {
+    AutoDetectTypes,
+    SetOptions,
+    UpdateOptions,
+} from '@serialport/bindings-cpp';
 import { Renderer, WebContents } from 'electron';
 import { SERIALPORT_CHANNEL } from 'pc-nrfconnect-shared/main';
 import { SerialPort, SerialPortOpenOptions } from 'serialport';
@@ -220,9 +224,8 @@ const removeRenderer = (path: string, sender: Renderer): boolean => {
     return closedPort;
 };
 
-export const update = (path: string, baudRate: number) => {
+export const update = (path: string, options: UpdateOptions) => {
     const openPort = serialPorts.get(path);
-
     if (!openPort) {
         logger.error(
             `SerialPort: Port with path=${path} could not update options, because port was not found.`
@@ -231,9 +234,8 @@ export const update = (path: string, baudRate: number) => {
     }
 
     const { serialPort, renderers } = openPort;
-
     return new Promise<void>((resolve, reject) => {
-        serialPort.update({ baudRate }, error => {
+        serialPort.update(options, error => {
             if (error) {
                 logger.error(
                     `SerialPort: Port with path=${path} could not update options: ${error.message}`
@@ -247,7 +249,9 @@ export const update = (path: string, baudRate: number) => {
                     );
                 });
                 logger.info(
-                    `SerialPort: Port with path=${path} updated settings: baudRate=${baudRate}`
+                    `SerialPort: Port with path=${path} updated settings: ${JSON.stringify(
+                        options
+                    )}`
                 );
                 resolve();
             }
@@ -269,7 +273,9 @@ export const set = (path: string, newOptions: SetOptions) => {
 
     serialPort.set(newOptions);
     logger.info(
-        `SerialPort: Port with path=${path} was set with new settings: ${newOptions}`
+        `SerialPort: Port with path=${path} was set with new settings: ${JSON.stringify(
+            newOptions
+        )}`
     );
 
     renderers.forEach(renderer => {

--- a/src/main/serialport.ts
+++ b/src/main/serialport.ts
@@ -23,6 +23,7 @@ type OpenPort = {
     renderers: Renderer[];
     settingsLocked: boolean;
     opening: boolean;
+    options: SerialPortOpenOptions<AutoDetectTypes>;
 };
 export const serialPorts = initPlatformSpecificMap<string, OpenPort>();
 
@@ -52,18 +53,26 @@ export const openOrAdd = async (
         if (!alreadyInList) {
             let isDifferentSettings;
             if (existingPort.serialPort) {
-                const currentOptions = existingPort.serialPort.settings;
-                Object.entries(options).every(([key, value]) => {
-                    if (
-                        !(key in currentOptions) ||
-                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                        (currentOptions as any)[key] !== value
-                    ) {
-                        isDifferentSettings = true;
-                        return false;
-                    }
-                    return true;
-                });
+                const currentOptions = existingPort.options;
+
+                if (
+                    Object.keys(currentOptions).length ===
+                    Object.keys(options).length
+                ) {
+                    Object.entries(options).every(([key, value]) => {
+                        if (
+                            !(key in currentOptions) ||
+                            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                            (currentOptions as any)[key] !== value
+                        ) {
+                            isDifferentSettings = true;
+                            return false;
+                        }
+                        return true;
+                    });
+                } else {
+                    isDifferentSettings = true;
+                }
             }
 
             if (isDifferentSettings) {
@@ -314,6 +323,7 @@ const openNewSerialPort = async (
         renderers: openPort?.renderers ?? [],
         settingsLocked,
         opening: true,
+        options,
     };
     serialPorts.set(path, newOpenPort);
 

--- a/src/main/serialport.ts
+++ b/src/main/serialport.ts
@@ -1,0 +1,348 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import type { AutoDetectTypes, SetOptions } from '@serialport/bindings-cpp';
+import { Renderer, WebContents } from 'electron';
+import { SERIALPORT_CHANNEL } from 'pc-nrfconnect-shared/main';
+import { SerialPort, SerialPortOpenOptions } from 'serialport';
+
+export type Renderer = Pick<WebContents, 'on' | 'send' | 'id'>;
+
+/**
+ *  serialPorts: {
+
+        '/dev/Robot': {
+            renderers: Renderer[],
+            serialPort: SerialPort,
+        },
+
+        '/dev/Rowboat': {
+            renderers: Renderer[],
+            serialPort: SerialPort,
+        }
+    }
+*/
+type OpenPort = {
+    serialPort: SerialPort;
+    renderers: Renderer[];
+    settingsLocked: boolean;
+    opening: boolean;
+};
+
+const serialPorts = new Map<string, OpenPort>();
+
+export const openOrAdd = async (
+    sender: Renderer,
+    options: SerialPortOpenOptions<AutoDetectTypes>,
+    overwrite: boolean
+) => {
+    const { path } = options;
+    const existingPort = serialPorts.get(path);
+
+    if (existingPort) {
+        // Port is already opened
+
+        if (existingPort.opening) {
+            throw new Error('PORT_IS_ALREADY_BEING_OPENED');
+        }
+
+        const renderers = existingPort.renderers;
+        const alreadyInList = renderers.find(
+            existing => sender.id === existing.id
+        );
+
+        if (!alreadyInList) {
+            let isDifferentSettings;
+            if (existingPort.serialPort) {
+                const currentOptions = existingPort.serialPort.settings;
+                Object.entries(options).forEach(([key, value]) => {
+                    if (
+                        !(key in currentOptions) ||
+                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                        (currentOptions as any)[key] !== value
+                    ) {
+                        isDifferentSettings = true;
+                    }
+                });
+            }
+
+            if (isDifferentSettings) {
+                if (!overwrite) {
+                    throw new Error('FAILED_DIFFERENT_SETTINGS');
+                }
+
+                const result = await changeOptions(options);
+                if (result === 'SUCCESS') {
+                    existingPort.renderers.forEach(renderer => {
+                        renderer.send(SERIALPORT_CHANNEL.ON_CHANGED, options);
+                    });
+                    renderers.push(sender);
+                    sender.on('destroyed', () => {
+                        console.log('Window Closed!');
+                        removeRenderer(path, sender);
+                    });
+                    return;
+                }
+                throw new Error('FAILED');
+            }
+            renderers.push(sender);
+            sender.on('destroyed', () => {
+                console.log('Window Closed!');
+                removeRenderer(path, sender);
+            });
+        }
+        return;
+    }
+
+    let port: SerialPort<AutoDetectTypes>;
+    try {
+        port = new SerialPort({ ...options, autoOpen: false });
+    } catch (error) {
+        throw new Error('FAILED');
+    }
+    const openPort: OpenPort = {
+        serialPort: port,
+        renderers: [sender],
+        settingsLocked: false,
+        opening: true,
+    };
+    serialPorts.set(path, openPort);
+
+    // Remove renderer if renderer process is destroyed (window is closed).
+    sender.on('destroyed', () => removeRenderer(path, sender));
+    // Remove renderer if renderer window is reloaded
+    sender.on('did-finish-load', () => {
+        removeRenderer(path, sender);
+    });
+
+    port.on('data', data => {
+        onData(path, data);
+    });
+
+    port.on('close', (error: Error) => {
+        // Device powers off, or is closed manually: do a clean up
+        if (error) {
+            if (openPort) {
+                openPort.renderers.forEach(renderer => {
+                    renderer.send(SERIALPORT_CHANNEL.ON_CLOSED);
+                });
+
+                serialPorts.delete(path);
+            }
+        }
+    });
+
+    return new Promise<void>((resolve, reject) => {
+        port.open(err => {
+            if (err) {
+                reject(new Error('FAILED'));
+            }
+            openPort.opening = false;
+            resolve();
+        });
+    });
+};
+
+export const writeToSerialport = (
+    path: string,
+    sender: Renderer,
+    data: string | number[] | Buffer
+) => {
+    const openPort = serialPorts.get(path);
+    if (!openPort) {
+        throw new Error('PORT_NOT_FOUND');
+    }
+
+    if (!openPort.serialPort.isOpen) {
+        throw new Error('PORT_NOT_OPEN');
+    }
+
+    return new Promise<void>((resolve, reject) => {
+        openPort.serialPort.write(data, error => {
+            if (error) {
+                reject(error);
+            }
+
+            openPort.renderers
+                .filter(renderer => renderer.id !== sender.id)
+                .forEach(renderer =>
+                    renderer.send('serialport:on-write', data)
+                );
+            resolve();
+        });
+    });
+};
+
+const onData = (path: string, chunk: unknown) => {
+    const openPort = serialPorts.get(path);
+    if (openPort) {
+        openPort.renderers.forEach(renderer =>
+            renderer.send(SERIALPORT_CHANNEL.ON_DATA, chunk)
+        );
+    }
+};
+
+export const isOpen = (path: string): boolean => {
+    const port = serialPorts.get(path)?.serialPort;
+    if (!port) {
+        return false;
+    }
+
+    return port.isOpen;
+};
+
+/* Return true if port is closed, false otherwise */
+export const closeSerialPort = (
+    path: string,
+    sender: Renderer
+): [Error | undefined, boolean] => {
+    const port = serialPorts.get(path)?.serialPort;
+    let portWasClosed = false;
+    if (!port) {
+        return [
+            Error(
+                `Could not find SerialPort with path ${path}, and could not be closed.`
+            ),
+            portWasClosed,
+        ];
+    }
+
+    const renderers = serialPorts.get(path)?.renderers;
+    if (renderers) {
+        // FIXME: Issue is I can't get the potential Error from port.close().
+        // removeRenderer will close the port and return true if list of renderers is empty after removing sender.
+        portWasClosed = removeRenderer(path, sender);
+    }
+    return [undefined, portWasClosed];
+};
+
+const removeRenderer = (path: string, sender: Renderer): boolean => {
+    let closedPort = false;
+    const openPort = serialPorts.get(path);
+    if (openPort) {
+        openPort.renderers = openPort.renderers.filter(
+            renderer => renderer.id !== sender.id
+        );
+
+        if (openPort.renderers.length === 0) {
+            if (openPort.serialPort.isOpen) {
+                openPort.serialPort.close();
+                serialPorts.delete(path);
+                closedPort = true;
+            }
+        } else {
+            serialPorts.set(path, openPort);
+        }
+    }
+    return closedPort;
+};
+
+export const update = (path: string, baudRate: number) => {
+    const openPort = serialPorts.get(path);
+
+    if (!openPort) {
+        return;
+    }
+
+    const { serialPort, renderers } = openPort;
+
+    return new Promise<void>((resolve, reject) => {
+        serialPort.update({ baudRate }, error => {
+            if (error) {
+                reject(error);
+            }
+            renderers.forEach(renderer => {
+                renderer.send(
+                    SERIALPORT_CHANNEL.ON_UPDATE,
+                    serialPort.settings
+                );
+            });
+            resolve();
+        });
+    });
+};
+
+export const set = (path: string, newOptions: SetOptions) => {
+    const openPort = serialPorts.get(path);
+
+    if (!openPort) {
+        return;
+    }
+
+    const { serialPort, renderers } = openPort;
+
+    serialPort.set(newOptions);
+
+    renderers.forEach(renderer => {
+        // TODO: Review if we actually want to send newOptions?
+        // You also have a get() function, but it's only a subset of SetOptions, called PortStatus
+        renderer.send(SERIALPORT_CHANNEL.ON_SET, newOptions);
+    });
+};
+
+const openNewSerialPort = (options: SerialPortOpenOptions<AutoDetectTypes>) => {
+    const { path } = options;
+    const openPort = serialPorts.get(path);
+    if (openPort && openPort.serialPort.isOpen) {
+        openPort.serialPort.close();
+    }
+    const newOpenPort = {
+        ...openPort,
+        serialPort: new SerialPort({ ...options, path, autoOpen: false }),
+    } as OpenPort;
+    serialPorts.set(path, newOpenPort);
+
+    const { serialPort: port } = newOpenPort;
+
+    port.on('data', data => {
+        onData(path, data);
+    });
+
+    port.on('close', (error: Error) => {
+        // Device powers off, or is closed manually: do a clean up
+        if (error) {
+            const refreshedOpenPort = serialPorts.get(path);
+            if (refreshedOpenPort) {
+                refreshedOpenPort.renderers.forEach(renderer => {
+                    renderer.send(SERIALPORT_CHANNEL.ON_CLOSED);
+                });
+
+                serialPorts.delete(path);
+            }
+        }
+    });
+    return new Promise((resolve, reject) => {
+        newOpenPort.serialPort.open(err => {
+            if (err) {
+                reject(Error('FAILED'));
+            }
+            resolve('SUCCESS');
+        });
+    });
+};
+
+export const changeOptions = async (
+    options: SerialPortOpenOptions<AutoDetectTypes>
+) => {
+    const openPort = serialPorts.get(options.path);
+    if (!openPort) {
+        return 'FAILED';
+    }
+
+    const result = await openNewSerialPort(options);
+    if (result !== 'SUCCESS') {
+        return 'FAILED';
+    }
+    return result;
+};
+
+export const getSettings = (path: string): number | void => {
+    const openPort = serialPorts.get(path);
+    if (!openPort) {
+        return;
+    }
+    return openPort.serialPort.baudRate;
+};

--- a/src/main/serialport.ts
+++ b/src/main/serialport.ts
@@ -355,6 +355,10 @@ const openNewSerialPort = async (
                 logger.error(
                     `SerialPort: Port with path=${path} could not be opened: ${err.message}`
                 );
+                newOpenPort.renderers.forEach(renderer => {
+                    renderer.send(SERIALPORT_CHANNEL.ON_CLOSED);
+                });
+                serialPorts.delete(path);
                 reject(Error('FAILED'));
             } else {
                 newOpenPort.opening = false;

--- a/src/main/serialport.ts
+++ b/src/main/serialport.ts
@@ -121,17 +121,15 @@ export const writeToSerialport = (
         throw new Error('PORT_NOT_OPEN');
     }
 
+    openPort.renderers
+        .filter(renderer => renderer.id !== sender.id)
+        .forEach(renderer => renderer.send('serialport:on-write', data));
+
     return new Promise<void>((resolve, reject) => {
         openPort.serialPort.write(data, error => {
             if (error) {
                 reject(error);
             }
-
-            openPort.renderers
-                .filter(renderer => renderer.id !== sender.id)
-                .forEach(renderer =>
-                    renderer.send('serialport:on-write', data)
-                );
             resolve();
         });
     });

--- a/src/main/serialport.ts
+++ b/src/main/serialport.ts
@@ -286,14 +286,24 @@ export const set = (path: string, newOptions: SetOptions) => {
     });
 };
 
-const openNewSerialPort = (options: SerialPortOpenOptions<AutoDetectTypes>) => {
+const openNewSerialPort = async (
+    options: SerialPortOpenOptions<AutoDetectTypes>
+) => {
     const { path } = options;
     const openPort = serialPorts.get(path);
     if (openPort && openPort.serialPort.isOpen) {
         logger.info(
             `SerialPort: Port with path=${path} is already open, but will be reopened.`
         );
-        openPort.serialPort.close();
+        await new Promise<void>((resolve, reject) => {
+            openPort.serialPort.close(error => {
+                if (error) {
+                    reject(error);
+                } else {
+                    resolve();
+                }
+            });
+        });
     }
 
     const newOpenPort: OpenPort = {

--- a/src/main/serialport.ts
+++ b/src/main/serialport.ts
@@ -56,9 +56,8 @@ export const openOrAdd = async (
             throw new Error('PORT_IS_ALREADY_BEING_OPENED');
         }
 
-        const renderers = existingPort.renderers;
-        const alreadyInList = renderers.find(
-            existing => sender.id === existing.id
+        const alreadyInList = existingPort.renderers.some(
+            renderer => renderer.id === sender.id
         );
 
         if (!alreadyInList) {
@@ -97,7 +96,7 @@ export const openOrAdd = async (
                     renderer.send(SERIALPORT_CHANNEL.ON_CHANGED, options);
                 });
             }
-            renderers.push(sender);
+            existingPort.renderers.push(sender);
             addSenderEvents(path, sender);
             logger.info(
                 `SerialPort: Port with path=${path} added renderer with id=${sender.id} to its list of renderers.`

--- a/src/main/serialport.ts
+++ b/src/main/serialport.ts
@@ -121,9 +121,9 @@ export const writeToSerialport = (
         throw new Error('PORT_NOT_OPEN');
     }
 
-    openPort.renderers
-        .filter(renderer => renderer.id !== sender.id)
-        .forEach(renderer => renderer.send('serialport:on-write', data));
+    openPort.renderers.forEach(renderer =>
+        renderer.send('serialport:on-write', data)
+    );
 
     return new Promise<void>((resolve, reject) => {
         openPort.serialPort.write(data, error => {

--- a/src/main/serialport.ts
+++ b/src/main/serialport.ts
@@ -294,9 +294,6 @@ export const changeOptions = async (
     }
 
     const result = await openNewSerialPort(options);
-    if (result !== 'SUCCESS') {
-        return 'FAILED';
-    }
     return result;
 };
 

--- a/src/main/serialport.ts
+++ b/src/main/serialport.ts
@@ -65,14 +65,16 @@ export const openOrAdd = async (
             let isDifferentSettings;
             if (existingPort.serialPort) {
                 const currentOptions = existingPort.serialPort.settings;
-                Object.entries(options).forEach(([key, value]) => {
+                Object.entries(options).every(([key, value]) => {
                     if (
                         !(key in currentOptions) ||
                         // eslint-disable-next-line @typescript-eslint/no-explicit-any
                         (currentOptions as any)[key] !== value
                     ) {
                         isDifferentSettings = true;
+                        return false;
                     }
+                    return true;
                 });
             }
 

--- a/src/main/serialport.ts
+++ b/src/main/serialport.ts
@@ -14,31 +14,17 @@ import { SERIALPORT_CHANNEL } from 'pc-nrfconnect-shared/main';
 import { SerialPort, SerialPortOpenOptions } from 'serialport';
 
 import { logger } from './log';
+import { initPlatformSpecificMap } from './utils/map';
 
 export type Renderer = Pick<WebContents, 'on' | 'send' | 'id'>;
 
-/**
- *  serialPorts: {
-
-        '/dev/Robot': {
-            renderers: Renderer[],
-            serialPort: SerialPort,
-        },
-
-        '/dev/Rowboat': {
-            renderers: Renderer[],
-            serialPort: SerialPort,
-        }
-    }
-*/
 type OpenPort = {
     serialPort: SerialPort;
     renderers: Renderer[];
     settingsLocked: boolean;
     opening: boolean;
 };
-
-const serialPorts = new Map<string, OpenPort>();
+const serialPorts = initPlatformSpecificMap<string, OpenPort>();
 
 export const openOrAdd = async (
     sender: Renderer,
@@ -47,7 +33,6 @@ export const openOrAdd = async (
 ) => {
     const { path } = options;
     const existingPort = serialPorts.get(path);
-
     if (existingPort) {
         if (existingPort.opening) {
             logger.warn(

--- a/src/main/utils/map.ts
+++ b/src/main/utils/map.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+class CaseInsensitiveMap<T, U> extends Map<T, U> {
+    set(key: T, value: U): this {
+        if (typeof key === 'string') {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            key = key.toLowerCase() as any as T;
+        }
+        return super.set(key, value);
+    }
+
+    get(key: T): U | undefined {
+        if (typeof key === 'string') {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            key = key.toLowerCase() as any as T;
+        }
+        return super.get(key);
+    }
+
+    has(key: T): boolean {
+        if (typeof key === 'string') {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            key = key.toLowerCase() as any as T;
+        }
+        return super.has(key);
+    }
+}
+
+type PlatformSpecificMap<T, U> = CaseInsensitiveMap<T, U> | Map<T, U>;
+
+export const initPlatformSpecificMap = <T, U>(): PlatformSpecificMap<T, U> => {
+    if (process.platform === 'win32') {
+        return new CaseInsensitiveMap<T, U>();
+    }
+    return new Map<T, U>();
+};

--- a/src/main/utils/map.ts
+++ b/src/main/utils/map.ts
@@ -28,6 +28,14 @@ class CaseInsensitiveMap<T, U> extends Map<T, U> {
         }
         return super.has(key);
     }
+
+    delete(key: T): boolean {
+        if (typeof key === 'string') {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            key = key.toLowerCase() as any as T;
+        }
+        return super.delete(key);
+    }
 }
 
 type PlatformSpecificMap<T, U> = CaseInsensitiveMap<T, U> | Map<T, U>;

--- a/src/test/setupMocks.js
+++ b/src/test/setupMocks.js
@@ -13,4 +13,7 @@ jest.mock('electron', () => ({
                   }
                 : 'Unknown channel used in tests',
     },
+    app: {
+        on: jest.fn(),
+    },
 }));

--- a/src/test/setupMocks.js
+++ b/src/test/setupMocks.js
@@ -17,3 +17,11 @@ jest.mock('electron', () => ({
         on: jest.fn(),
     },
 }));
+
+jest.mock('./../main/log.ts', () => ({
+    logger: {
+        error: jest.fn(),
+        warn: jest.fn(),
+        info: jest.fn(),
+    },
+}));


### PR DESCRIPTION
# Notable changes

- Updated serialport from `serialport.io` from v8 to v10
- Implemented `serialport.ts` which keeps track of serialports and subscribing renderer processes
- Implemented IPC communication between main process and renderer processes in order for the renderer process to ask for serialport communication through the main process. Implementation of a SerialPort wrapper may be found in https://github.com/NordicSemiconductor/pc-nrfconnect-shared/pull/429

edit: changed https://github.com/NordicSemiconductor/pc-nrfconnect-shared/pull/423 -> new PR https://github.com/NordicSemiconductor/pc-nrfconnect-shared/pull/429

