### PR TITLE
Fix: Dropdown appeared in front of dropzone info

### DIFF
--- a/src/launcher/features/localAppInstall/dropZoneInfo.module.scss
+++ b/src/launcher/features/localAppInstall/dropZoneInfo.module.scss
@@ -14,7 +14,7 @@
     height: 100vh;
 
     background-color: #00000080;
-    z-index: 100;
+    z-index: 2000;
 
     display: flex;
     align-items: center;


### PR DESCRIPTION
- Open a dropdown by clicking on the triangle button and leave it open without selecting anything
- Drag a file over the launcher window while the menu is open

Expected: Show dropzone info in front of all other elements Actual: The dropdown appeared in front of the dropzone info

Cause: Bootstrap uses z-indices around 1000.
https://getbootstrap.com/docs/4.0/layout/overview/#z-index

Fix: Use a z-index of 2000 for the overlay, so it appears in front of all bootstap components.

Before:
![Screenshot 2023-01-19 at 14 17 09](https://user-images.githubusercontent.com/260705/213452673-0647592a-1405-4a05-a637-b68bd3a579ad.png)

Now: 
![Screenshot 2023-01-19 at 14 17 32](https://user-images.githubusercontent.com/260705/213452685-0e765b6e-426e-4393-ae73-d83c6abda179.png)
