### PR TITLE
Support withdrawn apps

### DIFF
--- a/src/ipc/apps.ts
+++ b/src/ipc/apps.ts
@@ -58,9 +58,16 @@ export interface InstalledDownloadableApp
     releaseNote?: string;
 }
 
+export interface WithdrawnApp extends InstalledApp, DownloadableAppInfo {
+    url: '';
+    source: SourceName;
+    iconPath: string;
+}
+
 export type DownloadableApp =
     | InstalledDownloadableApp
-    | UninstalledDownloadableApp;
+    | UninstalledDownloadableApp
+    | WithdrawnApp;
 
 export type LaunchableApp = LocalApp | InstalledDownloadableApp;
 
@@ -76,6 +83,9 @@ export const isDownloadable = (app: App): app is DownloadableApp =>
 
 export const isInstalled = (app: App): app is LaunchableApp =>
     app.currentVersion != null;
+
+export const isWithdrawn = (app: App): app is WithdrawnApp =>
+    isDownloadable(app) && !('latestVersion' in app);
 
 export const updateAvailable = (app: InstalledDownloadableApp) =>
     app.currentVersion !== app.latestVersion;

--- a/src/ipc/apps.ts
+++ b/src/ipc/apps.ts
@@ -69,7 +69,7 @@ export type DownloadableApp =
     | UninstalledDownloadableApp
     | WithdrawnApp;
 
-export type LaunchableApp = LocalApp | InstalledDownloadableApp;
+export type LaunchableApp = LocalApp | InstalledDownloadableApp | WithdrawnApp;
 
 export type App = LocalApp | DownloadableApp;
 

--- a/src/launcher/features/apps/App/App.tsx
+++ b/src/launcher/features/apps/App/App.tsx
@@ -14,6 +14,7 @@ import Row from 'react-bootstrap/Row';
 import {
     isDownloadable,
     isInstalled,
+    isWithdrawn,
     updateAvailable,
 } from '../../../../ipc/apps';
 import { DisplayedApp } from '../appsSlice';
