### PR TITLE
Add serialport dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2095,6 +2095,13 @@
                 "prebuild": "^11.0.0",
                 "prebuild-install": "^7.0.1",
                 "sander": "^0.6.0"
+            },
+            "dependencies": {
+                "node-addon-api": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.0.2.tgz",
+                    "integrity": "sha512-+D4s2HCnxPd5PjjI0STKwncjXTUKKqm74MDMz9OPXavjsGmjkvwgLtA5yoxJUdmpj52+2u+RrXgPipahKczMKg=="
+                }
             }
         },
         "@npmcli/fs": {
@@ -2264,7 +2271,6 @@
             "version": "10.2.2",
             "resolved": "https://registry.npmjs.org/@serialport/binding-mock/-/binding-mock-10.2.2.tgz",
             "integrity": "sha512-HAFzGhk9OuFMpuor7aT5G1ChPgn5qSsklTFOTUX72Rl6p0xwcSVsRtG/xaGp6bxpN7fI9D/S8THLBWbBgS6ldw==",
-            "dev": true,
             "requires": {
                 "@serialport/bindings-interface": "^1.2.1",
                 "debug": "^4.3.3"
@@ -2274,64 +2280,48 @@
             "version": "10.8.0",
             "resolved": "https://registry.npmjs.org/@serialport/bindings-cpp/-/bindings-cpp-10.8.0.tgz",
             "integrity": "sha512-OMQNJz5kJblbmZN5UgJXLwi2XNtVLxSKmq5VyWuXQVsUIJD4l9UGHnLPqM5LD9u3HPZgDI5w7iYN7gxkQNZJUw==",
-            "dev": true,
             "requires": {
                 "@serialport/bindings-interface": "1.2.2",
                 "@serialport/parser-readline": "^10.2.1",
                 "debug": "^4.3.2",
                 "node-addon-api": "^5.0.0",
                 "node-gyp-build": "^4.3.0"
-            },
-            "dependencies": {
-                "node-addon-api": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.0.0.tgz",
-                    "integrity": "sha512-CvkDw2OEnme7ybCykJpVcKH+uAOLV2qLqiyla128dN9TkEWfrYmxG6C2boDe5KcNQqZF3orkqzGgOMvZ/JNekA==",
-                    "dev": true
-                }
             }
         },
         "@serialport/bindings-interface": {
             "version": "1.2.2",
             "resolved": "https://registry.npmjs.org/@serialport/bindings-interface/-/bindings-interface-1.2.2.tgz",
-            "integrity": "sha512-CJaUd5bLvtM9c5dmO9rPBHPXTa9R2UwpkJ0wdh9JCYcbrPWsKz+ErvR0hBLeo7NPeiFdjFO4sonRljiw4d2XiA==",
-            "dev": true
+            "integrity": "sha512-CJaUd5bLvtM9c5dmO9rPBHPXTa9R2UwpkJ0wdh9JCYcbrPWsKz+ErvR0hBLeo7NPeiFdjFO4sonRljiw4d2XiA=="
         },
         "@serialport/parser-byte-length": {
             "version": "10.5.0",
             "resolved": "https://registry.npmjs.org/@serialport/parser-byte-length/-/parser-byte-length-10.5.0.tgz",
-            "integrity": "sha512-eHhr4lHKboq1OagyaXAqkemQ1XyoqbLQC8XJbvccm95o476TmEdW5d7AElwZV28kWprPW68ZXdGF2VXCkJgS2w==",
-            "dev": true
+            "integrity": "sha512-eHhr4lHKboq1OagyaXAqkemQ1XyoqbLQC8XJbvccm95o476TmEdW5d7AElwZV28kWprPW68ZXdGF2VXCkJgS2w=="
         },
         "@serialport/parser-cctalk": {
             "version": "10.5.0",
             "resolved": "https://registry.npmjs.org/@serialport/parser-cctalk/-/parser-cctalk-10.5.0.tgz",
-            "integrity": "sha512-Iwsdr03xmCKAiibLSr7b3w6ZUTBNiS+PwbDQXdKU/clutXjuoex83XvsOtYVcNZmwJlVNhAUbkG+FJzWwIa4DA==",
-            "dev": true
+            "integrity": "sha512-Iwsdr03xmCKAiibLSr7b3w6ZUTBNiS+PwbDQXdKU/clutXjuoex83XvsOtYVcNZmwJlVNhAUbkG+FJzWwIa4DA=="
         },
         "@serialport/parser-delimiter": {
             "version": "10.5.0",
             "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-10.5.0.tgz",
-            "integrity": "sha512-/uR/yT3jmrcwnl2FJU/2ySvwgo5+XpksDUR4NF/nwTS5i3CcuKS+FKi/tLzy1k8F+rCx5JzpiK+koqPqOUWArA==",
-            "dev": true
+            "integrity": "sha512-/uR/yT3jmrcwnl2FJU/2ySvwgo5+XpksDUR4NF/nwTS5i3CcuKS+FKi/tLzy1k8F+rCx5JzpiK+koqPqOUWArA=="
         },
         "@serialport/parser-inter-byte-timeout": {
             "version": "10.5.0",
             "resolved": "https://registry.npmjs.org/@serialport/parser-inter-byte-timeout/-/parser-inter-byte-timeout-10.5.0.tgz",
-            "integrity": "sha512-WPvVlSx98HmmUF9jjK6y9mMp3Wnv6JQA0cUxLeZBgS74TibOuYG3fuUxUWGJALgAXotOYMxfXSezJ/vSnQrkhQ==",
-            "dev": true
+            "integrity": "sha512-WPvVlSx98HmmUF9jjK6y9mMp3Wnv6JQA0cUxLeZBgS74TibOuYG3fuUxUWGJALgAXotOYMxfXSezJ/vSnQrkhQ=="
         },
         "@serialport/parser-packet-length": {
             "version": "10.5.0",
             "resolved": "https://registry.npmjs.org/@serialport/parser-packet-length/-/parser-packet-length-10.5.0.tgz",
-            "integrity": "sha512-jkpC/8w4/gUBRa2Teyn7URv1D7T//0lGj27/4u9AojpDVXsR6dtdcTG7b7dNirXDlOrSLvvN7aS5/GNaRlEByw==",
-            "dev": true
+            "integrity": "sha512-jkpC/8w4/gUBRa2Teyn7URv1D7T//0lGj27/4u9AojpDVXsR6dtdcTG7b7dNirXDlOrSLvvN7aS5/GNaRlEByw=="
         },
         "@serialport/parser-readline": {
             "version": "10.5.0",
             "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-10.5.0.tgz",
             "integrity": "sha512-0aXJknodcl94W9zSjvU+sLdXiyEG2rqjQmvBWZCr8wJZjWEtv3RgrnYiWq4i2OTOyC8C/oPK8ZjpBjQptRsoJQ==",
-            "dev": true,
             "requires": {
                 "@serialport/parser-delimiter": "10.5.0"
             }
@@ -2339,32 +2329,27 @@
         "@serialport/parser-ready": {
             "version": "10.5.0",
             "resolved": "https://registry.npmjs.org/@serialport/parser-ready/-/parser-ready-10.5.0.tgz",
-            "integrity": "sha512-QIf65LTvUoxqWWHBpgYOL+soldLIIyD1bwuWelukem2yDZVWwEjR288cLQ558BgYxH4U+jLAQahhqoyN1I7BaA==",
-            "dev": true
+            "integrity": "sha512-QIf65LTvUoxqWWHBpgYOL+soldLIIyD1bwuWelukem2yDZVWwEjR288cLQ558BgYxH4U+jLAQahhqoyN1I7BaA=="
         },
         "@serialport/parser-regex": {
             "version": "10.5.0",
             "resolved": "https://registry.npmjs.org/@serialport/parser-regex/-/parser-regex-10.5.0.tgz",
-            "integrity": "sha512-9jnr9+PCxRoLjtGs7uxwsFqvho+rxuJlW6ZWSB7oqfzshEZWXtTJgJRgac/RuLft4hRlrmRz5XU40i3uoL4HKw==",
-            "dev": true
+            "integrity": "sha512-9jnr9+PCxRoLjtGs7uxwsFqvho+rxuJlW6ZWSB7oqfzshEZWXtTJgJRgac/RuLft4hRlrmRz5XU40i3uoL4HKw=="
         },
         "@serialport/parser-slip-encoder": {
             "version": "10.5.0",
             "resolved": "https://registry.npmjs.org/@serialport/parser-slip-encoder/-/parser-slip-encoder-10.5.0.tgz",
-            "integrity": "sha512-wP8m+uXQdkWSa//3n+VvfjLthlabwd9NiG6kegf0fYweLWio8j4pJRL7t9eTh2Lbc7zdxuO0r8ducFzO0m8CQw==",
-            "dev": true
+            "integrity": "sha512-wP8m+uXQdkWSa//3n+VvfjLthlabwd9NiG6kegf0fYweLWio8j4pJRL7t9eTh2Lbc7zdxuO0r8ducFzO0m8CQw=="
         },
         "@serialport/parser-spacepacket": {
             "version": "10.5.0",
             "resolved": "https://registry.npmjs.org/@serialport/parser-spacepacket/-/parser-spacepacket-10.5.0.tgz",
-            "integrity": "sha512-BEZ/HAEMwOd8xfuJSeI/823IR/jtnThovh7ils90rXD4DPL1ZmrP4abAIEktwe42RobZjIPfA4PaVfyO0Fjfhg==",
-            "dev": true
+            "integrity": "sha512-BEZ/HAEMwOd8xfuJSeI/823IR/jtnThovh7ils90rXD4DPL1ZmrP4abAIEktwe42RobZjIPfA4PaVfyO0Fjfhg=="
         },
         "@serialport/stream": {
             "version": "10.5.0",
             "resolved": "https://registry.npmjs.org/@serialport/stream/-/stream-10.5.0.tgz",
             "integrity": "sha512-gbcUdvq9Kyv2HsnywS7QjnEB28g+6OGB5Z8TLP7X+UPpoMIWoUsoQIq5Kt0ZTgMoWn3JGM2lqwTsSHF+1qhniA==",
-            "dev": true,
             "requires": {
                 "@serialport/bindings-interface": "1.2.2",
                 "debug": "^4.3.2"
@@ -3511,9 +3496,9 @@
             }
         },
         "@types/yargs": {
-            "version": "17.0.15",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.15.tgz",
-            "integrity": "sha512-ZHc4W2dnEQPfhn06TBEdWaiUHEZAocYaiVMfwOipY5jcJt/251wVrKCBWBetGZWO5CF8tdb7L3DmdxVlZ2BOIg==",
+            "version": "17.0.17",
+            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
+            "integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
             "dev": true,
             "requires": {
                 "@types/yargs-parser": "*"
@@ -5514,17 +5499,28 @@
                     }
                 },
                 "tar": {
-                    "version": "6.1.12",
-                    "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.12.tgz",
-                    "integrity": "sha512-jU4TdemS31uABHd+Lt5WEYJuzn+TJTCBLljvIAHZOz6M9Os5pJ4dD+vRFLxPa/n3T0iEFzpi+0x1UfuDZYbRMw==",
+                    "version": "6.1.13",
+                    "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.13.tgz",
+                    "integrity": "sha512-jdIBIN6LTIe2jqzay/2vtYLlBHa3JF42ot3h1dW8Q0PaAG4v8rm0cvpVePtau5C6OKXGGcgO9q2AMNSWxiLqKw==",
                     "dev": true,
                     "requires": {
                         "chownr": "^2.0.0",
                         "fs-minipass": "^2.0.0",
-                        "minipass": "^3.0.0",
+                        "minipass": "^4.0.0",
                         "minizlib": "^2.1.1",
                         "mkdirp": "^1.0.3",
                         "yallist": "^4.0.0"
+                    },
+                    "dependencies": {
+                        "minipass": {
+                            "version": "4.0.0",
+                            "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.0.0.tgz",
+                            "integrity": "sha512-g2Uuh2jEKoht+zvO6vJqXmYpflPqzRBT+Th2h01DKh5z7wbY/AZ2gCQ78cP70YoHPyFdY30YBV5WxgLOEwOykw==",
+                            "dev": true,
+                            "requires": {
+                                "yallist": "^4.0.0"
+                            }
+                        }
                     }
                 },
                 "yallist": {
@@ -5938,33 +5934,11 @@
                     "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
                     "dev": true
                 },
-                "ansi-styles": {
-                    "version": "6.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-                    "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-                    "dev": true
-                },
                 "emoji-regex": {
                     "version": "9.2.2",
                     "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
                     "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
                     "dev": true
-                },
-                "is-fullwidth-code-point": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
-                    "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
-                    "dev": true
-                },
-                "slice-ansi": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
-                    "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^6.0.0",
-                        "is-fullwidth-code-point": "^4.0.0"
-                    }
                 },
                 "string-width": {
                     "version": "5.1.2",
@@ -7999,9 +7973,9 @@
             }
         },
         "es-abstract": {
-            "version": "1.20.4",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.4.tgz",
-            "integrity": "sha512-0UtvRN79eMe2L+UNEF1BwRe364sj/DXhQ/k5FmivgoSdpM90b8Jc0mDzKMGo7QS0BVbOP/bTwBKNnDc9rNzaPA==",
+            "version": "1.20.5",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.5.tgz",
+            "integrity": "sha512-7h8MM2EQhsCA7pU/Nv78qOXFpD8Rhqd12gYiSJVkrH9+e8VuA8JlPJK/hQjjlLv6pJvx/z1iRFKzYb0XT/RuAQ==",
             "dev": true,
             "requires": {
                 "call-bind": "^1.0.2",
@@ -8010,6 +7984,7 @@
                 "function.prototype.name": "^1.1.5",
                 "get-intrinsic": "^1.1.3",
                 "get-symbol-description": "^1.0.0",
+                "gopd": "^1.0.1",
                 "has": "^1.0.3",
                 "has-property-descriptors": "^1.0.0",
                 "has-symbols": "^1.0.3",
@@ -8025,8 +8000,8 @@
                 "object.assign": "^4.1.4",
                 "regexp.prototype.flags": "^1.4.3",
                 "safe-regex-test": "^1.0.0",
-                "string.prototype.trimend": "^1.0.5",
-                "string.prototype.trimstart": "^1.0.5",
+                "string.prototype.trimend": "^1.0.6",
+                "string.prototype.trimstart": "^1.0.6",
                 "unbox-primitive": "^1.0.2"
             }
         },
