### PR TITLE
Fix: Remove unneeded class

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nrfconnect",
-    "version": "4.1.0-pre1",
+    "version": "4.1.0-pre2",
     "description": "nRF Connect for Desktop",
     "repository": {
         "type": "git",

--- a/src/launcher/features/apps/InstallOtherVersionDialog.tsx
+++ b/src/launcher/features/apps/InstallOtherVersionDialog.tsx
@@ -105,7 +105,7 @@ export default () => {
             <form className={styles.versionListLine}>
                 {/* eslint-disable-next-line jsx-a11y/label-has-associated-control -- versionList is the id for a control */}
                 <label htmlFor="versionList">Version to install:</label>
-                <div className={styles.versionList}>
+                <div>
                     <VersionList
                         id="versionList"
                         app={

--- a/src/launcher/features/apps/installOtherVersionDialog.module.scss
+++ b/src/launcher/features/apps/installOtherVersionDialog.module.scss
@@ -10,7 +10,3 @@
     align-items: baseline;
     gap: 1rem;
 }
-
-.versionList {
-    width: 'fit-content';
-}


### PR DESCRIPTION
Just having a simple div was already enough to avert the `width: 100%` of the Dropdown.

The previous CSS was even illegal because of the quotes.