### PR TITLE
Enhance installing other versions … again

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "nrfconnect",
-    "version": "4.1.0-pre1",
+    "version": "4.1.0-pre2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "nrfconnect",
-            "version": "4.1.0-pre1",
+            "version": "4.1.0-pre2",
             "license": "Proprietary",
             "dependencies": {
                 "@electron/remote": "2.0.8",
@@ -41,7 +41,7 @@
                 "electron-builder": "^22.14.13",
                 "electron-devtools-installer": "3.2.0",
                 "electron-notarize": "0.3.0",
-                "pc-nrfconnect-shared": "github:NordicSemiconductor/pc-nrfconnect-shared#v36",
+                "pc-nrfconnect-shared": "github:NordicSemiconductor/pc-nrfconnect-shared#v38",
                 "playwright": "^1.16.3",
                 "xvfb-maybe": "0.2.1"
             }
@@ -14092,8 +14092,8 @@
             }
         },
         "node_modules/pc-nrfconnect-shared": {
-            "version": "36.0.0",
-            "resolved": "git+ssh://git@github.com/NordicSemiconductor/pc-nrfconnect-shared.git#42985301320c814de63813eeb6d6527db1090569",
+            "version": "38.0.0",
+            "resolved": "git+ssh://git@github.com/NordicSemiconductor/pc-nrfconnect-shared.git#917feacc4b5d6ac942f8b0e5669de1cad6fce836",
             "dev": true,
             "hasInstallScript": true,
             "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nrfconnect",
-    "version": "4.1.0-pre2",
+    "version": "4.1.0-pre3",
     "description": "nRF Connect for Desktop",
     "repository": {
         "type": "git",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
         "electron-builder": "^22.14.13",
         "electron-devtools-installer": "3.2.0",
         "electron-notarize": "0.3.0",
-        "pc-nrfconnect-shared": "github:NordicSemiconductor/pc-nrfconnect-shared#v36",
+        "pc-nrfconnect-shared": "github:NordicSemiconductor/pc-nrfconnect-shared#v38",
         "playwright": "^1.16.3",
         "xvfb-maybe": "0.2.1"
     },

--- a/src/ipc/appDetails.ts
+++ b/src/ipc/appDetails.ts
@@ -24,6 +24,7 @@ export type AppDetails = LaunchableApp & {
     homeDir: string;
     tmpDir: string;
     bundledJlink: string;
+    path: string;
 };
 
 type GetAppDetails = () => AppDetails;

--- a/src/launcher/features/apps/installOtherVersionDialog.module.scss
+++ b/src/launcher/features/apps/installOtherVersionDialog.module.scss
@@ -6,6 +6,7 @@
 
 .versionListLine {
     font-size: 14px;
+    line-height: normal;
     display: flex;
     align-items: baseline;
     gap: 1rem;

--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -235,5 +235,7 @@ export const getAppDetails = (webContents: WebContents): AppDetails => {
         tmpDir: electronApp.getPath('temp'),
         bundledJlink: bundledJlinkVersion,
         ...appWindow.app,
+        // Remove at some point in the future when all apps are update to at least shared v39
+        path: appWindow.app.installed.path,
     };
 };


### PR DESCRIPTION
When installing other app versions, the dropdown for the version list is enhanced in several regards:

- If it has scrollbars, they are working correctly (one can click on them or drag the slider), before clicking on them closed the dropdown.
- The scrollbars are styled consistently with the rest of the UI
- The items are now centred vertically

Also fixed a regression: Apps showed the app path as “undefined” in their log.