### PR TITLE
Set a minimal version for GSA

### DIFF
--- a/src/launcher/util/minimalRequiredAppVersions.ts
+++ b/src/launcher/util/minimalRequiredAppVersions.ts
@@ -6,10 +6,11 @@
 
 export default {
     'pc-nrfconnect-dtm': '2.0.4',
+    'pc-nrfconnect-gettingstarted': '2.1.1',
     'pc-nrfconnect-linkmonitor': '2.0.3',
     'pc-nrfconnect-ppk': '3.5.4',
+    'pc-nrfconnect-programmer': '3.0.5',
     'pc-nrfconnect-rssi': '1.4.3',
     'pc-nrfconnect-tracecollector-preview': '0.3.7',
     'pc-nrfconnect-tracecollector': '1.1.4',
-    'pc-nrfconnect-programmer': '3.0.5',
 } as Record<string, string>;


### PR DESCRIPTION
Because the version 2.1.0 does not work with launcher 4.0.0.