### PR TITLE
Fix: Handle corrupt updates.json gracefully

### DIFF
--- a/src/main/apps.ts
+++ b/src/main/apps.ts
@@ -329,8 +329,16 @@ const isErroneous = (result: AppResult): result is ErroneousAppResult =>
 const isSuccessful = (result: AppResult): result is SuccessfulAppResult =>
     result.status === 'success';
 
-const getUpdates = (source: SourceName) =>
-    fileUtil.readJsonFile<UpdatesJson>(getUpdatesJsonPath(source));
+const getUpdates = (source: SourceName) => {
+    try {
+        return fileUtil.readJsonFile<UpdatesJson>(getUpdatesJsonPath(source));
+    } catch (error) {
+        console.log(
+            `Failed to read updates file for source \`${source}\`. Falling back to assuming no updates.`
+        );
+        return {};
+    }
+};
 
 const getDownloadableAppsFromSource = (source: SourceName) => {
     const apps = downloadableAppsInAppsJson(source);


### PR DESCRIPTION
If an updates.json file was corrupt (e.g. just an empty file) the launcher was:

- Not showing any downloadable apps
- Not creating a correct updates.json file
- Not showing any sources besides official and local