### PR TITLE
Fix: Install too recent version

### DIFF
--- a/src/launcher/features/apps/appsEffects.ts
+++ b/src/launcher/features/apps/appsEffects.ts
@@ -22,6 +22,7 @@ import {
     LaunchableApp,
     removeDownloadableApp as removeDownloadableAppInMain,
     removeLocalApp as removeLocalAppInMain,
+    UninstalledDownloadableApp,
 } from '../../../ipc/apps';
 import { openApp } from '../../../ipc/openWindow';
 import type { AppDispatch } from '../../store';
@@ -167,11 +168,11 @@ export const installLocalApp =
     };
 
 export const installDownloadableApp =
-    (app: DownloadableAppInfo) => (dispatch: AppDispatch) => {
+    (app: UninstalledDownloadableApp) => (dispatch: AppDispatch) => {
         sendAppUsageData(EventAction.INSTALL_APP, app.source, app.name);
         dispatch(installDownloadableAppStarted(app));
 
-        installDownloadableAppInMain(app, 'latest')
+        installDownloadableAppInMain(app, app.latestVersion)
             .then(installedApp => {
                 dispatch(updateDownloadableAppInfo(installedApp));
             })


### PR DESCRIPTION
If there was a more recent version of an app available on the server but the launcher did not yet know about it (e.g. because “Check for updates at startup” is disabled), the launcher got confused when installing the app.

![image](https://user-images.githubusercontent.com/260705/215026666-c996f6b7-1bae-4ec9-bba3-8cb7b5ff37c2.png)

## Bug description
### Initial situation
- Version 1 of an app is locally installed
- Version 2 of an app is available on the server
- Locally we do _not_ have the version yet, that version 2 is available (e.g. because “Check for updates at startup” is disabled)

### Steps
- Uninstall version 1 of the app (after this, the launcher still shows version 1 as being available))
- Install the app again

### Expected
- Version 1 of the app is installed
- No available update is shown (until the server is checked for an update, e.g. the launcher is restarted or “Check for updates” is clicked in the settings)

### Actual
- Version 2 of the app is installed
- The launcher says version 2 is installed but that version 1 is available (as if version 1 was an update but “updating” doesn't really update to it)

https://trello.com/c/DDxGWNrQ/93-launcher-updating-to-the-lower-version
