### PR TITLE
Extend `open:app` IPC channel

### DIFF
--- a/src/ipc/config.ts
+++ b/src/ipc/config.ts
@@ -14,7 +14,7 @@ export type StartupApp =
     | {
           local: false;
           name: string;
-          sourceName: string;
+          source: string;
       };
 
 export interface Configuration {

--- a/src/ipc/openWindow.ts
+++ b/src/ipc/openWindow.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
+import { OpenAppOptions } from '../main/windows';
 import { LaunchableApp } from './apps';
 import { on, send } from './infrastructure/rendererToMain';
 
@@ -13,7 +14,7 @@ const channel = {
 };
 
 // open app
-type OpenApp = (app: LaunchableApp) => void;
+type OpenApp = (app: LaunchableApp, openAppOptions?: OpenAppOptions) => void;
 
 export const openApp = send<OpenApp>(channel.app);
 export const registerOpenApp = on<OpenApp>(channel.app);

--- a/src/ipc/openWindow.ts
+++ b/src/ipc/openWindow.ts
@@ -4,8 +4,9 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-import { OpenAppOptions } from '../main/windows';
-import { LaunchableApp } from './apps';
+import type { OpenAppOptions } from 'pc-nrfconnect-shared/main';
+
+import { AppSpec } from './apps';
 import { on, send } from './infrastructure/rendererToMain';
 
 const channel = {
@@ -14,7 +15,7 @@ const channel = {
 };
 
 // open app
-type OpenApp = (app: LaunchableApp, openAppOptions?: OpenAppOptions) => void;
+type OpenApp = (app: AppSpec, openAppOptions?: OpenAppOptions) => void;
 
 export const openApp = send<OpenApp>(channel.app);
 export const registerOpenApp = on<OpenApp>(channel.app);

--- a/src/main/browser.ts
+++ b/src/main/browser.ts
@@ -42,11 +42,25 @@ const createSplashScreen = (icon: BrowserWindowOptions['icon']) => {
     return splashScreen;
 };
 
-export const createWindow = (options: BrowserWindowOptions) => {
+const mergeAdditionalArguments = (nonCommandlineArguments: string[]) => {
+    // Index of command line started arguments
     const appArgumentsIndex = process.argv.indexOf('--');
     const additionalArguments =
-        appArgumentsIndex === -1 ? [] : process.argv.slice(appArgumentsIndex);
+        appArgumentsIndex === -1
+            ? []
+            : process.argv.slice(appArgumentsIndex + 1);
 
+    if (appArgumentsIndex === -1 && nonCommandlineArguments.length === 0) {
+        return [];
+    }
+
+    return ['--', ...nonCommandlineArguments, ...additionalArguments];
+};
+
+export const createWindow = (
+    options: BrowserWindowOptions,
+    nonCommandlineArguments: string[] = []
+) => {
     const mergedOptions: BrowserWindowOptions = {
         minWidth: 308,
         minHeight: 499,
@@ -56,7 +70,9 @@ export const createWindow = (options: BrowserWindowOptions) => {
             nodeIntegration: true,
             sandbox: false,
             contextIsolation: false,
-            additionalArguments,
+            additionalArguments: mergeAdditionalArguments(
+                nonCommandlineArguments
+            ),
             backgroundThrottling: false,
         },
         ...options,

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -29,13 +29,13 @@ const getStartupApp = (argv: Argv): StartupApp | undefined => {
         };
     }
 
-    const sourceName = argv.source || OFFICIAL;
+    const source = argv.source || OFFICIAL;
 
     const downloadableApp = argv['open-downloadable-app'];
     if (downloadableApp != null) {
         return {
             local: false,
-            sourceName,
+            source,
             name: downloadableApp,
         };
     }
@@ -49,7 +49,7 @@ const getStartupApp = (argv: Argv): StartupApp | undefined => {
 
         return {
             local: false,
-            sourceName,
+            source,
             name: officialApp,
         };
     }

--- a/src/main/configureElectronApp.ts
+++ b/src/main/configureElectronApp.ts
@@ -29,7 +29,7 @@ const openInitialWindow = async () => {
     if (startupApp.local) {
         await openLocalAppWindow(startupApp.name);
     } else {
-        await openDownloadableAppWindow(startupApp.name, startupApp.sourceName);
+        await openDownloadableAppWindow(startupApp);
     }
 };
 

--- a/src/main/registerIpcHandler.ts
+++ b/src/main/registerIpcHandler.ts
@@ -90,7 +90,7 @@ import {
     setShownStates,
 } from './settings';
 import { addSource, getAllSources, removeSource } from './sources';
-import { getAppDetails, openAppWindow, openLauncherWindow } from './windows';
+import { getAppDetails, openApp, openLauncherWindow } from './windows';
 
 export default () => {
     Store.initRenderer();
@@ -118,7 +118,7 @@ export default () => {
     registerStartUpdate(startUpdate);
     registerCancelUpdate(cancelUpdate);
 
-    registerOpenApp(openAppWindow);
+    registerOpenApp(openApp);
     registerOpenLauncher(openLauncherWindow);
 
     registerDownloadAllAppsJsonFiles(downloadAllAppsJsonFiles);

--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -13,10 +13,12 @@ import {
 } from 'electron';
 import fs from 'fs';
 import path from 'path';
+import { OpenAppOptions } from 'pc-nrfconnect-shared/main';
 
 import { AppDetails } from '../ipc/appDetails';
 import { isInstalled, LaunchableApp } from '../ipc/apps';
 import { registerLauncherWindowFromMain as registerLauncherWindow } from '../ipc/infrastructure/mainToRenderer';
+import { openApp } from '../ipc/openWindow';
 import { getDownloadableApps, getLocalApps } from './apps';
 import * as browser from './browser';
 import bundledJlinkVersion from './bundledJlinkVersion';
@@ -80,7 +82,10 @@ export const hideLauncherWindow = () => {
     launcherWindow?.hide();
 };
 
-export const openAppWindow = (app: LaunchableApp) => {
+export const openAppWindow = (
+    app: LaunchableApp,
+    openAppOptions?: OpenAppOptions
+) => {
     const { lastWindowState } = settings.get();
 
     let { x, y } = lastWindowState;
@@ -101,19 +106,34 @@ export const openAppWindow = (app: LaunchableApp) => {
         }
     }
 
-    const appWindow = browser.createWindow({
-        title: `${app.displayName || app.name} v${app.currentVersion}`,
-        url: `file://${getElectronResourcesDir()}/app.html?appPath=${app.path}`,
-        icon: getAppIcon(app),
-        x,
-        y,
-        width,
-        height,
-        minHeight: 500,
-        minWidth: 760,
-        show: true,
-        backgroundColor: '#fff',
-    });
+    let additionalArguments: string[] = [];
+    if (openAppOptions?.serialPortPath !== undefined) {
+        additionalArguments = [
+            '--deviceSerial',
+            openAppOptions.device.serialNumber,
+            '--comPort',
+            openAppOptions.serialPortPath,
+        ];
+    }
+
+    const appWindow = browser.createWindow(
+        {
+            title: `${app.displayName || app.name} v${app.currentVersion}`,
+            url: `file://${getElectronResourcesDir()}/app.html?appPath=${
+                app.path
+            }`,
+            icon: getAppIcon(app),
+            x,
+            y,
+            width,
+            height,
+            minHeight: 500,
+            minWidth: 760,
+            show: true,
+            backgroundColor: '#fff',
+        },
+        additionalArguments
+    );
 
     appWindows.push({
         browserWindow: appWindow,


### PR DESCRIPTION
## Motivation

Extend the IPC call with channel `open:app`, in order to also provide a device and serial port to open automatically when the app is opened. One use case is Cellular Monitor, where we want to open Serial Terminal, and to avoid having to setup the device, and the serial port, we want to simply open the Terminal and have it ready to read and write to the correct serial port.

### What to think about

- The PR bumps several versions of pc-nrfconnect-shared, from `v6.18.1` to `v13`
- The `lockFileVersion` is now `v3` (package-lock.json). The npm version used was `v9.5.0`, and the related node version was `v18.14.2`. The motivation to bump npm version was that the npm install did not work on pc-nrfconnect-shared, and the only reason I found was that the git install was incompatible with the version of npm, and bumping the npm version seemed to work immediately.

### Particular feedback desire

- I would like feedback on the changelog wording, and if it is necessary to mention at all?