### PR TITLE
Enhance error dialog

### DIFF
--- a/Changelog.minor.md
+++ b/Changelog.minor.md
@@ -14,6 +14,12 @@ release the new version.
 -   #834: Send the IPC message `serialport:on-write` only after something was
     written to a serial port.
 -   #836: Bumped device-lib-js to 0.6.9.
+-   #840: Error dialogs now make it easier to understand if there are multiple
+    errors and also can show technical details when a source fails to load.
+
+### Removed
+
+-   #839: Device-lib proxies.
 
 ### Fixed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
                 "electron-builder": "^22.14.13",
                 "electron-devtools-installer": "3.2.0",
                 "electron-notarize": "0.3.0",
-                "pc-nrfconnect-shared": "github:NordicSemiconductor/pc-nrfconnect-shared#v38",
+                "pc-nrfconnect-shared": "github:NordicSemiconductor/pc-nrfconnect-shared#v52",
                 "playwright": "^1.16.3",
                 "xvfb-maybe": "0.2.1"
             }
@@ -2180,6 +2180,26 @@
                 "sander": "^0.6.0"
             }
         },
+        "node_modules/@pkgr/utils": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/@pkgr/utils/-/utils-2.4.1.tgz",
+            "integrity": "sha512-JOqwkgFEyi+OROIyq7l4Jy28h/WwhDnG/cPkXG2Z1iFbubB6jsHW1NDvmyOzTBxHr3yg68YGirmh1JUgMqa+9w==",
+            "dev": true,
+            "dependencies": {
+                "cross-spawn": "^7.0.3",
+                "fast-glob": "^3.2.12",
+                "is-glob": "^4.0.3",
+                "open": "^9.1.0",
+                "picocolors": "^1.0.0",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/unts"
+            }
+        },
         "node_modules/@playwright/test": {
             "version": "1.29.1",
             "dev": true,
@@ -2723,9 +2743,9 @@
             }
         },
         "node_modules/@swc/core": {
-            "version": "1.3.46",
-            "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.46.tgz",
-            "integrity": "sha512-WxzgJMWUBVJ95HsvEqlWzM3Qxp2FQrPa4QdAkQQuuvCMnfdctGUbhX/c3LiSRlWrl2LIkYAi4bLansTOol4QcQ==",
+            "version": "1.3.56",
+            "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.56.tgz",
+            "integrity": "sha512-yz/EeXT+PMZucUNrYceRUaTfuNS4IIu5EDZSOlvCEvm4jAmZi7CYH1B/kvzEzoAOzr7zkQiDPNJftcQXLkjbjA==",
             "dev": true,
             "hasInstallScript": true,
             "engines": {
@@ -2736,25 +2756,30 @@
                 "url": "https://opencollective.com/swc"
             },
             "optionalDependencies": {
-                "@swc/core-darwin-arm64": "1.3.46",
-                "@swc/core-darwin-x64": "1.3.46",
-                "@swc/core-linux-arm-gnueabihf": "1.3.46",
-                "@swc/core-linux-arm64-gnu": "1.3.46",
-                "@swc/core-linux-arm64-musl": "1.3.46",
-                "@swc/core-linux-x64-gnu": "1.3.46",
-                "@swc/core-linux-x64-musl": "1.3.46",
-                "@swc/core-win32-arm64-msvc": "1.3.46",
-                "@swc/core-win32-ia32-msvc": "1.3.46",
-                "@swc/core-win32-x64-msvc": "1.3.46"
+                "@swc/core-darwin-arm64": "1.3.56",
+                "@swc/core-darwin-x64": "1.3.56",
+                "@swc/core-linux-arm-gnueabihf": "1.3.56",
+                "@swc/core-linux-arm64-gnu": "1.3.56",
+                "@swc/core-linux-arm64-musl": "1.3.56",
+                "@swc/core-linux-x64-gnu": "1.3.56",
+                "@swc/core-linux-x64-musl": "1.3.56",
+                "@swc/core-win32-arm64-msvc": "1.3.56",
+                "@swc/core-win32-ia32-msvc": "1.3.56",
+                "@swc/core-win32-x64-msvc": "1.3.56"
             },
             "peerDependencies": {
                 "@swc/helpers": "^0.5.0"
+            },
+            "peerDependenciesMeta": {
+                "@swc/helpers": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@swc/core-darwin-arm64": {
-            "version": "1.3.46",
-            "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.46.tgz",
-            "integrity": "sha512-kY4ASe7SsntDw2B1T70H9K1CFmK8POi+LyIpeCyC96EB9wbH2Sax+ploBB/wZALbYzr/dMJzOCU8QXzdmVS4Rg==",
+            "version": "1.3.56",
+            "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.56.tgz",
+            "integrity": "sha512-DZcu7BzDaLEdWHabz9DRTP0yEBLqkrWmskFcD5BX0lGAvoIvE4duMnAqi5F2B3X7630QioHRCYFoRw2WkeE3Cw==",
             "cpu": [
                 "arm64"
             ],
@@ -2768,9 +2793,9 @@
             }
         },
         "node_modules/@swc/core-darwin-x64": {
-            "version": "1.3.46",
-            "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.46.tgz",
-            "integrity": "sha512-kE3PMk8xW+2BZ3oZiTxxsUU/GzrGwM+qS4frOBz9TYHZe+W1dTtj4F9vBit4PFJ+tv4O6DPt9neGobzdq0UmRw==",
+            "version": "1.3.56",
+            "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.56.tgz",
+            "integrity": "sha512-VH5saqYFasdRXJy6RAT+MXm0+IjkMZvOkohJwUei+oA65cKJofQwrJ1jZro8yOJFYvUSI3jgNRGsdBkmo/4hMw==",
             "cpu": [
                 "x64"
             ],
@@ -2784,9 +2809,9 @@
             }
         },
         "node_modules/@swc/core-linux-arm-gnueabihf": {
-            "version": "1.3.46",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.46.tgz",
-            "integrity": "sha512-7TbiUr9MYxT+mC7sVrayag/isFoaZUG/ogkEK8B/ouA1pnIYqWh3N5ifqCzfcSRiOURt+vVqPyoO1puSiNzVuQ==",
+            "version": "1.3.56",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.56.tgz",
+            "integrity": "sha512-LWwPo6NnJkH01+ukqvkoNIOpMdw+Zundm4vBeicwyVrkP+mC3kwVfi03TUFpQUz3kRKdw/QEnxGTj+MouCPbtw==",
             "cpu": [
                 "arm"
             ],
@@ -2800,9 +2825,9 @@
             }
         },
         "node_modules/@swc/core-linux-arm64-gnu": {
-            "version": "1.3.46",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.46.tgz",
-            "integrity": "sha512-Ycw4LU/wsUK9R+Y/2qFOPQseZDfM5D5gbWGrrYj5RoTm57FbnUsSsO26QeZxUNvams1oAQDkZDuerCc9qBRzIQ==",
+            "version": "1.3.56",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.56.tgz",
+            "integrity": "sha512-GzsUy/4egJ4cMlxbM+Ub7AMi5CKAc+pxBxrh8MUPQbyStW8jGgnQsJouTnGy0LHawtdEnsCOl6PcO6OgvktXuQ==",
             "cpu": [
                 "arm64"
             ],
@@ -2816,9 +2841,9 @@
             }
         },
         "node_modules/@swc/core-linux-arm64-musl": {
-            "version": "1.3.46",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.46.tgz",
-            "integrity": "sha512-cBclyr6IW1PBr8l9D4FkebgbqlkiIYnSJCbY84J/6PfTzQlD6w9a1TAoYxdGZpJ7SGHdmB0oDiZS1rhxCSCV/Q==",
+            "version": "1.3.56",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.56.tgz",
+            "integrity": "sha512-9gxL09BIiAv8zY0DjfnFf19bo8+P4T9tdhzPwcm+1yPJcY5yr1+YFWLNFzz01agtOj6VlZ2/wUJTaOfdjjtc+A==",
             "cpu": [
                 "arm64"
             ],
@@ -2832,9 +2857,9 @@
             }
         },
         "node_modules/@swc/core-linux-x64-gnu": {
-            "version": "1.3.46",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.46.tgz",
-            "integrity": "sha512-amqMhTA2CXB6t11hVAZSSPKq4DZ9/sWbW3wYYQHxzqrMJML0726OJs4pt0XnlU7FzdP/9M9j2B/gWCRaCMxXVA==",
+            "version": "1.3.56",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.56.tgz",
+            "integrity": "sha512-n0ORNknl50vMRkll3BDO1E4WOqY6iISlPV1ZQCRLWQ6YQ2q8/WAryBxc2OAybcGHBUFkxyACpJukeU1QZ/9tNw==",
             "cpu": [
                 "x64"
             ],
@@ -2848,9 +2873,9 @@
             }
         },
         "node_modules/@swc/core-linux-x64-musl": {
-            "version": "1.3.46",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.46.tgz",
-            "integrity": "sha512-WOQZTIkJ9khIj5Z2unf6OTrWV9k8br+HZ93RvnamEmJBlLPUuT9IjB+agNhjaDgOpz9/ZldSGqV7vzl5FGQl1Q==",
+            "version": "1.3.56",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.56.tgz",
+            "integrity": "sha512-r+D34WLAOAlJtfw1gaVWpHRwCncU9nzW9i7w9kSw4HpWYnHJOz54jLGSEmNsrhdTCz1VK2ar+V2ktFUsrlGlDA==",
             "cpu": [
                 "x64"
             ],
@@ -2864,9 +2889,9 @@
             }
         },
         "node_modules/@swc/core-win32-arm64-msvc": {
-            "version": "1.3.46",
-            "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.46.tgz",
-            "integrity": "sha512-4JSREbqaTRQ6QO0EeoiB6G5vuFT8zI8aTOLu5At7Cvlw+X7bOGNO+wJ3Tqw7O+68OL+0bPHzHGTXKL9kUccY1A==",
+            "version": "1.3.56",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.56.tgz",
+            "integrity": "sha512-29Yt75Is6X24z3x8h/xZC1HnDPkPpyLH9mDQiM6Cuc0I9mVr1XSriPEUB2N/awf5IE4SA8c+3IVq1DtKWbkJIw==",
             "cpu": [
                 "arm64"
             ],
@@ -2880,9 +2905,9 @@
             }
         },
         "node_modules/@swc/core-win32-ia32-msvc": {
-            "version": "1.3.46",
-            "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.46.tgz",
-            "integrity": "sha512-kC8dIDzcArm1e85yHJsEZFxcNq5NztLkrqkP1nVOQ+9QXD9DKhjbZtWy2gnpclinii6KEGng8SieWiJiOA0CBQ==",
+            "version": "1.3.56",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.56.tgz",
+            "integrity": "sha512-mplp0zbYDrcHtfvkniXlXdB04e2qIjz2Gq/XHKr4Rnc6xVORJjjXF91IemXKpavx2oZYJws+LNJL7UFQ8jyCdQ==",
             "cpu": [
                 "ia32"
             ],
@@ -2896,9 +2921,9 @@
             }
         },
         "node_modules/@swc/core-win32-x64-msvc": {
-            "version": "1.3.46",
-            "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.46.tgz",
-            "integrity": "sha512-rrSAfq+DvpJioBxUsnuH+sKl0eXid1DwkwNzkVGHEreN9GoP7GospWtFq7VDcO6DrS/s3HtR4/TzoIYFEBCRIg==",
+            "version": "1.3.56",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.56.tgz",
+            "integrity": "sha512-zp8MBnrw/bjdLenO/ifYzHrImSjKunqL0C2IF4LXYNRfcbYFh2NwobsVQMZ20IT0474lKRdlP8Oxdt+bHuXrzA==",
             "cpu": [
                 "x64"
             ],
@@ -2916,6 +2941,7 @@
             "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.0.tgz",
             "integrity": "sha512-SjY/p4MmECVVEWspzSRpQEM3sjR17sP8PbGxELWrT+YZMBfiUyt1MRUNjMV23zohwlG2HYtCQOsCwsTHguXkyg==",
             "dev": true,
+            "optional": true,
             "peer": true,
             "dependencies": {
                 "tslib": "^2.4.0"
@@ -3359,12 +3385,6 @@
             "dependencies": {
                 "@types/lodash": "*"
             }
-        },
-        "node_modules/@types/long": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
-            "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
-            "dev": true
         },
         "node_modules/@types/minimatch": {
             "version": "5.1.2",
@@ -4969,6 +4989,18 @@
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
             }
         },
