### PR TITLE
feat: remove unused hostedModules

### DIFF
--- a/src/app/module-loader.js
+++ b/src/app/module-loader.js
@@ -33,7 +33,4 @@ hostedModules['@nordicsemiconductor/nrf-device-lib-js'] =
     require('./device-lib-js').default;
 hostedModules['pc-nrfconnect-shared'] = require('pc-nrfconnect-shared');
 hostedModules['react-dom'] = require('react-dom');
-hostedModules['react-redux'] = require('react-redux');
 hostedModules['react'] = require('react');
-hostedModules['redux-devtools-extension'] = require('redux-devtools-extension');
-hostedModules['redux-thunk'] = require('redux-thunk');


### PR DESCRIPTION
These 3 modules were not listed as externals in shared. They also don't seem worth listing as externals (their total bundle size is ~43kb for a development build)