### PR TITLE
Fix: Adding sources

### DIFF
--- a/src/launcher/features/sources/sourcesEffects.ts
+++ b/src/launcher/features/sources/sourcesEffects.ts
@@ -16,7 +16,7 @@ import {
 } from '../../../ipc/sources';
 import type { AppDispatch } from '../../store';
 import { fetchInfoForAllDownloadableApps } from '../apps/appsEffects';
-import { hideSource } from '../filter/filterSlice';
+import { hideSource, showSource } from '../filter/filterSlice';
 import {
     addSource as addSourceAction,
     removeSource as removeSourceAction,
@@ -39,7 +39,7 @@ export const addSource = (url: SourceUrl) => (dispatch: AppDispatch) => {
     addSourceInMain(url)
         .then(name => {
             dispatch(addSourceAction({ name, url }));
-            dispatch(hideSource(name));
+            dispatch(showSource(name));
         })
         .catch(error =>
             dispatch(

--- a/src/main/apps.ts
+++ b/src/main/apps.ts
@@ -35,7 +35,8 @@ import describeError from './describeError';
 import * as fileUtil from './fileUtil';
 import { mkdir, mkdirIfNotExists } from './mkdir';
 import * as net from './net';
-import * as registryApi from './registryApi';
+import * as registryApi from './registryApi'; // eslint-disable-line import/no-cycle -- Because this causes no problems and is temporary anyhow
+// eslint-disable-next-line import/no-cycle -- Because this causes no problems and is temporary anyhow
 import {
     AppsJson,
     downloadAllAppsJson,
@@ -50,7 +51,7 @@ const isInstalled = (appPath: string) => fs.pathExistsSync(appPath);
  * Create the updates.json file containing the latest available versions for
  * a source. Format: { "foo": "x.y.z", "bar: "x.y.z" }.
  */
-const generateUpdatesJsonFile = async (sourceName: SourceName) => {
+export const generateUpdatesJsonFile = async (sourceName: SourceName) => {
     const fileName = getUpdatesJsonPath(sourceName);
 
     const latestVersions = await registryApi.getLatestAppVersions(

--- a/src/main/registryApi.ts
+++ b/src/main/registryApi.ts
@@ -11,7 +11,7 @@ import url from 'url';
 
 import { AppSpec } from '../ipc/apps';
 import * as net from './net';
-import { getSourceUrl } from './sources';
+import { getSourceUrl } from './sources'; // eslint-disable-line import/no-cycle -- Because this causes no problems and is temporary anyhow
 
 interface AppInfo {
     ['dist-tags']: {

--- a/src/main/sources.ts
+++ b/src/main/sources.ts
@@ -9,6 +9,7 @@ import fs from 'fs-extra';
 
 import { DownloadableAppInfoBase } from '../ipc/apps';
 import { allStandardSourceNames } from '../ipc/sources';
+import { generateUpdatesJsonFile } from './apps'; // eslint-disable-line import/no-cycle -- Because this causes no problems and is temporary anyhow
 import {
     getAppsJsonPath,
     getAppsRootDir,
@@ -177,6 +178,8 @@ export const addSource = async (url: string) => {
     saveAllSources();
 
     addShownSource(name);
+
+    await generateUpdatesJsonFile(name);
 
     return name;
 };


### PR DESCRIPTION
This fixes two bugs around adding sources:

- Added source should be directly visible.
- Installing apps from a freshly added source failed.

### Added source should be directly visible

When adding a source, it was initially hidden by the filter. But when you add a source, you usually also want to work with it right away, e.g. install an app from it. So it is better to have it initially visible.

### Installing apps from a freshly added source failed
Steps to reproduce:
- Remove the “Test” source (if you have it)
- Add the “Test” source  https://developer.nordicsemi.com/.pc-tools/nrfconnect-apps/test/apps.json
- Go to the apps list and search, e.g. for the Getting Started Assistant

Expected result:
- It is shown with the installable version v2.1.1 by the source name  “Test”
- Clicking on “Install” installs it

Actual result:
- No version for the app by the source name “Test”
- Clicking on “Install” leads to an error