+        "node_modules/bplist-parser": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.2.0.tgz",
+            "integrity": "sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==",
+            "dev": true,
+            "dependencies": {
+                "big-integer": "^1.6.44"
+            },
+            "engines": {
+                "node": ">= 5.10.0"
+            }
+        },
         "node_modules/brace-expansion": {
             "version": "1.1.11",
             "license": "MIT",
@@ -5215,6 +5247,21 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/bundle-name": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-3.0.0.tgz",
+            "integrity": "sha512-PKA4BeSvBpQKQ8iPOGCSiell+N8P+Tf1DlwqmYhpe2gAhKPHn8EYOxVT+ShuGmhg8lN8XiSlS80yiExKXrURlw==",
+            "dev": true,
+            "dependencies": {
+                "run-applescript": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/cacheable-lookup": {
@@ -6261,10 +6308,178 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/default-browser": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-4.0.0.tgz",
+            "integrity": "sha512-wX5pXO1+BrhMkSbROFsyxUm0i/cJEScyNhA4PPxc41ICuv05ZZB/MX28s8aZx6xjmatvebIapF6hLEKEcpneUA==",
+            "dev": true,
+            "dependencies": {
+                "bundle-name": "^3.0.0",
+                "default-browser-id": "^3.0.0",
+                "execa": "^7.1.1",
+                "titleize": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/default-browser-id": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-3.0.0.tgz",
+            "integrity": "sha512-OZ1y3y0SqSICtE8DE4S8YOE9UZOJ8wO16fKWVP5J1Qz42kV9jcnMVFrEE/noXb/ss3Q4pZIH79kxofzyNNtUNA==",
+            "dev": true,
+            "dependencies": {
+                "bplist-parser": "^0.2.0",
+                "untildify": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/default-browser/node_modules/execa": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-7.1.1.tgz",
+            "integrity": "sha512-wH0eMf/UXckdUYnO21+HDztteVv05rq2GXksxT4fCGeHkBhw1DROXh40wcjMcRqDOWE7iPJ4n3M7e2+YFP+76Q==",
+            "dev": true,
+            "dependencies": {
+                "cross-spawn": "^7.0.3",
+                "get-stream": "^6.0.1",
+                "human-signals": "^4.3.0",
+                "is-stream": "^3.0.0",
+                "merge-stream": "^2.0.0",
+                "npm-run-path": "^5.1.0",
+                "onetime": "^6.0.0",
+                "signal-exit": "^3.0.7",
+                "strip-final-newline": "^3.0.0"
+            },
+            "engines": {
+                "node": "^14.18.0 || ^16.14.0 || >=18.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/execa?sponsor=1"
+            }
+        },
+        "node_modules/default-browser/node_modules/get-stream": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+            "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/default-browser/node_modules/human-signals": {
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-4.3.1.tgz",
+            "integrity": "sha512-nZXjEF2nbo7lIw3mgYjItAfgQXog3OjJogSbKa2CQIIvSGWcKgeJnQlNXip6NglNzYH45nSRiEVimMvYL8DDqQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=14.18.0"
+            }
+        },
+        "node_modules/default-browser/node_modules/is-stream": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+            "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+            "dev": true,
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/default-browser/node_modules/mimic-fn": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-4.0.0.tgz",
+            "integrity": "sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/default-browser/node_modules/npm-run-path": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.1.0.tgz",
+            "integrity": "sha512-sJOdmRGrY2sjNTRMbSvluQqg+8X7ZK61yvzBEIDhz4f8z1TZFYABsqjjCBd/0PUNE9M6QDgHJXQkGUEm7Q+l9Q==",
+            "dev": true,
+            "dependencies": {
+                "path-key": "^4.0.0"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/default-browser/node_modules/onetime": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-6.0.0.tgz",
+            "integrity": "sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==",
+            "dev": true,
+            "dependencies": {
+                "mimic-fn": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/default-browser/node_modules/path-key": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
+            "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/default-browser/node_modules/strip-final-newline": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-3.0.0.tgz",
+            "integrity": "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/defer-to-connect": {
             "version": "1.1.3",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/define-lazy-prop": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+            "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/define-properties": {
             "version": "1.2.0",
@@ -7117,6 +7332,19 @@
                 "once": "^1.4.0"
             }
         },
+        "node_modules/enhanced-resolve": {
+            "version": "5.14.1",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.14.1.tgz",
+            "integrity": "sha512-Vklwq2vDKtl0y/vtwjSesgJ5MYS7Etuk5txS8VdKL4AOS1aUlD96zqIfsOSLQsdv3xgMRbtkWM8eG9XDfKUPow==",
+            "dev": true,
+            "dependencies": {
+                "graceful-fs": "^4.2.4",
+                "tapable": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=10.13.0"
+            }
+        },
         "node_modules/entities": {
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
@@ -7721,23 +7949,60 @@
             }
         },
         "node_modules/eslint-import-resolver-typescript": {
-            "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-2.7.1.tgz",
-            "integrity": "sha512-00UbgGwV8bSgUv34igBDbTOtKhqoRMy9bFjNehT40bXg6585PNIct8HhXZ0SybqB9rWtXj9crcku8ndDn/gIqQ==",
+            "version": "3.5.5",
+            "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.5.5.tgz",
+            "integrity": "sha512-TdJqPHs2lW5J9Zpe17DZNQuDnox4xo2o+0tE7Pggain9Rbc19ik8kFtXdxZ250FVx2kF4vlt2RSf4qlUpG7bhw==",
             "dev": true,
             "dependencies": {
                 "debug": "^4.3.4",
-                "glob": "^7.2.0",
+                "enhanced-resolve": "^5.12.0",
+                "eslint-module-utils": "^2.7.4",
+                "get-tsconfig": "^4.5.0",
+                "globby": "^13.1.3",
+                "is-core-module": "^2.11.0",
                 "is-glob": "^4.0.3",
-                "resolve": "^1.22.0",
-                "tsconfig-paths": "^3.14.1"
+                "synckit": "^0.8.5"
             },
             "engines": {
-                "node": ">=4"
+                "node": "^14.18.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/unts/projects/eslint-import-resolver-ts"
             },
             "peerDependencies": {
                 "eslint": "*",
                 "eslint-plugin-import": "*"
+            }
+        },
+        "node_modules/eslint-import-resolver-typescript/node_modules/globby": {
+            "version": "13.1.4",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-13.1.4.tgz",
+            "integrity": "sha512-iui/IiiW+QrJ1X1hKH5qwlMQyv34wJAYwH1vrf8b9kBA4sNiif3gKsMHa+BrdnOpEudWjpotfa7LrTzB1ERS/g==",
+            "dev": true,
+            "dependencies": {
+                "dir-glob": "^3.0.1",
+                "fast-glob": "^3.2.11",
+                "ignore": "^5.2.0",
+                "merge2": "^1.4.1",
+                "slash": "^4.0.0"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/eslint-import-resolver-typescript/node_modules/slash": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/slash/-/slash-4.0.0.tgz",
+            "integrity": "sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/eslint-module-utils": {
@@ -7989,9 +8254,9 @@
             }
         },
         "node_modules/eslint-plugin-simple-import-sort": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-7.0.0.tgz",
-            "integrity": "sha512-U3vEDB5zhYPNfxT5TYR7u01dboFZp+HNpnGhkDB2g/2E4wZ/g1Q9Ton8UwCLfRV9yAKyYqDh62oHOamvkFxsvw==",
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-10.0.0.tgz",
+            "integrity": "sha512-AeTvO9UCMSNzIHRkg8S6c3RPy5YEwKWSQPx3DYghLedo2ZQxowPFLGDN1AZ2evfg6r6mjBSZSLxLFsWSu3acsw==",
             "dev": true,
             "peerDependencies": {
                 "eslint": ">=5.0.0"
@@ -9034,6 +9299,18 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/get-tsconfig": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.6.0.tgz",
+            "integrity": "sha512-lgbo68hHTQnFddybKbbs/RDRJnJT5YyGy2kQzVwbq+g67X73i+5MVTval34QxGkOe9X5Ujf1UYpCaphLyltjEg==",
+            "dev": true,
+            "dependencies": {
+                "resolve-pkg-maps": "^1.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+            }
+        },
         "node_modules/getpass": {
             "version": "0.1.7",
             "license": "MIT",
@@ -10035,6 +10312,21 @@
                 "url": "https://github.com/sponsors/wooorm"
             }
         },
+        "node_modules/is-docker": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+            "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+            "dev": true,
+            "bin": {
+                "is-docker": "cli.js"
+            },
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/is-extglob": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -10098,6 +10390,24 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/is-inside-container": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+            "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+            "dev": true,
+            "dependencies": {
+                "is-docker": "^3.0.0"
+            },
+            "bin": {
+                "is-inside-container": "cli.js"
+            },
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/is-installed-globally": {
@@ -10379,6 +10689,33 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/is-wsl": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+            "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+            "dev": true,
+            "dependencies": {
+                "is-docker": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/is-wsl/node_modules/is-docker": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+            "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+            "dev": true,
+            "bin": {
+                "is-docker": "cli.js"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/is-yarn-global": {
@@ -12150,12 +12487,12 @@
             }
         },
         "node_modules/klaw": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
-            "integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/klaw/-/klaw-4.1.0.tgz",
+            "integrity": "sha512-1zGZ9MF9H22UnkpVeuaGKOjfA2t6WrfdrJmGjy16ykcjnKQDmHVX+KI477rpbGevz/5FD4MC3xf1oxylBgcaQw==",
             "dev": true,
-            "dependencies": {
-                "graceful-fs": "^4.1.9"
+            "engines": {
+                "node": ">=14.14.0"
             }
         },
         "node_modules/kleur": {
@@ -12354,9 +12691,9 @@
             }
         },
         "node_modules/long": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-            "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
+            "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==",
             "dev": true
         },
         "node_modules/longest-streak": {
@@ -13513,18 +13850,18 @@
             }
         },
         "node_modules/npm-run-all2": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/npm-run-all2/-/npm-run-all2-5.0.2.tgz",
