### PR TITLE
Offer update for re-released apps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
                 "@nordicsemiconductor/nrf-device-lib-js": "0.6.5",
                 "axios": "0.22.0",
                 "chmodr": "1.2.0",
+                "electron-store": "8.1.0",
                 "electron-updater": "4.3.1",
                 "fs-extra": "9.0.0",
                 "lodash.merge": "4.6.2",
@@ -3947,7 +3948,6 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
             "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
-            "dev": true,
             "dependencies": {
                 "ajv": "^8.0.0"
             },
@@ -3964,7 +3964,6 @@
             "version": "8.12.0",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
             "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-            "dev": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "json-schema-traverse": "^1.0.0",
@@ -3979,8 +3978,7 @@
         "node_modules/ajv-formats/node_modules/json-schema-traverse": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-            "dev": true
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
         },
         "node_modules/ajv-keywords": {
             "version": "3.5.2",
@@ -4575,7 +4573,6 @@
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/atomically/-/atomically-1.7.0.tgz",
             "integrity": "sha512-Xcz9l0z7y9yQ9rdDaxlmaI4uJHf/T8g9hOEzJcsEqX2SjCj4J20uK7+ldkDHMbpJDK76wF7xEIgxc/vSlsfw5w==",
-            "dev": true,
             "engines": {
                 "node": ">=10.12.0"
             }
@@ -5812,7 +5809,6 @@
             "version": "10.2.0",
             "resolved": "https://registry.npmjs.org/conf/-/conf-10.2.0.tgz",
             "integrity": "sha512-8fLl9F04EJqjSqH+QjITQfJF8BrOVaYr1jewVgSRAEWePfxT0sku4w2hrGQ60BC/TNLGQ2pgxNlTbWQmMPFvXg==",
-            "dev": true,
             "dependencies": {
                 "ajv": "^8.6.3",
                 "ajv-formats": "^2.1.1",
@@ -5836,7 +5832,6 @@
             "version": "8.12.0",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
             "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-            "dev": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "json-schema-traverse": "^1.0.0",
@@ -5851,14 +5846,12 @@
         "node_modules/conf/node_modules/json-schema-traverse": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-            "dev": true
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
         },
         "node_modules/conf/node_modules/semver": {
             "version": "7.4.0",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.4.0.tgz",
             "integrity": "sha512-RgOxM8Mw+7Zus0+zcLEUn8+JfoLpj/huFTItQy2hsM4khuC1HYRDp0cU482Ewn/Fcy6bCjufD8vAj7voC66KQw==",
-            "dev": true,
             "dependencies": {
                 "lru-cache": "^6.0.0"
             },
@@ -6162,7 +6155,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/debounce-fn/-/debounce-fn-4.0.0.tgz",
             "integrity": "sha512-8pYCQiL9Xdcg0UPSD3d+0KMlOjp+KGU5EPwYddgzQ7DATsg4fuUDjQtsYLmWjnk2obnNHgV3vE2Y4jejSOJVBQ==",
-            "dev": true,
             "dependencies": {
                 "mimic-fn": "^3.0.0"
             },
@@ -6612,7 +6604,6 @@
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-6.0.1.tgz",
             "integrity": "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==",
-            "dev": true,
             "dependencies": {
                 "is-obj": "^2.0.0"
             },
@@ -7060,7 +7051,6 @@
             "version": "8.1.0",
             "resolved": "https://registry.npmjs.org/electron-store/-/electron-store-8.1.0.tgz",
             "integrity": "sha512-2clHg/juMjOH0GT9cQ6qtmIvK183B39ZXR0bUoPwKwYHJsEF3quqyDzMFUAu+0OP8ijmN2CbPRAelhNbWUbzwA==",
-            "dev": true,
             "dependencies": {
                 "conf": "^10.2.0",
                 "type-fest": "^2.17.0"
@@ -10210,7 +10200,6 @@
         },
         "node_modules/is-obj": {
             "version": "2.0.0",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -12034,8 +12023,7 @@
         "node_modules/json-schema-typed": {
             "version": "7.0.3",
             "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-7.0.3.tgz",
-            "integrity": "sha512-7DE8mpG+/fVw+dTpjbxnx47TaMnDfOI1jwft9g1VybltZCduyRQPJPvc+zzKY9WPHxhPWczyFuYa6I8Mw4iU5A==",
-            "dev": true
+            "integrity": "sha512-7DE8mpG+/fVw+dTpjbxnx47TaMnDfOI1jwft9g1VybltZCduyRQPJPvc+zzKY9WPHxhPWczyFuYa6I8Mw4iU5A=="
         },
         "node_modules/json-stable-stringify": {
             "version": "0.0.1",
@@ -12992,7 +12980,6 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-3.1.0.tgz",
             "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==",
-            "dev": true,
             "engines": {
                 "node": ">=8"
             }
@@ -13822,7 +13809,6 @@
             "version": "5.1.2",
             "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
             "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-            "dev": true,
             "dependencies": {
                 "mimic-fn": "^2.1.0"
             },
@@ -13837,7 +13823,6 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
             "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-            "dev": true,
             "engines": {
                 "node": ">=6"
             }
@@ -14439,7 +14424,6 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
             "integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
-            "dev": true,
             "dependencies": {
                 "find-up": "^3.0.0"
             },
@@ -14451,7 +14435,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
             "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-            "dev": true,
             "dependencies": {
                 "locate-path": "^3.0.0"
             },
@@ -14463,7 +14446,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
             "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-            "dev": true,
             "dependencies": {
                 "p-locate": "^3.0.0",
                 "path-exists": "^3.0.0"
@@ -14476,7 +14458,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
             "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-            "dev": true,
             "dependencies": {
                 "p-limit": "^2.0.0"
             },
@@ -14488,7 +14469,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
             "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
-            "dev": true,
             "engines": {
                 "node": ">=4"
             }
@@ -16590,7 +16570,6 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
             "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-            "dev": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -18297,7 +18276,6 @@
             "version": "2.19.0",
             "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
             "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-            "dev": true,
             "engines": {
                 "node": ">=12.20"
             },

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
         "@nordicsemiconductor/nrf-device-lib-js": "0.6.5",
         "axios": "0.22.0",
         "chmodr": "1.2.0",
+        "electron-store": "8.1.0",
         "electron-updater": "4.3.1",
         "fs-extra": "9.0.0",
         "lodash.merge": "4.6.2",

--- a/src/ipc/apps.ts
+++ b/src/ipc/apps.ts
@@ -81,11 +81,23 @@ export const isInstalled = (app?: App): app is LaunchableApp =>
 export const isWithdrawn = (app?: App): app is WithdrawnApp =>
     isDownloadable(app) && app.isWithdrawn;
 
+const latestVersionHasDifferentChecksum = (app: InstalledDownloadableApp) => {
+    const shaOfLatest = app.versions?.[app.latestVersion]?.shasum;
+    const shaOfInstalled = app.installed.shasum;
+
+    return (
+        shaOfLatest != null &&
+        shaOfInstalled != null &&
+        shaOfInstalled !== shaOfLatest
+    );
+};
+
 export const isUpdatable = (app?: App): app is InstalledDownloadableApp =>
     !isWithdrawn(app) &&
     isInstalled(app) &&
     isDownloadable(app) &&
-    app.currentVersion !== app.latestVersion;
+    (app.currentVersion !== app.latestVersion ||
+        latestVersionHasDifferentChecksum(app));
 
 const channel = {
     downloadLatestAppInfos: 'apps:download-latest-app-infos',


### PR DESCRIPTION
Implement https://trello.com/c/i7TRarLY: For officially released apps, the SHA must never changed because we never re-release the same version. But for test releases we do that. And until now, that meant that you do not get a notification that a test release has changed. But now the SHA will change when a new test release is published, which makes it easier for people testing releases.

To test this, you can e.g. go to an app, build and publish it once to the test source source with this:
```
npm run build:prod && npm  run  nordic-publish -- -s test
```
Install the app in the launcher.

Then append a newline to `package.json` and build and publish it again:
```
echo >> package.json && npm run build:prod && npm  run  nordic-publish -- -s test
```
Restart the launcher and it will show an update for the app with version number staying the same.