### PR TITLE
Fix: Error on fresh install

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+### Fixed
+
+-   When nRF Connect for Desktop was never installed on a computer before, a
+    misleading error message (Unable to retrieve the official source from …) was
+    shown and it was impossible to install any apps.
+
 ## 4.1.0 - 2023-05-08
 
 ### Added

--- a/src/main/apps/sources.ts
+++ b/src/main/apps/sources.ts
@@ -147,7 +147,10 @@ const downloadSourceJsonToFile = async (source: Source) => {
 };
 
 const readSourceJson = (source: Source) =>
-    readJsonFile<SourceJson>(getSourceJsonPath(source));
+    readJsonFile<SourceJson>(getSourceJsonPath(source), {
+        name: source.name,
+        apps: [],
+    });
 
 export const writeSourceJson = (source: Source, sourceJson: SourceJson) =>
     writeJsonFile(getSourceJsonPath(source), sourceJson);


### PR DESCRIPTION
When nRF Connect for Desktop was never installed on a computer before, a misleading error message (Unable to retrieve the official source from …) was shown and it was impossible to install any apps.