@@ -10549,86 +10524,7 @@
             "resolved": "https://registry.npmjs.org/iconv-corefoundation/-/iconv-corefoundation-1.1.7.tgz",
             "integrity": "sha512-T10qvkw0zz4wnm560lOEg0PovVqUXuOFhhHAkixw8/sycy7TJt7v/RrkEKEQnAw2viPSJu6iAkErxnzR0g8PpQ==",
             "dev": true,
-            "optional": true,
-            "requires": {
-                "cli-truncate": "^2.1.0",
-                "node-addon-api": "^1.6.3"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "5.0.1",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-                    "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-                    "dev": true,
-                    "optional": true
-                },
-                "astral-regex": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
-                    "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
-                    "dev": true,
-                    "optional": true
-                },
-                "cli-truncate": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
-                    "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "slice-ansi": "^3.0.0",
-                        "string-width": "^4.2.0"
-                    }
-                },
-                "is-fullwidth-code-point": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-                    "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-                    "dev": true,
-                    "optional": true
-                },
-                "node-addon-api": {
-                    "version": "1.7.2",
-                    "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
-                    "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==",
-                    "dev": true,
-                    "optional": true
-                },
-                "slice-ansi": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
-                    "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "ansi-styles": "^4.0.0",
-                        "astral-regex": "^2.0.0",
-                        "is-fullwidth-code-point": "^3.0.0"
-                    }
-                },
-                "string-width": {
-                    "version": "4.2.3",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-                    "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "emoji-regex": "^8.0.0",
-                        "is-fullwidth-code-point": "^3.0.0",
-                        "strip-ansi": "^6.0.1"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "6.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-                    "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "ansi-regex": "^5.0.1"
-                    }
-                }
-            }
+            "optional": true
         },
         "iconv-lite": {
             "version": "0.4.24",
@@ -13495,9 +13391,9 @@
             }
         },
         "node-addon-api": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.0.2.tgz",