@@ -41,11 +42,15 @@ const App: React.FC<{ app: DisplayedApp }> = ({ app }) => (
                     {isInstalled(app) && <>, v{app.currentVersion}</>}
                     {isInstalled(app) &&
                         isDownloadable(app) &&
+                        !isWithdrawn(app) &&
                         updateAvailable(app) && (
                             <> (v{app.latestVersion} available)</>
                         )}
-                    {!isInstalled(app) && app.latestVersion && (
-                        <>, v{app.latestVersion}</>
+                    {!isInstalled(app) &&
+                        !isWithdrawn(app) &&
+                        app.latestVersion && <>, v{app.latestVersion}</>}
+                    {isWithdrawn(app) && (
+                        <>, not available for download any more</>
                     )}
                 </div>
             </Col>

--- a/src/launcher/features/apps/App/InstallApp.tsx
+++ b/src/launcher/features/apps/App/InstallApp.tsx
@@ -7,14 +7,14 @@
 import React from 'react';
 import Button from 'react-bootstrap/Button';
 
-import { isInstalled } from '../../../../ipc/apps';
+import { isInstalled, isWithdrawn } from '../../../../ipc/apps';
 import { useLauncherDispatch } from '../../../util/hooks';
 import { installDownloadableApp } from '../appsEffects';
 import { DisplayedApp, isInProgress } from '../appsSlice';
 
 const InstallApp: React.FC<{ app: DisplayedApp }> = ({ app }) => {
     const dispatch = useLauncherDispatch();
-    if (isInstalled(app)) return null;
+    if (isInstalled(app) || isWithdrawn(app)) return null;
 
     return (
         <Button

--- a/src/launcher/features/apps/App/ShowReleaseNotes.tsx
+++ b/src/launcher/features/apps/App/ShowReleaseNotes.tsx
@@ -7,14 +7,15 @@
 import React from 'react';
 import Dropdown from 'react-bootstrap/Dropdown';
 
-import { isDownloadable } from '../../../../ipc/apps';
+import { isDownloadable, isWithdrawn } from '../../../../ipc/apps';
 import { useLauncherDispatch } from '../../../util/hooks';
 import { show as showReleaseNotes } from '../../releaseNotes/releaseNotesDialogSlice';
 import { DisplayedApp } from '../appsSlice';
 
 const ShowReleaseNotes: React.FC<{ app: DisplayedApp }> = ({ app }) => {
     const dispatch = useLauncherDispatch();
-    if (!isDownloadable(app) || app.releaseNote == null) return null;
+    if (!isDownloadable(app) || isWithdrawn(app) || app.releaseNote == null)
+        return null;
 
     return (
         <Dropdown.Item

--- a/src/launcher/features/apps/App/UpdateApp.tsx
+++ b/src/launcher/features/apps/App/UpdateApp.tsx
@@ -10,6 +10,7 @@ import Button from 'react-bootstrap/Button';
 import {
     isDownloadable,
     isInstalled,
+    isWithdrawn,
     updateAvailable,
 } from '../../../../ipc/apps';
 import { useLauncherDispatch } from '../../../util/hooks';
@@ -19,7 +20,12 @@ import { DisplayedApp, isInProgress } from '../appsSlice';
 const UpdateApp: React.FC<{ app: DisplayedApp }> = ({ app }) => {
     const dispatch = useLauncherDispatch();
 
-    if (!isInstalled(app) || !isDownloadable(app) || !updateAvailable(app))
+    if (
+        !isInstalled(app) ||
+        !isDownloadable(app) ||
+        !updateAvailable(app) ||
+        isWithdrawn(app)
+    )
         return null;
 
     return (

--- a/src/launcher/features/apps/App/UpdateApp.tsx
+++ b/src/launcher/features/apps/App/UpdateApp.tsx
@@ -21,10 +21,10 @@ const UpdateApp: React.FC<{ app: DisplayedApp }> = ({ app }) => {
     const dispatch = useLauncherDispatch();
 
     if (
+        isWithdrawn(app) ||
         !isInstalled(app) ||
         !isDownloadable(app) ||
-        !updateAvailable(app) ||
-        isWithdrawn(app)
+        !updateAvailable(app)
     )
         return null;
 

--- a/src/launcher/features/apps/appsSlice.ts
+++ b/src/launcher/features/apps/appsSlice.ts
@@ -330,7 +330,7 @@ export const getDownloadableApp =
 
 export const isAppUpdateAvailable = (state: RootState) =>
     state.apps.downloadableApps.find(
-        app => isInstalled(app) && updateAvailable(app)
+        app => !isWithdrawn(app) && isInstalled(app) && updateAvailable(app)
     ) != null;
 
 export const getUpdateCheckStatus = (state: RootState) => ({
@@ -341,7 +341,9 @@ export const getUpdateCheckStatus = (state: RootState) => ({
 export const getUpdatableVisibleApps = (state: RootState) =>
     state.apps.downloadableApps
         .filter(getAppsFilter(state))
-        .filter(app => isInstalled(app) && updateAvailable(app));
+        .filter(
+            app => !isWithdrawn(app) && isInstalled(app) && updateAvailable(app)
+        );
 
 export const getConfirmLaunch = (state: RootState) => ({
     isDialogVisible: state.apps.isConfirmLaunchDialogVisible,

--- a/src/launcher/features/apps/appsSlice.ts
+++ b/src/launcher/features/apps/appsSlice.ts
@@ -13,6 +13,7 @@ import {
     DownloadableApp,
     isDownloadable,
     isInstalled,
+    isWithdrawn,
     LaunchableApp,
     LocalApp,
     updateAvailable,
@@ -192,7 +193,9 @@ const slice = createSlice({
             }>
         ) {
             updateApp(payload.app, state.downloadableApps, app => {
-                app.releaseNote = payload.releaseNote;
+                if (!isWithdrawn(app)) {
+                    app.releaseNote = payload.releaseNote;
+                }
             });
         },
         updateInstallProgress(state, { payload }: PayloadAction<Progress>) {
@@ -237,11 +240,20 @@ const slice = createSlice({
             state,
             { payload: removedApp }: PayloadAction<AppSpec>
         ) {
-            resetProgress(removedApp, state.downloadableApps);
+            const appToBeRemoved = state.downloadableApps.find(
+                equalsSpec(removedApp)
+            );
+            if (appToBeRemoved != null && isWithdrawn(appToBeRemoved)) {
+                state.downloadableApps = state.downloadableApps.filter(
+                    notEqualsSpec(removedApp)
+                );
+            } else {
+                resetProgress(removedApp, state.downloadableApps);
 
-            updateApp(removedApp, state.downloadableApps, app => {
-                app.currentVersion = undefined;
-            });
+                updateApp(removedApp, state.downloadableApps, app => {
+                    app.currentVersion = undefined;
+                });
+            }
         },
 
         // Confirm launch dialog

--- a/src/launcher/features/filter/UpdateAllApps.tsx
+++ b/src/launcher/features/filter/UpdateAllApps.tsx
@@ -7,6 +7,7 @@
 import React from 'react';
 import Button from 'react-bootstrap/Button';
 
+import { isWithdrawn } from '../../../ipc/apps';
 import { useLauncherDispatch, useLauncherSelector } from '../../util/hooks';
 import { updateDownloadableApp } from '../apps/appsEffects';
 import { getUpdatableVisibleApps } from '../apps/appsSlice';
@@ -16,9 +17,11 @@ export default () => {
     const updatableApps = useLauncherSelector(getUpdatableVisibleApps);
 
     const updateAllApps = () =>
-        updatableApps.forEach(app =>
-            dispatch(updateDownloadableApp(app, app.latestVersion))
-        );
+        updatableApps.forEach(app => {
+            if (!isWithdrawn(app)) {
+                dispatch(updateDownloadableApp(app, app.latestVersion));
+            }
+        });
 
     if (updatableApps.length === 0) return null;
 

--- a/src/launcher/features/releaseNotes/ReleaseNotesDialog.tsx
+++ b/src/launcher/features/releaseNotes/ReleaseNotesDialog.tsx
@@ -14,6 +14,7 @@ import {
     DownloadableApp,
     isDownloadable,
     isInstalled,
+    isWithdrawn,
     updateAvailable,
 } from '../../../ipc/apps';
 import { useLauncherDispatch, useLauncherSelector } from '../../util/hooks';
@@ -30,6 +31,10 @@ export default () => {
     const dispatch = useLauncherDispatch();
     const appToDisplay = useLauncherSelector(getReleaseNotesDialog);
     const app = useLauncherSelector(getDownloadableApp(appToDisplay));
+
+    if (app != null && isWithdrawn(app)) {
+        return null;
+    }
 
     const isVisible = appToDisplay.name != null;
 

--- a/src/launcher/features/releaseNotes/ReleaseNotesDialog.tsx
+++ b/src/launcher/features/releaseNotes/ReleaseNotesDialog.tsx
@@ -24,6 +24,7 @@ import { getReleaseNotesDialog, hide } from './releaseNotesDialogSlice';
 
 const canBeInstalledOrUpdated = (app?: App): app is DownloadableApp =>
     app != null &&
+    !isWithdrawn(app) &&
     isDownloadable(app) &&
     (!isInstalled(app) || updateAvailable(app));
 

--- a/src/launcher/util/appCompatibilityWarning.ts
+++ b/src/launcher/util/appCompatibilityWarning.ts
@@ -6,7 +6,7 @@
 
 import semver from 'semver';
 
-import { isDownloadable, LaunchableApp } from '../../ipc/apps';
+import { isDownloadable, isWithdrawn, LaunchableApp } from '../../ipc/apps';
 import mainConfig from './mainConfig';
 import minimalRequiredAppVersions from './minimalRequiredAppVersions';
 
@@ -72,6 +72,7 @@ const checkMinimalRequiredAppVersions: AppCompatibilityChecker = app => {
     const fittingVersionExists =
         minimalRequiredAppVersions[app.name] != null &&
         isDownloadable(app) &&
+        !isWithdrawn(app) &&
         app.latestVersion != null &&
         semver.gte(app.latestVersion, minimalRequiredAppVersions[app.name]);
 


### PR DESCRIPTION
Handle the case, when an app was once downloadable and installed by users but is now removed from the server.

Until now, the app then just disappeared from the launcher, even though it was still installed in the filesystem.

Now, it stays as an installed app, is marked as “not available for download any more”, and can still be opened as normal. After clicking on “Uninstall” it completely disappears.

Implements https://trello.com/c/ugc49yNz/894-fix-keep-installed-apps-visible-when-removed-on-server

## How to check this
- Add the “Test” source https://developer.nordicsemi.com/.pc-tools/nrfconnect-apps/test/apps.json and the “Release Test” source https://developer.nordicsemi.com/.pc-tools/nrfconnect-apps/release-test/apps.json if you do not have it already.
- Install the “Getting Started Assistant” from the “Release Test” source (NB: The “Test” source doesn't have that app).
- Quit the launcher and do a manual modification in your filesystem:
	- Move the folder `pc-nrfconnect-gettingstarted` from `~/.nrfconnect-apps/external/Release\ Test/node_modules/` to `~/.nrfconnect-apps/external/Test/node_modules`
- Start the launcher
	- Before the change: The “Getting Started Assistant” from the “Release Test” source is uninstalled again. There is no “Getting Started Assistant” from the “Test” source.
	- After the change: As before, the “Getting Started Assistant” from the “Release Test” source is uninstalled again. But now there is also a “Getting Started Assistant” from the “Test” source, marked as “not available for download any more”. It can still be opened as normal. After clicking on “Uninstall” it completely disappears. 