-            "integrity": "sha512-S2G6FWZ3pNWAAKm2PFSOtEAG/N+XO/kz3+9l6V91IY+Y3XFSt7Lp7DV92KCgEboEW0hRTu0vFaMe4zXDZYaOyA==",
+            "version": "6.0.5",
+            "resolved": "https://registry.npmjs.org/npm-run-all2/-/npm-run-all2-6.0.5.tgz",
+            "integrity": "sha512-YfYsybLmMLeHK00shmIrArZbbqSov/0o692j8PAJTqZGpWy2bJMnMO00Xrex8S0ziePJUZy14CueF7rVMYAg/w==",
             "dev": true,
             "dependencies": {
                 "ansi-styles": "^5.0.0",
                 "cross-spawn": "^7.0.3",
                 "memorystream": "^0.3.1",
-                "minimatch": "^3.0.4",
-                "pidtree": "^0.5.0",
+                "minimatch": "^8.0.2",
+                "pidtree": "^0.6.0",
                 "read-pkg": "^5.2.0",
-                "shell-quote": "^1.6.1"
+                "shell-quote": "^1.7.3"
             },
             "bin": {
                 "npm-run-all": "bin/npm-run-all/index.js",
@@ -13532,7 +13869,8 @@
                 "run-s": "bin/run-s/index.js"
             },
             "engines": {
-                "node": ">= 10"
+                "node": "^14.18.0 || >=16.0.0",
+                "npm": ">= 8"
             }
         },
         "node_modules/npm-run-all2/node_modules/ansi-styles": {
@@ -13545,6 +13883,30 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/npm-run-all2/node_modules/brace-expansion": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/npm-run-all2/node_modules/minimatch": {
+            "version": "8.0.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
+            "integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
+            "dev": true,
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/npm-run-path": {
@@ -13830,6 +14192,24 @@
                 "node": ">=6"
             }
         },