-            "integrity": "sha512-+D4s2HCnxPd5PjjI0STKwncjXTUKKqm74MDMz9OPXavjsGmjkvwgLtA5yoxJUdmpj52+2u+RrXgPipahKczMKg=="
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.0.0.tgz",
+            "integrity": "sha512-CvkDw2OEnme7ybCykJpVcKH+uAOLV2qLqiyla128dN9TkEWfrYmxG6C2boDe5KcNQqZF3orkqzGgOMvZ/JNekA=="
         },
         "node-gyp": {
             "version": "6.1.0",
@@ -13584,8 +13480,7 @@
         "node-gyp-build": {
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
-            "integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==",
-            "dev": true
+            "integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg=="
         },
         "node-int64": {
             "version": "0.4.0",
@@ -14539,8 +14434,8 @@
             }
         },
         "pc-nrfconnect-shared": {
-            "version": "git+https://github.com/NordicSemiconductor/pc-nrfconnect-shared.git#1522956ba69feae747752321c29e016225dd947c",
-            "from": "git+https://github.com/NordicSemiconductor/pc-nrfconnect-shared.git#v6.13.1",
+            "version": "git+https://github.com/NordicSemiconductor/pc-nrfconnect-shared.git#16b1ab36be801e0f6828310909e08e83f8e234e4",
+            "from": "git+https://github.com/NordicSemiconductor/pc-nrfconnect-shared.git#v6.13.2",
             "dev": true,
             "requires": {
                 "@babel/core": "7.18.9",
@@ -17065,7 +16960,6 @@
             "version": "10.5.0",
             "resolved": "https://registry.npmjs.org/serialport/-/serialport-10.5.0.tgz",
             "integrity": "sha512-7OYLDsu5i6bbv3lU81pGy076xe0JwpK6b49G6RjNvGibstUqQkI+I3/X491yBGtf4gaqUdOgoU1/5KZ/XxL4dw==",
-            "dev": true,
             "requires": {
                 "@serialport/binding-mock": "10.2.2",
                 "@serialport/bindings-cpp": "10.8.0",
@@ -17237,29 +17131,25 @@
             "dev": true
         },
         "slice-ansi": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
-            "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
+            "integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
             "dev": true,
             "requires": {
-                "ansi-styles": "^3.2.0",
-                "astral-regex": "^1.0.0",
-                "is-fullwidth-code-point": "^2.0.0"
+                "ansi-styles": "^6.0.0",
+                "is-fullwidth-code-point": "^4.0.0"
             },
             "dependencies": {
                 "ansi-styles": {
-                    "version": "3.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-                    "dev": true,
-                    "requires": {
-                        "color-convert": "^1.9.0"
-                    }
+                    "version": "6.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+                    "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+                    "dev": true
                 },
                 "is-fullwidth-code-point": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                    "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
+                    "integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
                     "dev": true
                 }
             }
@@ -18002,6 +17892,15 @@
                     "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
                     "dev": true
                 },
