### PR TITLE
Enhance override for wrong signature

### DIFF
--- a/src/app/device-lib-js.ts
+++ b/src/app/device-lib-js.ts
@@ -11,8 +11,8 @@ const hotplug = new Proxy(deviceLib.startHotplugEvents, {
         // @ts-expect-error Typing of argArray too weak
         const id = target(...argArray);
         window.addEventListener('beforeunload', () => {
-            // todo: update types on next device-lib update
-            deviceLib.stopHotplugEvents(id as unknown as number);
+            // @ts-expect-error Signature is wrong, fixed in NordicPlayground/nrf-device-lib-js#185
+            deviceLib.stopHotplugEvents(id);
         });
 
         return id;
@@ -24,8 +24,8 @@ const logEvents = new Proxy(deviceLib.startLogEvents, {
         // @ts-expect-error Typing of argArray too weak
         const id = target(...argArray);
         window.addEventListener('beforeunload', () => {
-            // todo: update types on next device-lib update
-            deviceLib.stopLogEvents(id as unknown as number);
+            // @ts-expect-error Signature is wrong, fixed in NordicPlayground/nrf-device-lib-js#185
+            deviceLib.stopLogEvents(id);
         });
 
         return id;


### PR DESCRIPTION
With `id as unknown as number` we have to remember to remove it when it is fixed upstream. With `@ts-expect-error` the type checker gives us an error as soon as it is fixed upstream and we have to remove the override.
