### PR TITLE
Copy old source URL

### DIFF
--- a/src/launcher/features/settings/Settings.tsx
+++ b/src/launcher/features/settings/Settings.tsx
@@ -129,7 +129,12 @@ export default () => {
                                             variant="outline-secondary"
                                             size="sm"
                                             onClick={() =>
-                                                clipboard.writeText(source.url)
+                                                clipboard.writeText(
+                                                    source.url.replace(
+                                                        /source.json$/,
+                                                        'apps.json'
+                                                    )
+                                                )
                                             }
                                             title="Copy URL to clipboard"
                                         >


### PR DESCRIPTION
The URLs for sources changes in the 4.1 release, e.g. from https://developer.nordicsemi.com/.pc-tools/nrfconnect-apps/crasher/apps.json to https://developer.nordicsemi.com/.pc-tools/nrfconnect-apps/crasher/source.json (notice the different filename at the end).

The old URL (with `apps.json` at the end) will continue to work for now. Users of 4.0 and before need the old URLs anyhow, as these versions cannot understand the new files.

So, for now we prefer that people continue to distribute the old URLs, since they work with both old and new releases.

For this, the “Copy URL” function now also copies the old URL.