+        "node_modules/open": {
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/open/-/open-9.1.0.tgz",
+            "integrity": "sha512-OS+QTnw1/4vrf+9hh1jc1jnYjzSG4ttTBB8UxOwAnInG3Uo4ssetzC1ihqaIHjLJnA5GGlRl6QlZXOTQhRBUvg==",
+            "dev": true,
+            "dependencies": {
+                "default-browser": "^4.0.0",
+                "define-lazy-prop": "^3.0.0",
+                "is-inside-container": "^1.0.0",
+                "is-wsl": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/optionator": {
             "version": "0.9.1",
             "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
@@ -14087,8 +14467,8 @@
             }
         },
         "node_modules/pc-nrfconnect-shared": {
-            "version": "38.0.0",
-            "resolved": "git+ssh://git@github.com/NordicSemiconductor/pc-nrfconnect-shared.git#917feacc4b5d6ac942f8b0e5669de1cad6fce836",
+            "version": "52.0.0",
+            "resolved": "git+ssh://git@github.com/NordicSemiconductor/pc-nrfconnect-shared.git#4ebe46da48eede1e99c4e69332e4d74da3ef53f4",
             "dev": true,
             "hasInstallScript": true,
             "license": "ISC",
@@ -14098,7 +14478,7 @@
                 "@reduxjs/toolkit": "1.9.3",
                 "@svgr/core": "^7.0.0",
                 "@svgr/plugin-jsx": "7.0.0",
-                "@swc/core": "1.3.46",
+                "@swc/core": "1.3.56",
                 "@swc/jest": "0.2.24",
                 "@testing-library/jest-dom": "5.16.5",
                 "@testing-library/react": "10.4.9",
@@ -14134,14 +14514,14 @@
                 "eslint": "8.37.0",
                 "eslint-config-airbnb": "19.0.4",
                 "eslint-config-prettier": "8.8.0",
-                "eslint-import-resolver-typescript": "2.7.1",
+                "eslint-import-resolver-typescript": "3.5.5",
                 "eslint-plugin-import": "2.27.5",
                 "eslint-plugin-jsx-a11y": "6.7.1",
                 "eslint-plugin-md": "^1.0.19",
                 "eslint-plugin-prettier": "^4.2.1",
                 "eslint-plugin-react": "7.32.2",
                 "eslint-plugin-react-hooks": "4.6.0",
-                "eslint-plugin-simple-import-sort": "7.0.0",
+                "eslint-plugin-simple-import-sort": "10.0.0",
                 "eslint-plugin-testing-library": "^5.6.0",
                 "events": "3.3.0",
                 "fast-glob": "3.2.12",
@@ -14150,15 +14530,15 @@
                 "husky": "8.0.3",
                 "jest": "29.5.0",
                 "jest-environment-jsdom": "29.5.0",
-                "klaw": "3.0.0",
+                "klaw": "4.1.0",
                 "lodash.range": "3.2.0",
                 "mousetrap": "1.6.5",
-                "npm-run-all2": "5.0.2",
+                "npm-run-all2": "6.0.5",
                 "nrf-intel-hex": "^1.3.0",
                 "postcss-modules": "^6.0.0",
-                "prettier": "2.8.7",
+                "prettier": "2.8.8",
                 "prettysize": "2.0.0",
-                "protobufjs": "^6.11.2",
+                "protobufjs": "^7.0.0",
                 "react": "16.14.0",
                 "react-bootstrap": "1.6.6",
                 "react-dom": "16.14.0",
@@ -14347,9 +14727,9 @@
             }
         },
         "node_modules/pidtree": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.5.0.tgz",
