### PR TITLE
Fix: Wrong app state when downgrading launcher

### DIFF
--- a/Changelog.minor.md
+++ b/Changelog.minor.md
@@ -1,0 +1,25 @@
+This Changelog collects changes which we consider not to be relevant enough for
+the normal Changelog.md.
+
+E.g. because the change is purely internal and so not visible to the users or
+because it is so minor that the users will rarely care about them.
+
+It is still helpful that we collect them, e.g. so that we can check them when
+release the new version.
+
+## 4.1.2-pre
+
+### Fixed
+
+-   #835: Wrong state for when users jumped between launcher versions.
+
+    To reproduce:
+
+    1. Remove the folder ~/.nrfconnect-apps (to start out with a clean,
+       controlled state)
+    1. Run the launcher 4.1.1. With it install the Programmer app and quit it.
+    1. Run the launcher 4.0.1. With it uninstall Programmer and quit it.
+    1. Run the launcher 4.1.1.
+
+    Now the launcher showed the Programmer as seemingly installed again but
+    launching or uninstalling it did not work.

--- a/Changelog.minor.md
+++ b/Changelog.minor.md
@@ -9,6 +9,12 @@ release the new version.
 
 ## 4.1.2-pre
 
+### Changed
+
+-   #834: Send the IPC message `serialport:on-write` only after something was
+    written to a serial port.
+-   #836: Bumped device-lib-js to 0.6.9.
+
 ### Fixed
 
 -   #835: Wrong state for when users jumped between launcher versions.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "nrfconnect",
-    "version": "4.1.1",
+    "version": "4.1.2-pre",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "nrfconnect",
-            "version": "4.1.1",
+            "version": "4.1.2-pre",
             "license": "Proprietary",
             "dependencies": {
                 "@electron/remote": "2.0.8",
@@ -16,7 +16,7 @@
                 "electron-store": "8.1.0",
                 "electron-updater": "4.3.1",
                 "fs-extra": "9.0.0",
-                "lodash.merge": "4.6.2",
+                "lodash": "^4.17.21",
                 "mustache": "4.0.1",
                 "node-watch": "^0.7.3",
                 "react": "16.14.0",
@@ -31,7 +31,7 @@
             "devDependencies": {
                 "@playwright/test": "^1.16.3",
                 "@types/chmodr": "1.0.0",
-                "@types/lodash.merge": "4.6.7",
+                "@types/lodash": "^4.14.194",
                 "@types/mustache": "4.2.1",
                 "@types/node": "14.17.17",
                 "@types/targz": "1.0.1",
@@ -3346,17 +3346,10 @@
             }
         },
         "node_modules/@types/lodash": {
-            "version": "4.14.191",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@types/lodash.merge": {
-            "version": "4.6.7",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/lodash": "*"
-            }
+            "version": "4.14.194",
+            "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.194.tgz",
+            "integrity": "sha512-r22s9tAS7imvBt2lyHC9B8AGwWnXaYb1tY09oyLkXDs4vArpYJzw09nj8MLx5VfciBPGIb+ZwG0ssYnEPJxn/g==",
+            "dev": true
         },
         "node_modules/@types/lodash.range": {
             "version": "3.2.7",
@@ -12297,7 +12290,8 @@
         },
         "node_modules/lodash": {
             "version": "4.17.21",
-            "license": "MIT"
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
         },
         "node_modules/lodash.camelcase": {
             "version": "4.3.0",
@@ -12323,6 +12317,7 @@
         },
         "node_modules/lodash.merge": {
             "version": "4.6.2",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/lodash.pad": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nrfconnect",
-    "version": "4.1.1",
+    "version": "4.1.2-pre",
     "description": "nRF Connect for Desktop",
     "repository": {
         "type": "git",
@@ -92,7 +92,7 @@
     "devDependencies": {
         "@playwright/test": "^1.16.3",
         "@types/chmodr": "1.0.0",
-        "@types/lodash.merge": "4.6.7",
+        "@types/lodash": "^4.14.194",
         "@types/mustache": "4.2.1",
         "@types/node": "14.17.17",
         "@types/targz": "1.0.1",
@@ -114,7 +114,7 @@
         "electron-store": "8.1.0",
         "electron-updater": "4.3.1",
         "fs-extra": "9.0.0",
-        "lodash.merge": "4.6.2",
+        "lodash": "^4.17.21",
         "mustache": "4.0.1",
         "node-watch": "^0.7.3",
         "react": "16.14.0",


### PR DESCRIPTION
Fixes https://trello.com/c/sC0xkJct.

To reproduce:

1. Remove the folder ~/.nrfconnect-apps (to start out with a clean, controlled state)
2. Run the launcher 4.1.1. With it install the Programmer app and quit it.
3. Run the launcher 4.0.1. With it uninstall Programmer and quit it.
4. Run the launcher 4.1.1.

Now the launcher showed the Programmer as seemingly installed again but launching or uninstalling it did not work.