+                "ansi-styles": {
+                    "version": "3.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+                    "dev": true,
+                    "requires": {
+                        "color-convert": "^1.9.0"
+                    }
+                },
                 "emoji-regex": {
                     "version": "7.0.3",
                     "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
@@ -18013,6 +17912,17 @@
                     "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
                     "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
                     "dev": true
+                },
+                "slice-ansi": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+                    "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^3.2.0",
+                        "astral-regex": "^1.0.0",
+                        "is-fullwidth-code-point": "^2.0.0"
+                    }
                 },
                 "string-width": {
                     "version": "3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11943,8 +11943,7 @@
         "js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-            "dev": true
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
         },
         "js-yaml": {
             "version": "3.14.1",
@@ -12422,7 +12421,6 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
             "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-            "dev": true,
             "requires": {
                 "js-tokens": "^3.0.0 || ^4.0.0"
             }
@@ -14434,8 +14432,8 @@
             }
         },
         "pc-nrfconnect-shared": {
-            "version": "git+https://github.com/NordicSemiconductor/pc-nrfconnect-shared.git#16b1ab36be801e0f6828310909e08e83f8e234e4",
-            "from": "git+https://github.com/NordicSemiconductor/pc-nrfconnect-shared.git#v6.13.2",
+            "version": "git+https://github.com/NordicSemiconductor/pc-nrfconnect-shared.git#1522956ba69feae747752321c29e016225dd947c",
+            "from": "git+https://github.com/NordicSemiconductor/pc-nrfconnect-shared.git#v6.13.1",
             "dev": true,
             "requires": {
                 "@babel/core": "7.18.9",
@@ -15104,7 +15102,6 @@
             "version": "15.8.1",
             "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
             "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-            "dev": true,
             "requires": {
                 "loose-envify": "^1.4.0",
                 "object-assign": "^4.1.1",
@@ -15114,8 +15111,7 @@
                 "react-is": {
                     "version": "16.13.1",
                     "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-                    "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-                    "dev": true
+                    "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
                 }
             }
         },
@@ -15355,7 +15351,6 @@
             "version": "16.14.0",
             "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
             "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
-            "dev": true,
             "requires": {
                 "loose-envify": "^1.1.0",
                 "object-assign": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
         "electron-builder": "^22.14.13",
         "electron-devtools-installer": "3.2.0",
         "electron-notarize": "0.3.0",
-        "pc-nrfconnect-shared": "git+https://github.com/NordicSemiconductor/pc-nrfconnect-shared.git#v6.13.1",
+        "pc-nrfconnect-shared": "git+https://github.com/NordicSemiconductor/pc-nrfconnect-shared.git#v6.13.2",
         "playwright": "^1.16.3",
         "xvfb-maybe": "0.2.1"
     },
@@ -116,6 +116,7 @@
         "fs-extra": "9.0.0",
         "lodash.merge": "4.6.2",
         "mustache": "4.0.1",
+        "serialport": "10.5.0",
         "shasum": "1.0.2",
         "short-uuid": "4.2.0",
         "sudo-prompt": "^9.2.1",

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
         "fs-extra": "9.0.0",
         "lodash.merge": "4.6.2",
         "mustache": "4.0.1",
-        "react": "^16.14.0",
+        "react": "16.14.0",
         "serialport": "10.5.0",
         "shasum": "1.0.2",
         "short-uuid": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
         "electron-builder": "^22.14.13",
         "electron-devtools-installer": "3.2.0",
         "electron-notarize": "0.3.0",
-        "pc-nrfconnect-shared": "git+https://github.com/NordicSemiconductor/pc-nrfconnect-shared.git#v6.13.2",
+        "pc-nrfconnect-shared": "git+https://github.com/NordicSemiconductor/pc-nrfconnect-shared.git#v6.13.1",
         "playwright": "^1.16.3",
         "xvfb-maybe": "0.2.1"
     },