-            "integrity": "sha512-9nxspIM7OpZuhBxPg73Zvyq7j1QMPMPsGKTqRc2XOaFQauDvoNz9fM1Wdkjmeo7l9GXOZiRs97sPkuayl39wjA==",
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
+            "integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
             "dev": true,
             "bin": {
                 "pidtree": "bin/pidtree.js"
@@ -14866,9 +15246,9 @@
             }
         },
         "node_modules/prettier": {
-            "version": "2.8.7",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.7.tgz",
-            "integrity": "sha512-yPngTo3aXUUmyuTjeTUT75txrf+aMh9FiD7q9ZE/i6r0bPb22g4FsE6Y338PQX1bmfy08i9QQCB7/rcUAVntfw==",
+            "version": "2.8.8",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+            "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
             "dev": true,
             "bin": {
                 "prettier": "bin-prettier.js"
@@ -15018,9 +15398,9 @@
             }
         },
         "node_modules/protobufjs": {
-            "version": "6.11.3",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.3.tgz",
-            "integrity": "sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==",
+            "version": "7.2.3",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.3.tgz",
+            "integrity": "sha512-TtpvOqwB5Gdz/PQmOjgsrGH1nHjAQVCN7JG4A6r1sXRWESL5rNMAiRcBQlCAdKxZcAbstExQePYG8xof/JVRgg==",
             "dev": true,
             "hasInstallScript": true,
             "dependencies": {
@@ -15034,13 +15414,11 @@
                 "@protobufjs/path": "^1.1.2",
                 "@protobufjs/pool": "^1.1.0",
                 "@protobufjs/utf8": "^1.1.0",
-                "@types/long": "^4.0.1",
                 "@types/node": ">=13.7.0",
-                "long": "^4.0.0"
+                "long": "^5.0.0"
             },
-            "bin": {
-                "pbjs": "bin/pbjs",
-                "pbts": "bin/pbts"
+            "engines": {
+                "node": ">=12.0.0"
             }
         },
         "node_modules/psl": {
@@ -16659,6 +17037,15 @@
                 "node": ">=4"
             }
         },
