### PR TITLE
Fix: Ignore hidden dirs in local apps dir

### DIFF
--- a/src/main/fileUtil.ts
+++ b/src/main/fileUtil.ts
@@ -29,15 +29,13 @@ export const readJsonFile = <T>(filePath: string) => {
     }
 };
 
-const isDirectory = (dirPath: string, file: string) => {
-    const fileStats = fs.statSync(path.join(dirPath, file));
-    return fileStats.isDirectory();
-};
-
-export const listDirectories = (dirPath: string) =>
+export const listDirectories = (dirPath: string): string[] =>
     !fs.existsSync(dirPath)
         ? []
-        : fs.readdirSync(dirPath).filter(file => isDirectory(dirPath, file));
+        : fs
+              .readdirSync(dirPath, { withFileTypes: true })
+              .filter(file => file.isDirectory())
+              .map(file => file.name);
 
 const isFile = (dirPath: string, file: string) => {
     const fileStats = fs.statSync(path.join(dirPath, file));

--- a/src/main/fileUtil.ts
+++ b/src/main/fileUtil.ts
@@ -34,7 +34,7 @@ export const listDirectories = (dirPath: string): string[] =>
         ? []
         : fs
               .readdirSync(dirPath, { withFileTypes: true })
-              .filter(file => file.isDirectory())
+              .filter(file => file.isDirectory() && !file.name.startsWith('.'))
               .map(file => file.name);
 
 const isFile = (dirPath: string, file: string) => {


### PR DESCRIPTION


Some have a `.vscode` directory in the directory of the local apps and    we want to ignore that.