@@ -116,6 +116,7 @@
         "fs-extra": "9.0.0",
         "lodash.merge": "4.6.2",
         "mustache": "4.0.1",
+        "react": "^16.14.0",
         "serialport": "10.5.0",
         "shasum": "1.0.2",
         "short-uuid": "4.2.0",

--- a/src/app/module-loader.js
+++ b/src/app/module-loader.js
@@ -4,11 +4,16 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-/* eslint-disable no-underscore-dangle,dot-notation */
+/* eslint-disable no-underscore-dangle */
 import Module from 'module';
 
 const hostedModules = {};
 
+/*
+ * The loaded app may import react and react-redux. We must make sure that the
+ * app uses the same instances of react and react-redux as we have in core.
+ * Cannot have multiple copies of these loaded at the same time.
+ */
 const originalLoad = Module._load;
 Module._load = function load(modulePath) {
     if (hostedModules[modulePath]) {
@@ -18,9 +23,18 @@ Module._load = function load(modulePath) {
     return originalLoad.apply(this, arguments); // eslint-disable-line prefer-rest-params
 };
 
+/* eslint-disable dot-notation */
+// Disable dot-notation in this file, to keep the syntax below more consistent
 hostedModules['serialport'] = require('serialport');
+
 hostedModules['electron'] = require('electron');
 hostedModules['@electron/remote'] = require('@electron/remote');
 hostedModules[
     '@nordicsemiconductor/nrf-device-lib-js'
 ] = require('@nordicsemiconductor/nrf-device-lib-js');
+hostedModules['pc-nrfconnect-shared'] = require('pc-nrfconnect-shared');
+hostedModules['react-dom'] = require('react-dom');
+hostedModules['react-redux'] = require('react-redux');
+hostedModules['react'] = require('react');
+hostedModules['redux-devtools-extension'] = require('redux-devtools-extension');
+hostedModules['redux-thunk'] = require('redux-thunk');

--- a/src/app/module-loader.js
+++ b/src/app/module-loader.js
@@ -4,16 +4,11 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-/* eslint-disable no-underscore-dangle */
+/* eslint-disable no-underscore-dangle,dot-notation */
 import Module from 'module';
 
 const hostedModules = {};
 
-/*
- * The loaded app may import react and react-redux. We must make sure that the
- * app uses the same instances of react and react-redux as we have in core.
- * Cannot have multiple copies of these loaded at the same time.
- */
 const originalLoad = Module._load;
 Module._load = function load(modulePath) {
     if (hostedModules[modulePath]) {
@@ -23,40 +18,9 @@ Module._load = function load(modulePath) {
     return originalLoad.apply(this, arguments); // eslint-disable-line prefer-rest-params
 };
 
-const SerialPort = require('serialport');
-
-let hasShownDeprecatedPropertyWarning = false;
-const mayShowWarningAboutDeprecatedProperty = () => {
-    if (!hasShownDeprecatedPropertyWarning) {
-        console.warn(
-            'Using the property "comName" has been deprecated. You should now use "path". The property will be removed in the next major release.'
-        );
-    }
-    hasShownDeprecatedPropertyWarning = true;
-};
-const ducktapeComName = port => ({
-    ...port,
-    get comName() {
-        mayShowWarningAboutDeprecatedProperty();
-        return port.path;
-    },
-});
-
-const originalSerialPortList = SerialPort.list;
-SerialPort.list = () =>
-    originalSerialPortList().then(ports => ports.map(ducktapeComName));
-
-/* eslint-disable dot-notation */
-// Disable dot-notation in this file, to keep the syntax below more consistent
-hostedModules['serialport'] = SerialPort;
-
+hostedModules['serialport'] = require('serialport');
 hostedModules['electron'] = require('electron');
 hostedModules['@electron/remote'] = require('@electron/remote');
 hostedModules[
     '@nordicsemiconductor/nrf-device-lib-js'
 ] = require('@nordicsemiconductor/nrf-device-lib-js');
-hostedModules['react-dom'] = require('react-dom');
-hostedModules['react-redux'] = require('react-redux');
-hostedModules['react'] = require('react');
-hostedModules['redux-devtools-extension'] = require('redux-devtools-extension');
-hostedModules['redux-thunk'] = require('redux-thunk');


### PR DESCRIPTION
This is needed because electron-builder will ignore the transitive dependency on serialport from shared when creating the app.