+        "node_modules/resolve-pkg-maps": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+            "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+            "dev": true,
+            "funding": {
+                "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+            }
+        },
         "node_modules/resolve.exports": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.2.tgz",
@@ -16761,6 +17148,21 @@
             "license": "MIT",
             "engines": {
                 "node": "0.12.* || 4.* || 6.* || >= 7.*"
+            }
+        },
+        "node_modules/run-applescript": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-5.0.0.tgz",
+            "integrity": "sha512-XcT5rBksx1QdIhlFOCtgZkB99ZEouFZ1E2Kc2LHqNW13U3/74YGdkQRmThTwxy4QIyookibDKYZOPqX//6BlAg==",
+            "dev": true,
+            "dependencies": {
+                "execa": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/run-async": {
@@ -17573,6 +17975,22 @@
             "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
             "dev": true
         },
+        "node_modules/synckit": {
+            "version": "0.8.5",
+            "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.5.tgz",
+            "integrity": "sha512-L1dapNV6vu2s/4Sputv8xGsCdAVlb5nRDMFU/E27D44l5U6cw1g0dGd45uLc+OXjNMmF4ntiMdCimzcjFKQI8Q==",
+            "dev": true,
+            "dependencies": {
+                "@pkgr/utils": "^2.3.1",
+                "tslib": "^2.5.0"
+            },
+            "engines": {
+                "node": "^14.18.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/unts"
+            }
+        },
         "node_modules/systeminformation": {
             "version": "5.17.12",
             "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.17.12.tgz",
@@ -17695,6 +18113,15 @@
             "dependencies": {
                 "ansi-regex": "^4.1.0"
             },
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/tapable": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.1.tgz",
+            "integrity": "sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==",
+            "dev": true,
             "engines": {
                 "node": ">=6"
             }
@@ -17955,6 +18382,18 @@
             "dependencies": {
                 "readable-stream": ">=1.0.33-1 <1.1.0-0",
                 "xtend": ">=4.0.0 <4.1.0-0"
+            }
+        },
+        "node_modules/titleize": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/titleize/-/titleize-3.0.0.tgz",
+            "integrity": "sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/tmp": {
@@ -18495,6 +18934,15 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 4.0.0"
+            }
+        },
+        "node_modules/untildify": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
+            "integrity": "sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/unzip-crx-3": {

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
         "electron-builder": "^22.14.13",
         "electron-devtools-installer": "3.2.0",
         "electron-notarize": "0.3.0",
-        "pc-nrfconnect-shared": "github:NordicSemiconductor/pc-nrfconnect-shared#v38",
+        "pc-nrfconnect-shared": "github:NordicSemiconductor/pc-nrfconnect-shared#v52",
         "playwright": "^1.16.3",
         "xvfb-maybe": "0.2.1"
     },

