### PR TITLE
Don't open electron browser when clicking anchor tags

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nrfconnect",
-    "version": "4.0.0-pre3",
+    "version": "4.0.0-pre4",
     "description": "nRF Connect for Desktop",
     "repository": {
         "type": "git",

--- a/src/main/browser.ts
+++ b/src/main/browser.ts
@@ -47,7 +47,7 @@ export const createWindow = (options: BrowserWindowOptions) => {
     const additionalArguments =
         appArgumentsIndex === -1 ? [] : process.argv.slice(appArgumentsIndex);
 
-    const mergedOptions = {
+    const mergedOptions: BrowserWindowOptions = {
         minWidth: 308,
         minHeight: 499,
         show: false,
@@ -56,7 +56,6 @@ export const createWindow = (options: BrowserWindowOptions) => {
             nodeIntegration: true,
             sandbox: false,
             contextIsolation: false,
-            enableRemoteModule: true,
             additionalArguments,
             backgroundThrottling: false,
         },
@@ -81,7 +80,7 @@ export const createWindow = (options: BrowserWindowOptions) => {
     // new electron window.
     browserWindow.webContents.setWindowOpenHandler(({ url }) => {
         shell.openExternal(url);
-        return { action: 'allow' };
+        return { action: 'deny' };
     });
 
     browserWindow.once('ready-to-show', () => {


### PR DESCRIPTION
<a target="_blank" used to open external browser, but now opened in an electron window as well. This fix rectifies that. Links still open in an external browser.