### PR TITLE
feat: add hot-reloading for apps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
                 "fs-extra": "9.0.0",
                 "lodash.merge": "4.6.2",
                 "mustache": "4.0.1",
+                "node-watch": "^0.7.3",
                 "react": "16.14.0",
                 "serialport": "10.5.0",
                 "shasum": "1.0.2",
@@ -13425,6 +13426,14 @@
             "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.10.tgz",
             "integrity": "sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w==",
             "dev": true
+        },
+        "node_modules/node-watch": {
+            "version": "0.7.3",
+            "resolved": "https://registry.npmjs.org/node-watch/-/node-watch-0.7.3.tgz",
+            "integrity": "sha512-3l4E8uMPY1HdMMryPRUAl+oIHtXtyiTlIiESNSVSNxcPfzAFzeTbXFQkZfAwBbo0B1qMSG8nUABx+Gd+YrbKrQ==",
+            "engines": {
+                "node": ">=6"
+            }
         },
         "node_modules/noop-logger": {
             "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
         "fs-extra": "9.0.0",
         "lodash.merge": "4.6.2",
         "mustache": "4.0.1",
+        "node-watch": "^0.7.3",
         "react": "16.14.0",
         "serialport": "10.5.0",
         "shasum": "1.0.2",

--- a/src/app/index.jsx
+++ b/src/app/index.jsx
@@ -10,6 +10,7 @@ import './module-loader';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { dialog } from '@electron/remote';
+import nodeWatch from 'node-watch';
 
 import initApp from './initApp';
 
@@ -20,6 +21,15 @@ const render = App => {
     ReactDOM.render(<App />, document.getElementById('webapp'));
 };
 
+const mountApp = () => {
+    try {
+        const app = initApp(appPath);
+        render(app);
+    } catch (error) {
+        showLoadingError(error);
+    }
+};
+
 const showLoadingError = error => {
     console.error(error);
     dialog.showMessageBox({
@@ -28,9 +38,21 @@ const showLoadingError = error => {
     });
 };
 
-try {
-    const app = initApp(appPath);
-    render(app);
-} catch (error) {
-    showLoadingError(error);
+mountApp();
+
+if (process.env.NODE_ENV === 'development') {
+    nodeWatch(`${appPath}/dist/bundle.js`, evt => {
+        console.log('Hot reloading app due to bundle.js changes', evt);
+        mountApp();
+    });
+
+    nodeWatch(`${appPath}/dist/bundle.css`, () => {
+        console.log('Hot reloading app due to bundle.css changes');
+        const cssNode = [...document.head.children].find(node =>
+            node.href?.includes('bundle.css')
+        );
+        if (cssNode) {
+            cssNode.href = `bundle.css?${Date.now()}`;
+        }
+    });
 }


### PR DESCRIPTION
This is done through filewatchers watching the bundle.js and bundle.css. 
A change to the bundle.js remounts the `App` component. 
A change in the bundle.css simply updates the stylesheet node with a new querystring to avoid reusing cached versions.