--- a/src/ipc/apps.ts
+++ b/src/ipc/apps.ts
@@ -109,11 +109,13 @@ const channel = {
     removeDownloadableApp: 'apps:remove-downloadable-app',
 };
 
+export type SourceWithError = { source: Source; reason?: string };
+
 // downloadLatestAppInfos
 type DownloadLatestAppInfos = () => {
     apps: DownloadableApp[];
     appsWithErrors: AppWithError[];
-    sourcesWithErrors: Source[];
+    sourcesWithErrors: SourceWithError[];
 };
 
 export const downloadLatestAppInfos = invoke<DownloadLatestAppInfos>(
@@ -135,7 +137,7 @@ export const registerGetLocalApps = handle<GetLocalApps>(channel.getLocalApps);
 export type GetDownloadableAppsResult = {
     apps: DownloadableApp[];
     appsWithErrors: AppWithError[];
-    sourcesWithErrors: Source[];
+    sourcesWithErrors: SourceWithError[];
 };
 
 type GetDownloadableApps = () => GetDownloadableAppsResult;

--- a/src/ipc/serialport.ts
+++ b/src/ipc/serialport.ts
@@ -25,8 +25,7 @@ const channel = {
     close: SERIALPORT_CHANNEL.CLOSE,
     write: SERIALPORT_CHANNEL.WRITE,
     isOpen: SERIALPORT_CHANNEL.IS_OPEN,
-    // @ts-expect-error --Will be included in the next version of shared.
-    getOptions: SERIALPORT_CHANNEL.GET_OPTIONS ?? 'serialport:get-options',
+    getOptions: SERIALPORT_CHANNEL.GET_OPTIONS,
     update: SERIALPORT_CHANNEL.UPDATE,
     set: SERIALPORT_CHANNEL.SET,
 };

--- a/src/launcher/features/filter/filterSlice.ts
+++ b/src/launcher/features/filter/filterSlice.ts
@@ -9,13 +9,13 @@ import { createSlice } from '@reduxjs/toolkit';
 
 import { App, isInstalled } from '../../../ipc/apps';
 import {
-    type ShownStates,
     getHiddenSources as getPersistedHiddenSources,
     getNameFilter as getPersistedNameFilter,
     getShownStates as getPersistedShownStates,
     setHiddenSources as setPersistedHiddenSources,
     setNameFilter as setPersistedNameFilter,
     setShownStates as setPersistedShownStates,
+    type ShownStates,
 } from '../../../ipc/persistedStore';
 import type { SourceName } from '../../../ipc/sources';
 import type { RootState } from '../../store';

--- a/src/launcher/features/sources/sourcesEffects.ts
+++ b/src/launcher/features/sources/sourcesEffects.ts
@@ -6,6 +6,7 @@
 
 import { ErrorDialogActions } from 'pc-nrfconnect-shared';
 
+import { SourceWithError } from '../../../ipc/apps';
 import { cleanIpcErrorMessage } from '../../../ipc/error';
 import {
     addSource as addSourceInMain,
@@ -61,15 +62,17 @@ export const removeSource = (name: SourceName) => (dispatch: AppDispatch) => {
         );
 };
 
-const showProblemWithOfficialSource = (source: Source) =>
+const showProblemWithOfficialSource = (source: Source, reason?: string) =>
     ErrorDialogActions.showDialog(
         `Unable to retrieve the official source from ${source.url}.\n\n` +
             'This is usually caused by a missing internet connection. ' +
-            'Without retrieving that file, official apps cannot be installed. '
+            'Without retrieving that file, official apps cannot be installed. ',
+        undefined,
+        reason
     );
 
 const showProblemWithExtraSource =
-    (source: Source) => (dispatch: AppDispatch) => {
+    (source: Source, reason?: string) => (dispatch: AppDispatch) => {
         dispatch(
             ErrorDialogActions.showDialog(
                 `Unable to retrieve the source “${source.name}” ` +
@@ -84,18 +87,19 @@ const showProblemWithExtraSource =
                     Cancel: () => {
                         dispatch(ErrorDialogActions.hideDialog());
                     },
-                }
+                },
+                reason
             )
         );
     };
 
 export const handleSourcesWithErrors =
