### PR TITLE
Fix: Stuck state of Filter button

### DIFF
--- a/src/launcher/features/filter/AppFilterBar.tsx
+++ b/src/launcher/features/filter/AppFilterBar.tsx
@@ -14,10 +14,10 @@ import StateFilter from './StateFilter';
 import UpdateAllApps from './UpdateAllApps';
 
 const FilterDropdown = () => {
-    const [active, toggleActive] = useState(false);
+    const [active, setActive] = useState(false);
 
     return (
-        <Dropdown onToggle={() => toggleActive(!active)}>
+        <Dropdown onToggle={isOpen => setActive(isOpen)}>
             <Dropdown.Toggle variant="outline-secondary" active={active}>
                 <span className="mdi mdi-tune" />
                 Filter


### PR DESCRIPTION
The Filter button in the launcher was sometimes stuck in an “active” state. To reproduce:

- Click in Search field
- Hit tab to focus the Filter button
- Hit space twice to open and close the Filter Dropdown
- Hit tab to focus the Search field again

Expected: A Filter button rendered as inactive (white background)
Actual: A Filter button rendered as active (dark grey background)


https://user-images.githubusercontent.com/260705/212696406-71c4f39c-5584-49d5-bb1c-dd516f990bf5.mov

