### PR TITLE
Check for minimal app versions

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,8 @@
 
 -   Install local apps by dragging a file containing an app package and dropping
     it onto the app list.
--   Add support for Serial Terminal app
+-   Support for Serial Terminal app.
+-   Warn about outdated app versions.
 
 ### Changed
 

--- a/src/ipc/apps.ts
+++ b/src/ipc/apps.ts
@@ -28,7 +28,7 @@ interface BaseApp {
     iconPath?: string;
 }
 
-export interface InstalledApp extends BaseApp {
+interface InstalledApp extends BaseApp {
     currentVersion: string;
     path: string;
     shortcutIconPath: string;

--- a/src/launcher/util/appCompatibilityWarning.test.ts
+++ b/src/launcher/util/appCompatibilityWarning.test.ts
@@ -52,6 +52,12 @@ describe('check compatibility of an app with the launcher', () => {
             ).toMatchObject(undecidedCheck);
         });
 
+        it('treats caret ranges as greater-equal', () => {
+            expect(
+                checkEngineIsSupported(requiringEngine('^1.0.0'), '2.0.0')
+            ).toMatchObject(undecidedCheck);
+        });
+
         it('is undecided if the app requires the same version', () => {
             expect(
                 checkEngineIsSupported(requiringEngine('^1.2.3'), '1.2.3')

--- a/src/launcher/util/appCompatibilityWarning.test.ts
+++ b/src/launcher/util/appCompatibilityWarning.test.ts
@@ -6,14 +6,14 @@
 
 import { inspect } from 'util';
 
-import { InstalledApp } from '../../ipc/apps';
+import { LaunchableApp } from '../../ipc/apps';
 import { createDownloadableTestApp } from '../../test/testFixtures';
 import appCompatibilityWarning, {
     checkEngineIsSupported,
     checkEngineVersionIsSet,
 } from './appCompatibilityWarning';
 
-const requiringEngine = (engineVersion?: string): InstalledApp =>
+const requiringEngine = (engineVersion?: string): LaunchableApp =>
     createDownloadableTestApp(undefined, { engineVersion });
 
 const failingCheck = {
@@ -108,6 +108,18 @@ describe('check compatibility of an app with the launcher', () => {
                     });
                 }
             );
+
+            it('The app version is too old according to the list of minimal required versions', () => {
+                const compatibilityWarning = appCompatibilityWarning(
+                    createDownloadableTestApp('pc-nrfconnect-dtm', {
+                        currentVersion: '2.0.3',
+                        engineVersion: '1.0.0',
+                    }),
+                    '1.0.0'
+                );
+                expect(compatibilityWarning?.warning).toBeDefined();
+                expect(compatibilityWarning?.longWarning).toBeDefined();
+            });
         });
 
         describe('all checks are successful if', () => {

--- a/src/launcher/util/appCompatibilityWarning.ts
+++ b/src/launcher/util/appCompatibilityWarning.ts
@@ -38,13 +38,18 @@ export const checkEngineVersionIsSet: AppCompatibilityChecker = app =>
                   'engines.nrfconnect definition to package.json.'
           );
 
+const replaceCaretWithGreaterEqual = (engineVersion: string) =>
+    engineVersion.startsWith('^')
+        ? engineVersion.replace('^', '>=')
+        : engineVersion;
+
 export const checkEngineIsSupported: AppCompatibilityChecker = (
     app,
     providedVersionOfEngine
 ) => {
     const isSupportedEngine = semver.satisfies(
         semver.coerce(providedVersionOfEngine) ?? '0.0.0',
-        app.engineVersion! // eslint-disable-line @typescript-eslint/no-non-null-assertion -- checkEngineVersionIsSet above already checks that this is defined
+        replaceCaretWithGreaterEqual(app.engineVersion!) // eslint-disable-line @typescript-eslint/no-non-null-assertion -- checkEngineVersionIsSet above already checks that this is defined
     );
 
     return isSupportedEngine

--- a/src/launcher/util/appCompatibilityWarning.ts
+++ b/src/launcher/util/appCompatibilityWarning.ts
@@ -6,8 +6,9 @@
 
 import semver from 'semver';
 
-import { InstalledApp } from '../../ipc/apps';
+import { isDownloadable, LaunchableApp } from '../../ipc/apps';
 import mainConfig from './mainConfig';
+import minimalRequiredAppVersions from './minimalRequiredAppVersions';
 
 const undecided = { isDecided: false } as const;
 const incompatible = (warning: string, longWarning: string) =>
@@ -22,7 +23,7 @@ type Undecided = typeof undecided;
 type Incompatible = ReturnType<typeof incompatible>;
 
 type AppCompatibilityChecker = (
-    app: InstalledApp,
+    app: LaunchableApp,
     providedVersionOfEngine: string
 ) => Undecided | Incompatible;
 
@@ -58,12 +59,45 @@ export const checkEngineIsSupported: AppCompatibilityChecker = (
           );
 };
 
+const checkMinimalRequiredAppVersions: AppCompatibilityChecker = app => {
+    const appIsRecentEnough =
+        minimalRequiredAppVersions[app.name] == null ||
+        semver.gte(app.currentVersion, minimalRequiredAppVersions[app.name]);
+
+    const fittingVersionExists =
+        minimalRequiredAppVersions[app.name] != null &&
+        isDownloadable(app) &&
+        app.latestVersion != null &&
+        semver.gte(app.latestVersion, minimalRequiredAppVersions[app.name]);
+
+    return appIsRecentEnough
+        ? undecided
+        : incompatible(
+              'This versions of nRF Connect for Desktop does not support ' +
+                  `the version ${app.currentVersion} of this app. You ` +
+                  `need at least version ` +
+                  `${minimalRequiredAppVersions[app.name]} of this app.`,
+              `This versions of nRF Connect for Desktop does not support ` +
+                  `the version ${app.currentVersion} of the app ` +
+                  `"${app.displayName}". You need at least version ` +
+                  `${minimalRequiredAppVersions[app.name]} of this app.${
+                      fittingVersionExists
+                          ? ' Download the latest available version of this app.'
+                          : ''
+                  } Running the currently installed version of this app might not work as expected.`
+          );
+};
+
 export default (
-    app: InstalledApp,
+    app: LaunchableApp,
     providedVersionOfEngine = mainConfig().version
 ): undefined | { warning: string; longWarning: string } => {
     // eslint-disable-next-line no-restricted-syntax -- because here a loop is simpler than an array iteration function
-    for (const check of [checkEngineVersionIsSet, checkEngineIsSupported]) {
+    for (const check of [
+        checkEngineVersionIsSet,
+        checkEngineIsSupported,
+        checkMinimalRequiredAppVersions,
+    ]) {
         const result = check(app, providedVersionOfEngine);
         if (result.isDecided) {
             return { warning: result.warning, longWarning: result.longWarning };

--- a/src/launcher/util/minimalRequiredAppVersions.ts
+++ b/src/launcher/util/minimalRequiredAppVersions.ts
@@ -11,4 +11,5 @@ export default {
     'pc-nrfconnect-rssi': '1.4.3',
     'pc-nrfconnect-tracecollector-preview': '0.4.0',
     'pc-nrfconnect-tracecollector': '1.1.4',
+    'pc-nrfconnect-programmer': '3.0.5',
 } as Record<string, string>;

--- a/src/launcher/util/minimalRequiredAppVersions.ts
+++ b/src/launcher/util/minimalRequiredAppVersions.ts
@@ -9,7 +9,7 @@ export default {
     'pc-nrfconnect-linkmonitor': '2.0.3',
     'pc-nrfconnect-ppk': '3.5.4',
     'pc-nrfconnect-rssi': '1.4.3',
-    'pc-nrfconnect-tracecollector-preview': '0.4.0',
+    'pc-nrfconnect-tracecollector-preview': '0.3.7',
     'pc-nrfconnect-tracecollector': '1.1.4',
     'pc-nrfconnect-programmer': '3.0.5',
 } as Record<string, string>;

--- a/src/launcher/util/minimalRequiredAppVersions.ts
+++ b/src/launcher/util/minimalRequiredAppVersions.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+export default {
+    'pc-nrfconnect-dtm': '2.0.4',
+    'pc-nrfconnect-linkmonitor': '2.0.3',
+    'pc-nrfconnect-ppk': '3.5.4',
+    'pc-nrfconnect-rssi': '1.4.3',
+    'pc-nrfconnect-tracecollector-preview': '0.4.0',
+    'pc-nrfconnect-tracecollector': '1.1.4',
+} as Record<string, string>;


### PR DESCRIPTION
Keep in `minimalRequiredAppVersions.ts` a list of apps where we know, that the current version of the launcher requires at least a certain app version. 

If the installed app is older than that version, then warn about this. A warning is shown as an orange exclamation mark over the app icon and when hovering over that, a pop up is shown:

![Screenshot 2023-01-04 at 17 03 56](https://user-images.githubusercontent.com/260705/210598780-6ccc3bca-51f6-4cb8-87ce-9bd62a89c4b1.png)

If the users launch the app nonetheless, an additional warning is shown (comment to testers: This warning is not shown if you run the launcher from source, you need to build an executable for this, e.g. by running `npm run pack`):

![Screenshot 2023-01-04 at 16 54 24](https://user-images.githubusercontent.com/260705/210598992-0bf82440-5788-48cf-b383-9e71032356da.png)

If an app version that is recent enough exists, then the users are informed in the latter dialog that they should upgrade:

![Screenshot 2023-01-04 at 16 54 31](https://user-images.githubusercontent.com/260705/210599089-ed9c1d54-01de-4cbf-a6f2-092a7a2d8e8a.png)

~Still missing are appropriate versions for all apps in `minimalRequiredAppVersions.ts`.~