-    (sources: Source[]) => (dispatch: AppDispatch) => {
-        sources.forEach(source => {
+    (sources: SourceWithError[]) => (dispatch: AppDispatch) => {
+        sources.forEach(({ source, reason }) => {
             if (source.name === OFFICIAL) {
-                dispatch(showProblemWithOfficialSource(source));
+                dispatch(showProblemWithOfficialSource(source, reason));
             } else {
-                dispatch(showProblemWithExtraSource(source));
+                dispatch(showProblemWithExtraSource(source, reason));
             }
         });
     };

--- a/src/main/apps/apps.ts
+++ b/src/main/apps/apps.ts
@@ -13,11 +13,13 @@ import {
     DownloadableApp,
     isWithdrawn,
     LocalApp,
+    SourceWithError,
     UninstalledDownloadableApp,
 } from '../../ipc/apps';
 import { showErrorDialog } from '../../ipc/showErrorDialog';
 import { Source } from '../../ipc/sources';
 import { getAppsLocalDir } from '../config';
+import describeError from '../describeError';
 import { listDirectories } from '../fileUtil';
 import { downloadToJson } from '../net';
 import {
@@ -83,7 +85,7 @@ const addInstalledAppDatas = (downloadableApps: DownloadableApp[]) => {
 };
 
 export const getDownloadableApps = () => {
-    const sourcesWithErrors: Source[] = [];
+    const sourcesWithErrors: SourceWithError[] = [];
     const apps: DownloadableApp[] = [];
     const appsWithErrors: AppWithError[] = [];
 
@@ -104,7 +106,11 @@ export const getDownloadableApps = () => {
             apps.push(...result.apps);
             appsWithErrors.push(...result.appsWithErrors);
         } catch (error) {
-            sourcesWithErrors.push(source);
+            sourcesWithErrors.push({
+                source,
+                reason:
+                    error instanceof Error ? error.stack : describeError(error),
+            });
         }
     });
 

--- a/src/main/apps/sources.ts
+++ b/src/main/apps/sources.ts
@@ -9,6 +9,7 @@ import fs from 'fs-extra';
 import path from 'path';
 import { SourceJson } from 'pc-nrfconnect-shared';
 
+import { SourceWithError } from '../../ipc/apps';
 import { OFFICIAL, Source, SourceName, SourceUrl } from '../../ipc/sources';
 import { getAppsRootDir, getConfig, getNodeModulesDir } from '../config';
 import describeError from '../describeError';
@@ -209,7 +210,7 @@ export const newWithdrawnJson = (
 
 export const downloadAllSources = async () => {
     const successful: Source[] = [];
-    const erroneos: Source[] = [];
+    const erroneos: SourceWithError[] = [];
 
     await Promise.allSettled(
         sources.map(async source => {
@@ -230,7 +231,13 @@ export const downloadAllSources = async () => {
 
                 successful.push(source);
             } catch (error) {
-                erroneos.push(source);
+                erroneos.push({
+                    source,
+                    reason:
+                        error instanceof Error
+                            ? error.stack
+                            : describeError(error),
+                });
             }
         })
     );


### PR DESCRIPTION
For  https://trello.com/c/r6e7BZHe:

When a source failed to load, the error message “Unable to retrieve …” makes an assumption about the possible cause (“… usually caused by a missing internet connection”) but error reports from users showed us that we are not sure about this and it might also be caused by other things. E.g. in https://trello.com/c/RQnktqXb it was caused by something else.

To understand cases like these better, it is helpful to also get more technical details, e.g. the exception thrown. But we don’t want to display raw exceptions in all these cases, because that would not be user-friendly. So now we display a “Show technical details” button, which then reveals the text of the exception.

An example of the changed error dialog can be seen in https://github.com/NordicSemiconductor/pc-nrfconnect-shared/pull/621.