### PR TITLE
Enhance installing other versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
         "": {
             "name": "nrfconnect",
             "version": "4.1.0-pre1",
-            "hasInstallScript": true,
             "license": "Proprietary",
             "dependencies": {
                 "@electron/remote": "2.0.8",
@@ -42,7 +41,7 @@
                 "electron-builder": "^22.14.13",
                 "electron-devtools-installer": "3.2.0",
                 "electron-notarize": "0.3.0",
-                "pc-nrfconnect-shared": "github:NordicSemiconductor/pc-nrfconnect-shared#v32",
+                "pc-nrfconnect-shared": "github:NordicSemiconductor/pc-nrfconnect-shared#v36",
                 "playwright": "^1.16.3",
                 "xvfb-maybe": "0.2.1"
             }
@@ -928,9 +927,9 @@
             }
         },
         "node_modules/@esbuild/android-arm": {
-            "version": "0.17.15",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.15.tgz",
-            "integrity": "sha512-sRSOVlLawAktpMvDyJIkdLI/c/kdRTOqo8t6ImVxg8yT7LQDUYV5Rp2FKeEosLr6ZCja9UjYAzyRSxGteSJPYg==",
+            "version": "0.17.18",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.18.tgz",
+            "integrity": "sha512-EmwL+vUBZJ7mhFCs5lA4ZimpUH3WMAoqvOIYhVQwdIgSpHC8ImHdsRyhHAVxpDYUSm0lWvd63z0XH1IlImS2Qw==",
             "cpu": [
                 "arm"
             ],
@@ -944,9 +943,9 @@
             }
         },
         "node_modules/@esbuild/android-arm64": {
-            "version": "0.17.15",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.15.tgz",
-            "integrity": "sha512-0kOB6Y7Br3KDVgHeg8PRcvfLkq+AccreK///B4Z6fNZGr/tNHX0z2VywCc7PTeWp+bPvjA5WMvNXltHw5QjAIA==",
+            "version": "0.17.18",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.18.tgz",
+            "integrity": "sha512-/iq0aK0eeHgSC3z55ucMAHO05OIqmQehiGay8eP5l/5l+iEr4EIbh4/MI8xD9qRFjqzgkc0JkX0LculNC9mXBw==",
             "cpu": [
                 "arm64"
             ],
@@ -960,9 +959,9 @@
             }
         },
         "node_modules/@esbuild/android-x64": {
-            "version": "0.17.15",
-            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.15.tgz",
-            "integrity": "sha512-MzDqnNajQZ63YkaUWVl9uuhcWyEyh69HGpMIrf+acR4otMkfLJ4sUCxqwbCyPGicE9dVlrysI3lMcDBjGiBBcQ==",
+            "version": "0.17.18",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.18.tgz",
+            "integrity": "sha512-x+0efYNBF3NPW2Xc5bFOSFW7tTXdAcpfEg2nXmxegm4mJuVeS+i109m/7HMiOQ6M12aVGGFlqJX3RhNdYM2lWg==",
             "cpu": [
                 "x64"
             ],
@@ -976,9 +975,9 @@
             }
         },
         "node_modules/@esbuild/darwin-arm64": {
-            "version": "0.17.15",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.15.tgz",
-            "integrity": "sha512-7siLjBc88Z4+6qkMDxPT2juf2e8SJxmsbNVKFY2ifWCDT72v5YJz9arlvBw5oB4W/e61H1+HDB/jnu8nNg0rLA==",
+            "version": "0.17.18",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.18.tgz",
+            "integrity": "sha512-6tY+djEAdF48M1ONWnQb1C+6LiXrKjmqjzPNPWXhu/GzOHTHX2nh8Mo2ZAmBFg0kIodHhciEgUBtcYCAIjGbjQ==",
             "cpu": [
                 "arm64"
             ],
@@ -992,9 +991,9 @@
             }
         },
         "node_modules/@esbuild/darwin-x64": {
-            "version": "0.17.15",
-            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.15.tgz",
-            "integrity": "sha512-NbImBas2rXwYI52BOKTW342Tm3LTeVlaOQ4QPZ7XuWNKiO226DisFk/RyPk3T0CKZkKMuU69yOvlapJEmax7cg==",
+            "version": "0.17.18",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.18.tgz",
+            "integrity": "sha512-Qq84ykvLvya3dO49wVC9FFCNUfSrQJLbxhoQk/TE1r6MjHo3sFF2tlJCwMjhkBVq3/ahUisj7+EpRSz0/+8+9A==",
             "cpu": [
                 "x64"
             ],
@@ -1008,9 +1007,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-arm64": {
-            "version": "0.17.15",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.15.tgz",
-            "integrity": "sha512-Xk9xMDjBVG6CfgoqlVczHAdJnCs0/oeFOspFap5NkYAmRCT2qTn1vJWA2f419iMtsHSLm+O8B6SLV/HlY5cYKg==",
+            "version": "0.17.18",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.18.tgz",
+            "integrity": "sha512-fw/ZfxfAzuHfaQeMDhbzxp9mc+mHn1Y94VDHFHjGvt2Uxl10mT4CDavHm+/L9KG441t1QdABqkVYwakMUeyLRA==",
             "cpu": [
                 "arm64"
             ],
@@ -1024,9 +1023,9 @@
             }
         },
         "node_modules/@esbuild/freebsd-x64": {
-            "version": "0.17.15",
-            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.15.tgz",
-            "integrity": "sha512-3TWAnnEOdclvb2pnfsTWtdwthPfOz7qAfcwDLcfZyGJwm1SRZIMOeB5FODVhnM93mFSPsHB9b/PmxNNbSnd0RQ==",
+            "version": "0.17.18",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.18.tgz",
+            "integrity": "sha512-FQFbRtTaEi8ZBi/A6kxOC0V0E9B/97vPdYjY9NdawyLd4Qk5VD5g2pbWN2VR1c0xhzcJm74HWpObPszWC+qTew==",
             "cpu": [
                 "x64"
             ],
@@ -1040,9 +1039,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm": {
-            "version": "0.17.15",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.15.tgz",
-            "integrity": "sha512-MLTgiXWEMAMr8nmS9Gigx43zPRmEfeBfGCwxFQEMgJ5MC53QKajaclW6XDPjwJvhbebv+RzK05TQjvH3/aM4Xw==",
+            "version": "0.17.18",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.18.tgz",
+            "integrity": "sha512-jW+UCM40LzHcouIaqv3e/oRs0JM76JfhHjCavPxMUti7VAPh8CaGSlS7cmyrdpzSk7A+8f0hiedHqr/LMnfijg==",
             "cpu": [
                 "arm"
             ],
@@ -1056,9 +1055,9 @@
             }
         },
         "node_modules/@esbuild/linux-arm64": {
-            "version": "0.17.15",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.15.tgz",
-            "integrity": "sha512-T0MVnYw9KT6b83/SqyznTs/3Jg2ODWrZfNccg11XjDehIved2oQfrX/wVuev9N936BpMRaTR9I1J0tdGgUgpJA==",
+            "version": "0.17.18",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.18.tgz",
+            "integrity": "sha512-R7pZvQZFOY2sxUG8P6A21eq6q+eBv7JPQYIybHVf1XkQYC+lT7nDBdC7wWKTrbvMXKRaGudp/dzZCwL/863mZQ==",
             "cpu": [
                 "arm64"
             ],
@@ -1072,9 +1071,9 @@
             }
         },
         "node_modules/@esbuild/linux-ia32": {
-            "version": "0.17.15",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.15.tgz",
-            "integrity": "sha512-wp02sHs015T23zsQtU4Cj57WiteiuASHlD7rXjKUyAGYzlOKDAjqK6bk5dMi2QEl/KVOcsjwL36kD+WW7vJt8Q==",
+            "version": "0.17.18",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.18.tgz",
+            "integrity": "sha512-ygIMc3I7wxgXIxk6j3V00VlABIjq260i967Cp9BNAk5pOOpIXmd1RFQJQX9Io7KRsthDrQYrtcx7QCof4o3ZoQ==",
             "cpu": [
                 "ia32"
             ],
@@ -1088,9 +1087,9 @@
             }
         },
         "node_modules/@esbuild/linux-loong64": {
-            "version": "0.17.15",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.15.tgz",
-            "integrity": "sha512-k7FsUJjGGSxwnBmMh8d7IbObWu+sF/qbwc+xKZkBe/lTAF16RqxRCnNHA7QTd3oS2AfGBAnHlXL67shV5bBThQ==",
+            "version": "0.17.18",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.18.tgz",
+            "integrity": "sha512-bvPG+MyFs5ZlwYclCG1D744oHk1Pv7j8psF5TfYx7otCVmcJsEXgFEhQkbhNW8otDHL1a2KDINW20cfCgnzgMQ==",
             "cpu": [
                 "loong64"
             ],
@@ -1104,9 +1103,9 @@
             }
         },
         "node_modules/@esbuild/linux-mips64el": {
-            "version": "0.17.15",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.15.tgz",
-            "integrity": "sha512-ZLWk6czDdog+Q9kE/Jfbilu24vEe/iW/Sj2d8EVsmiixQ1rM2RKH2n36qfxK4e8tVcaXkvuV3mU5zTZviE+NVQ==",
+            "version": "0.17.18",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.18.tgz",
+            "integrity": "sha512-oVqckATOAGuiUOa6wr8TXaVPSa+6IwVJrGidmNZS1cZVx0HqkTMkqFGD2HIx9H1RvOwFeWYdaYbdY6B89KUMxA==",
             "cpu": [
                 "mips64el"
             ],
@@ -1120,9 +1119,9 @@
             }
         },
         "node_modules/@esbuild/linux-ppc64": {
-            "version": "0.17.15",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.15.tgz",
-            "integrity": "sha512-mY6dPkIRAiFHRsGfOYZC8Q9rmr8vOBZBme0/j15zFUKM99d4ILY4WpOC7i/LqoY+RE7KaMaSfvY8CqjJtuO4xg==",
+            "version": "0.17.18",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.18.tgz",
+            "integrity": "sha512-3dLlQO+b/LnQNxgH4l9rqa2/IwRJVN9u/bK63FhOPB4xqiRqlQAU0qDU3JJuf0BmaH0yytTBdoSBHrb2jqc5qQ==",
             "cpu": [
                 "ppc64"
             ],
@@ -1136,9 +1135,9 @@
             }
         },
         "node_modules/@esbuild/linux-riscv64": {
-            "version": "0.17.15",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.15.tgz",
-            "integrity": "sha512-EcyUtxffdDtWjjwIH8sKzpDRLcVtqANooMNASO59y+xmqqRYBBM7xVLQhqF7nksIbm2yHABptoioS9RAbVMWVA==",
+            "version": "0.17.18",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.18.tgz",
+            "integrity": "sha512-/x7leOyDPjZV3TcsdfrSI107zItVnsX1q2nho7hbbQoKnmoeUWjs+08rKKt4AUXju7+3aRZSsKrJtaRmsdL1xA==",
             "cpu": [
                 "riscv64"
             ],
@@ -1152,9 +1151,9 @@
             }
         },
         "node_modules/@esbuild/linux-s390x": {
-            "version": "0.17.15",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.15.tgz",
-            "integrity": "sha512-BuS6Jx/ezxFuHxgsfvz7T4g4YlVrmCmg7UAwboeyNNg0OzNzKsIZXpr3Sb/ZREDXWgt48RO4UQRDBxJN3B9Rbg==",
+            "version": "0.17.18",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.18.tgz",
+            "integrity": "sha512-cX0I8Q9xQkL/6F5zWdYmVf5JSQt+ZfZD2bJudZrWD+4mnUvoZ3TDDXtDX2mUaq6upMFv9FlfIh4Gfun0tbGzuw==",
             "cpu": [
                 "s390x"
             ],
@@ -1168,9 +1167,9 @@
             }
         },
         "node_modules/@esbuild/linux-x64": {
-            "version": "0.17.15",
-            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.15.tgz",
-            "integrity": "sha512-JsdS0EgEViwuKsw5tiJQo9UdQdUJYuB+Mf6HxtJSPN35vez1hlrNb1KajvKWF5Sa35j17+rW1ECEO9iNrIXbNg==",
+            "version": "0.17.18",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.18.tgz",
+            "integrity": "sha512-66RmRsPlYy4jFl0vG80GcNRdirx4nVWAzJmXkevgphP1qf4dsLQCpSKGM3DUQCojwU1hnepI63gNZdrr02wHUA==",
             "cpu": [
                 "x64"
             ],
@@ -1184,9 +1183,9 @@
             }
         },
         "node_modules/@esbuild/netbsd-x64": {
-            "version": "0.17.15",
-            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.15.tgz",
-            "integrity": "sha512-R6fKjtUysYGym6uXf6qyNephVUQAGtf3n2RCsOST/neIwPqRWcnc3ogcielOd6pT+J0RDR1RGcy0ZY7d3uHVLA==",
+            "version": "0.17.18",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.18.tgz",
+            "integrity": "sha512-95IRY7mI2yrkLlTLb1gpDxdC5WLC5mZDi+kA9dmM5XAGxCME0F8i4bYH4jZreaJ6lIZ0B8hTrweqG1fUyW7jbg==",
             "cpu": [
                 "x64"
             ],
@@ -1200,9 +1199,9 @@
             }
         },
         "node_modules/@esbuild/openbsd-x64": {
-            "version": "0.17.15",
-            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.15.tgz",
-            "integrity": "sha512-mVD4PGc26b8PI60QaPUltYKeSX0wxuy0AltC+WCTFwvKCq2+OgLP4+fFd+hZXzO2xW1HPKcytZBdjqL6FQFa7w==",
+            "version": "0.17.18",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.18.tgz",
+            "integrity": "sha512-WevVOgcng+8hSZ4Q3BKL3n1xTv5H6Nb53cBrtzzEjDbbnOmucEVcZeGCsCOi9bAOcDYEeBZbD2SJNBxlfP3qiA==",
             "cpu": [
                 "x64"
             ],
@@ -1216,9 +1215,9 @@
             }
         },
         "node_modules/@esbuild/sunos-x64": {
-            "version": "0.17.15",
-            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.15.tgz",
-            "integrity": "sha512-U6tYPovOkw3459t2CBwGcFYfFRjivcJJc1WC8Q3funIwX8x4fP+R6xL/QuTPNGOblbq/EUDxj9GU+dWKX0oWlQ==",
+            "version": "0.17.18",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.18.tgz",
+            "integrity": "sha512-Rzf4QfQagnwhQXVBS3BYUlxmEbcV7MY+BH5vfDZekU5eYpcffHSyjU8T0xucKVuOcdCsMo+Ur5wmgQJH2GfNrg==",
             "cpu": [
                 "x64"
             ],
@@ -1232,9 +1231,9 @@
             }
         },
         "node_modules/@esbuild/win32-arm64": {
-            "version": "0.17.15",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.15.tgz",
-            "integrity": "sha512-W+Z5F++wgKAleDABemiyXVnzXgvRFs+GVKThSI+mGgleLWluv0D7Diz4oQpgdpNzh4i2nNDzQtWbjJiqutRp6Q==",
+            "version": "0.17.18",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.18.tgz",
+            "integrity": "sha512-Kb3Ko/KKaWhjeAm2YoT/cNZaHaD1Yk/pa3FTsmqo9uFh1D1Rfco7BBLIPdDOozrObj2sahslFuAQGvWbgWldAg==",
             "cpu": [
                 "arm64"
             ],
@@ -1248,9 +1247,9 @@
             }
         },
         "node_modules/@esbuild/win32-ia32": {
-            "version": "0.17.15",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.15.tgz",
-            "integrity": "sha512-Muz/+uGgheShKGqSVS1KsHtCyEzcdOn/W/Xbh6H91Etm+wiIfwZaBn1W58MeGtfI8WA961YMHFYTthBdQs4t+w==",
+            "version": "0.17.18",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.18.tgz",
+            "integrity": "sha512-0/xUMIdkVHwkvxfbd5+lfG7mHOf2FRrxNbPiKWg9C4fFrB8H0guClmaM3BFiRUYrznVoyxTIyC/Ou2B7QQSwmw==",
             "cpu": [
                 "ia32"
             ],
@@ -1264,9 +1263,9 @@
             }
         },
         "node_modules/@esbuild/win32-x64": {
-            "version": "0.17.15",
-            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.15.tgz",
-            "integrity": "sha512-DjDa9ywLUUmjhV2Y9wUTIF+1XsmuFGvZoCmOWkli1XcNAh5t25cc7fgsCx4Zi/Uurep3TTLyDiKATgGEg61pkA==",
+            "version": "0.17.18",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.18.tgz",
+            "integrity": "sha512-qU25Ma1I3NqTSHJUOKi9sAH1/Mzuvlke0ioMJRthLXKm7JiSKVwFghlGbDLOO2sARECGhja4xYfRAZNPAkooYg==",
             "cpu": [
                 "x64"
             ],
@@ -7430,9 +7429,9 @@
             }
         },
         "node_modules/esbuild": {
-            "version": "0.17.15",
-            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.15.tgz",
-            "integrity": "sha512-LBUV2VsUIc/iD9ME75qhT4aJj0r75abCVS0jakhFzOtR7TQsqQA5w0tZ+KTKnwl3kXE0MhskNdHDh/I5aCR1Zw==",
+            "version": "0.17.18",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.18.tgz",
+            "integrity": "sha512-z1lix43jBs6UKjcZVKOw2xx69ffE2aG0PygLL5qJ9OS/gy0Ewd1gW/PUQIOIQGXBHWNywSc0floSKoMFF8aK2w==",
             "dev": true,
             "hasInstallScript": true,
             "bin": {
@@ -7442,41 +7441,41 @@
                 "node": ">=12"
             },
             "optionalDependencies": {
-                "@esbuild/android-arm": "0.17.15",
-                "@esbuild/android-arm64": "0.17.15",
-                "@esbuild/android-x64": "0.17.15",
-                "@esbuild/darwin-arm64": "0.17.15",
-                "@esbuild/darwin-x64": "0.17.15",
-                "@esbuild/freebsd-arm64": "0.17.15",
-                "@esbuild/freebsd-x64": "0.17.15",
-                "@esbuild/linux-arm": "0.17.15",
-                "@esbuild/linux-arm64": "0.17.15",
-                "@esbuild/linux-ia32": "0.17.15",
-                "@esbuild/linux-loong64": "0.17.15",
-                "@esbuild/linux-mips64el": "0.17.15",
-                "@esbuild/linux-ppc64": "0.17.15",
-                "@esbuild/linux-riscv64": "0.17.15",
-                "@esbuild/linux-s390x": "0.17.15",
-                "@esbuild/linux-x64": "0.17.15",
-                "@esbuild/netbsd-x64": "0.17.15",
-                "@esbuild/openbsd-x64": "0.17.15",
-                "@esbuild/sunos-x64": "0.17.15",
-                "@esbuild/win32-arm64": "0.17.15",
-                "@esbuild/win32-ia32": "0.17.15",
-                "@esbuild/win32-x64": "0.17.15"
+                "@esbuild/android-arm": "0.17.18",
+                "@esbuild/android-arm64": "0.17.18",
+                "@esbuild/android-x64": "0.17.18",
+                "@esbuild/darwin-arm64": "0.17.18",
+                "@esbuild/darwin-x64": "0.17.18",
+                "@esbuild/freebsd-arm64": "0.17.18",
+                "@esbuild/freebsd-x64": "0.17.18",
+                "@esbuild/linux-arm": "0.17.18",
+                "@esbuild/linux-arm64": "0.17.18",
+                "@esbuild/linux-ia32": "0.17.18",
+                "@esbuild/linux-loong64": "0.17.18",
+                "@esbuild/linux-mips64el": "0.17.18",
+                "@esbuild/linux-ppc64": "0.17.18",
+                "@esbuild/linux-riscv64": "0.17.18",
+                "@esbuild/linux-s390x": "0.17.18",
+                "@esbuild/linux-x64": "0.17.18",
+                "@esbuild/netbsd-x64": "0.17.18",
+                "@esbuild/openbsd-x64": "0.17.18",
+                "@esbuild/sunos-x64": "0.17.18",
+                "@esbuild/win32-arm64": "0.17.18",
+                "@esbuild/win32-ia32": "0.17.18",
+                "@esbuild/win32-x64": "0.17.18"
             }
         },
         "node_modules/esbuild-sass-plugin": {
-            "version": "2.8.0",
-            "resolved": "https://registry.npmjs.org/esbuild-sass-plugin/-/esbuild-sass-plugin-2.8.0.tgz",
-            "integrity": "sha512-PYDw/r+0lAOBjP4CDjkRRrYDtSta4kO0+p2Ofm4n15hbyhAsxa7hQpY8fY6Ja6VAzzC//VA9F1ki5L99apjLCA==",
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/esbuild-sass-plugin/-/esbuild-sass-plugin-2.9.0.tgz",
+            "integrity": "sha512-D7c8Ub+C4RfaqhOoo9EEWprYmP5ZCmpmcodmYDtpvCfPZLgsSbLaLHPXdul4TUWUMH5eJ6POw+aes/s42ffwrA==",
             "dev": true,
             "dependencies": {
-                "resolve": "^1.22.1",
-                "sass": "^1.59.3"
+                "resolve": "^1.22.2",
+                "sass": "^1.62.0"
             },
             "peerDependencies": {
-                "esbuild": "^0.17.12"
+                "esbuild": "^0.17.17"
             }
         },
         "node_modules/escalade": {
@@ -7897,19 +7896,19 @@
             }
         },
         "node_modules/eslint-plugin-prettier": {
-            "version": "3.4.1",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.1.tgz",
-            "integrity": "sha512-htg25EUYUeIhKHXjOinK4BgCcDwtLHjqaxCDsMy5nbnUMkKFvIhMVCp+5GFUXQ4Nr8lBsPqtGAqBenbpFqAA2g==",
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz",
+            "integrity": "sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==",
             "dev": true,
             "dependencies": {
                 "prettier-linter-helpers": "^1.0.0"
             },
             "engines": {
-                "node": ">=6.0.0"
+                "node": ">=12.0.0"
             },
             "peerDependencies": {
-                "eslint": ">=5.0.0",
-                "prettier": ">=1.13.0"
+                "eslint": ">=7.28.0",
+                "prettier": ">=2.0.0"
             },
             "peerDependenciesMeta": {
                 "eslint-config-prettier": {
@@ -14093,8 +14092,8 @@
             }
         },
         "node_modules/pc-nrfconnect-shared": {
-            "version": "32.0.0",
-            "resolved": "git+ssh://git@github.com/NordicSemiconductor/pc-nrfconnect-shared.git#2fb621787b56181bb1210250d2ce243b38e418eb",
+            "version": "36.0.0",
+            "resolved": "git+ssh://git@github.com/NordicSemiconductor/pc-nrfconnect-shared.git#42985301320c814de63813eeb6d6527db1090569",
             "dev": true,
             "hasInstallScript": true,
             "license": "ISC",
@@ -14135,8 +14134,8 @@
                 "enzyme": "3.11.0",
                 "enzyme-adapter-react-16": "1.15.7",
                 "enzyme-to-json": "3.6.2",
-                "esbuild": "0.17.15",
-                "esbuild-sass-plugin": "^2.4.0",
+                "esbuild": "^0.17.18",
+                "esbuild-sass-plugin": "^2.9.0",
                 "eslint": "8.37.0",
                 "eslint-config-airbnb": "19.0.4",
                 "eslint-config-prettier": "8.8.0",
@@ -14144,7 +14143,7 @@
                 "eslint-plugin-import": "2.27.5",
                 "eslint-plugin-jsx-a11y": "6.7.1",
                 "eslint-plugin-md": "^1.0.19",
-                "eslint-plugin-prettier": "^3.1.4",
+                "eslint-plugin-prettier": "^4.2.1",
                 "eslint-plugin-react": "7.32.2",
                 "eslint-plugin-react-hooks": "4.6.0",
                 "eslint-plugin-simple-import-sort": "7.0.0",
@@ -16884,9 +16883,9 @@
             }
         },
         "node_modules/sass": {
-            "version": "1.62.0",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.62.0.tgz",
-            "integrity": "sha512-Q4USplo4pLYgCi+XlipZCWUQz5pkg/ruSSgJ0WRDSb/+3z9tXUOkQ7QPYn4XrhZKYAK4HlpaQecRwKLJX6+DBg==",
+            "version": "1.62.1",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.62.1.tgz",
+            "integrity": "sha512-NHpxIzN29MXvWiuswfc1W3I0N8SXBd8UR26WntmDlRYf0bSADnwnOjsyMZ3lMezSlArD33Vs3YFhp7dWvL770A==",
             "dev": true,
             "dependencies": {
                 "chokidar": ">=3.0.0 <4.0.0",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
         "electron-builder": "^22.14.13",
         "electron-devtools-installer": "3.2.0",
         "electron-notarize": "0.3.0",
-        "pc-nrfconnect-shared": "github:NordicSemiconductor/pc-nrfconnect-shared#v32",
+        "pc-nrfconnect-shared": "github:NordicSemiconductor/pc-nrfconnect-shared#v36",
         "playwright": "^1.16.3",
         "xvfb-maybe": "0.2.1"
     },

--- a/src/launcher/features/apps/App/InstallOtherVersion.tsx
+++ b/src/launcher/features/apps/App/InstallOtherVersion.tsx
@@ -15,7 +15,13 @@ import { DisplayedApp, isInProgress } from '../appsSlice';
 const UninstallApp: React.FC<{ app: DisplayedApp }> = ({ app }) => {
     const dispatch = useLauncherDispatch();
 
-    if (!isDownloadable(app)) return null;
+    if (
+        !isDownloadable(app) ||
+        app.versions == null ||
+        Object.keys(app.versions).length < 2
+    ) {
+        return null;
+    }
 
     return (
         <Dropdown.Item

--- a/src/launcher/features/apps/InstallOtherVersionDialog.tsx
+++ b/src/launcher/features/apps/InstallOtherVersionDialog.tsx
@@ -5,8 +5,7 @@
  */
 
 import React, { useEffect, useMemo, useState } from 'react';
-import Dropdown from 'react-bootstrap/Dropdown';
-import { ConfirmationDialog } from 'pc-nrfconnect-shared';
+import { ConfirmationDialog, Dropdown } from 'pc-nrfconnect-shared';
 import { rsort } from 'semver';
 
 import { DownloadableApp } from '../../../ipc/apps';
@@ -17,42 +16,40 @@ import {
 } from './appDialogsSlice';
 import { installDownloadableApp } from './appsEffects';
 
+import styles from './installOtherVersionDialog.module.scss';
+
 const VersionList = ({
-    versionToInstall,
-    setVersionToInstall,
     app,
+    id,
+    setVersionToInstall,
+    versionToInstall,
 }: {
-    versionToInstall?: string;
-    setVersionToInstall: (version: string) => void;
     app?: DownloadableApp;
+    id: string;
+    setVersionToInstall: (version: string) => void;
+    versionToInstall?: string;
 }) => {
     const availableVersions = useMemo(
-        () => rsort(Object.keys(app?.versions ?? {})),
+        () =>
+            rsort(Object.keys(app?.versions ?? {})).map(v => ({
+                label: v,
+                value: v,
+            })),
         [app]
     );
 
+    const selectedVersionToInstall =
+        availableVersions.find(item => item.value === versionToInstall) ??
+        availableVersions[0];
+
     return (
         <Dropdown
-            as="span"
-            className="ml-3"
-            onSelect={version => {
-                if (version != null) {
-                    setVersionToInstall(version);
-                }
-            }}
-        >
-            <Dropdown.Toggle variant="outline-secondary">
-                {versionToInstall}
-            </Dropdown.Toggle>
-
-            <Dropdown.Menu>
-                {availableVersions.map(version => (
-                    <Dropdown.Item key={version} eventKey={version}>
-                        {version}
-                    </Dropdown.Item>
-                ))}
-            </Dropdown.Menu>
-        </Dropdown>
+            id={id}
+            onSelect={({ value }) => setVersionToInstall(value)}
+            selectedItem={selectedVersionToInstall}
+            items={availableVersions}
+            numItemsBeforeScroll={8}
+        />
     );
 };
 
@@ -105,18 +102,22 @@ export default () => {
                 Semiconductor.
             </p>
 
-            <p>
-                Version to install:
-                <VersionList
-                    app={
-                        installOtherVersionDialog.isVisible
-                            ? installOtherVersionDialog.app
-                            : undefined
-                    }
-                    versionToInstall={versionToInstall}
-                    setVersionToInstall={setVersionToInstall}
-                />
-            </p>
+            <form className={styles.versionListLine}>
+                {/* eslint-disable-next-line jsx-a11y/label-has-associated-control -- versionList is the id for a control */}
+                <label htmlFor="versionList">Version to install:</label>
+                <div className={styles.versionList}>
+                    <VersionList
+                        id="versionList"
+                        app={
+                            installOtherVersionDialog.isVisible
+                                ? installOtherVersionDialog.app
+                                : undefined
+                        }
+                        versionToInstall={versionToInstall}
+                        setVersionToInstall={setVersionToInstall}
+                    />
+                </div>
+            </form>
         </ConfirmationDialog>
     );
 };

--- a/src/launcher/features/apps/installOtherVersionDialog.module.scss
+++ b/src/launcher/features/apps/installOtherVersionDialog.module.scss
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+.versionListLine {
+    font-size: 14px;
+    display: flex;
+    align-items: baseline;
+    gap: 1rem;
+}
+
+.versionList {
+    width: 'fit-content';
+}

--- a/src/launcher/features/launcherUpdate/UpdateProgressDialog.tsx
+++ b/src/launcher/features/launcherUpdate/UpdateProgressDialog.tsx
@@ -6,7 +6,7 @@
 
 import React from 'react';
 import ProgressBar from 'react-bootstrap/ProgressBar';
-import { Dialog, DialogButton, Spinner } from 'pc-nrfconnect-shared';
+import { Dialog, DialogButton } from 'pc-nrfconnect-shared';
 
 import { useLauncherDispatch, useLauncherSelector } from '../../util/hooks';
 import { cancelDownload } from './launcherUpdateEffects';
@@ -25,7 +25,10 @@ export default () => {
 
     return (
         <Dialog isVisible={isVisible} closeOnUnfocus={false}>
-            <Dialog.Header title="Downloading update" />
+            <Dialog.Header
+                title="Downloading update"
+                showSpinner={!isProgressSupported}
+            />
             <Dialog.Body>
                 <p>Downloading nRF Connect for Desktop {version}...</p>
                 {isProgressSupported && (
@@ -40,7 +43,6 @@ export default () => {
                 </p>
             </Dialog.Body>
             <Dialog.Footer>
-                {!isProgressSupported && <Spinner />}
                 {isCancelSupported && (
                     <DialogButton
                         onClick={() => dispatch(cancelDownload())}

--- a/src/launcher/features/launcherUpdate/__snapshots__/UpdateAvailableDialog.test.tsx.snap
+++ b/src/launcher/features/launcherUpdate/__snapshots__/UpdateAvailableDialog.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`UpdateAvailableDialog shows the new version if one becomes available  1
     tabindex="-1"
   >
     <div
-      class="modal-dialog modal-lg modal-dialog-centered"
+      class="modal-dialog modal-dialog-centered"
     >
       <div
         class="modal-content"
@@ -34,11 +34,11 @@ exports[`UpdateAvailableDialog shows the new version if one becomes available  1
         <div
           class="modal-header"
         >
-          <p>
+          <div>
             <b>
               Update available
             </b>
-          </p>
+          </div>
         </div>
         <div
           class="modal-body"

--- a/src/launcher/features/launcherUpdate/__snapshots__/UpdateProgressDialog.test.tsx.snap
+++ b/src/launcher/features/launcherUpdate/__snapshots__/UpdateProgressDialog.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`UpdateProgressDialog can be without progress, and not cancellable 1`] =
     tabindex="-1"
   >
     <div
-      class="modal-dialog modal-lg modal-dialog-centered"
+      class="modal-dialog modal-dialog-centered"
     >
       <div
         class="modal-content"
@@ -28,11 +28,14 @@ exports[`UpdateProgressDialog can be without progress, and not cancellable 1`] =
         <div
           class="modal-header"
         >
-          <p>
+          <div>
             <b>
               Downloading update
             </b>
-          </p>
+            <div
+              class="spinner-border spinner-border-sm"
+            />
+          </div>
         </div>
         <div
           class="modal-body"
@@ -48,14 +51,7 @@ exports[`UpdateProgressDialog can be without progress, and not cancellable 1`] =
         </div>
         <div
           class="modal-footer"
-        >
-          <img
-            alt="Loading..."
-            height="16"
-            src="test-file-stub"
-            width="16"
-          />
-        </div>
+        />
       </div>
     </div>
   </div>
@@ -82,7 +78,7 @@ exports[`UpdateProgressDialog can have a version, percent downloaded, and be can
     tabindex="-1"
   >
     <div
-      class="modal-dialog modal-lg modal-dialog-centered"
+      class="modal-dialog modal-dialog-centered"
     >
       <div
         class="modal-content"
@@ -90,11 +86,11 @@ exports[`UpdateProgressDialog can have a version, percent downloaded, and be can
         <div
           class="modal-header"
         >
-          <p>
+          <div>
             <b>
               Downloading update
             </b>
-          </p>
+          </div>
         </div>
         <div
           class="modal-body"
@@ -158,7 +154,7 @@ exports[`UpdateProgressDialog has cancelling disabled after being cancelled 1`] 
     tabindex="-1"
   >
     <div
-      class="modal-dialog modal-lg modal-dialog-centered"
+      class="modal-dialog modal-dialog-centered"
     >
       <div
         class="modal-content"
@@ -166,11 +162,11 @@ exports[`UpdateProgressDialog has cancelling disabled after being cancelled 1`] 
         <div
           class="modal-header"
         >
-          <p>
+          <div>
             <b>
               Downloading update
             </b>
-          </p>
+          </div>
         </div>
         <div
           class="modal-body"
@@ -235,7 +231,7 @@ exports[`UpdateProgressDialog has cancelling disabled when 100 percent complete 
     tabindex="-1"
   >
     <div
-      class="modal-dialog modal-lg modal-dialog-centered"
+      class="modal-dialog modal-dialog-centered"
     >
       <div
         class="modal-content"
@@ -243,11 +239,11 @@ exports[`UpdateProgressDialog has cancelling disabled when 100 percent complete 
         <div
           class="modal-header"
         >
-          <p>
+          <div>
             <b>
               Downloading update
             </b>
-          </p>
+          </div>
         </div>
         <div
           class="modal-body"

--- a/src/launcher/features/settings/__snapshots__/Settings.test.tsx.snap
+++ b/src/launcher/features/settings/__snapshots__/Settings.test.tsx.snap
@@ -192,7 +192,7 @@ exports[`SettingsView should render check for updates completed, with everything
     tabindex="-1"
   >
     <div
-      class="modal-dialog modal-lg modal-dialog-centered"
+      class="modal-dialog modal-dialog-centered"
     >
       <div
         class="modal-content"
@@ -200,11 +200,11 @@ exports[`SettingsView should render check for updates completed, with everything
         <div
           class="modal-header"
         >
-          <p>
+          <div>
             <b>
               Update check completed
             </b>
-          </p>
+          </div>
         </div>
         <div
           class="modal-body"
@@ -419,7 +419,7 @@ exports[`SettingsView should render check for updates completed, with updates av
     tabindex="-1"
   >
     <div
-      class="modal-dialog modal-lg modal-dialog-centered"
+      class="modal-dialog modal-dialog-centered"
     >
       <div
         class="modal-content"
@@ -427,11 +427,11 @@ exports[`SettingsView should render check for updates completed, with updates av
         <div
           class="modal-header"
         >
-          <p>
+          <div>
             <b>
               Update check completed
             </b>
-          </p>
+          </div>
         </div>
         <div
           class="modal-body"

--- a/src/launcher/features/sources/__snapshots__/ConfirmRemoveSourceDialog.test.tsx.snap
+++ b/src/launcher/features/sources/__snapshots__/ConfirmRemoveSourceDialog.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`ConfirmRemoveSourceDialog shows the new version if one becomes availabl
     tabindex="-1"
   >
     <div
-      class="modal-dialog modal-lg modal-dialog-centered"
+      class="modal-dialog modal-dialog-centered"
     >
       <div
         class="modal-content"
@@ -34,11 +34,11 @@ exports[`ConfirmRemoveSourceDialog shows the new version if one becomes availabl
         <div
           class="modal-header"
         >
-          <p>
+          <div>
             <b>
               Remove app source
             </b>
-          </p>
+          </div>
         </div>
         <div
           class="modal-body"


### PR DESCRIPTION
When there were too many versions to display, the whole window showed a scrollbar, which would scroll away the dialog.

Now, if there are more than 8 versions available, a scrollbar will be shown in the dropdown instead.

This also changes the colour of the dropdown to dark, because I found no easy and not too dirty way to change this.

This also changes the font size of the items in the dropdown list (before it was bigger, now it is 14px, just like the surrounding text).

https://user-images.githubusercontent.com/260705/234587754-99d2c39d-e44e-4740-993e-03e6123bed65.mov

Only if multiple versions exist the button to install other versions should be shown. When only a single version was released, we do not need to show the button.

Occasionally it can also happen, that no versions at all are known. This case can e.g. happen after a migration from an older launcher and especially for withdrawn apps.
