### PR TITLE
Show latest app versions on top

### DIFF
--- a/src/launcher/features/apps/InstallOtherVersionDialog.tsx
+++ b/src/launcher/features/apps/InstallOtherVersionDialog.tsx
@@ -7,7 +7,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import Dropdown from 'react-bootstrap/Dropdown';
 import { ConfirmationDialog } from 'pc-nrfconnect-shared';
-import { sort } from 'semver';
+import { rsort } from 'semver';
 
 import { DownloadableApp } from '../../../ipc/apps';
 import { useLauncherDispatch, useLauncherSelector } from '../../util/hooks';
@@ -27,7 +27,7 @@ const VersionList = ({
     app?: DownloadableApp;
 }) => {
     const availableVersions = useMemo(
-        () => sort(Object.keys(app?.versions ?? {})),
+        () => rsort(Object.keys(app?.versions ?? {})),
         [app]
     );
 


### PR DESCRIPTION
When selecting an older version of an app to install: Show latest app versions on top.

![image](https://user-images.githubusercontent.com/260705/234040109-4229e893-895e-4fb2-8fb6-10f4acd500a9.png)
