### PR TITLE
fix: use encodeUriComponent to handle special characters in path

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,11 @@
 
 -   Minor fixes and improvements.
 
+### Fixed
+
+-   Having special characters (such as `&`) in the path created errors when
+    launching apps.
+
 ## 4.1.1 - 2023-05-10
 
 ### Fixed

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,7 +7,8 @@
 ### Fixed
 
 -   Having special characters (such as `&`) in the path created errors when
-    launching apps.
+    launching apps. Usually happened when these characters were part of the
+    username.
 
 ## 4.1.1 - 2023-05-10
 

--- a/resources/app.html
+++ b/resources/app.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html>
+
     <head>
         <meta charset="UTF-8" />
         <style>
@@ -16,10 +17,12 @@
                 border-left: 8px solid #0080c0;
                 animation: rotator 2s infinite linear;
             }
+
             @keyframes rotator {
                 0% {
                     transform: rotate(0deg);
                 }
+
                 100% {
                     transform: rotate(360deg);
                 }
@@ -36,7 +39,15 @@
             const params = new URL(window.location).searchParams;
             const appPath = params.get('appPath');
 
-            document.write("<base href='" + appPath + "/dist/' />");
+            const path = require('path');
+            document.write(
+                "<base href='" +
+                appPath
+                    .split(path.sep)
+                    .map(encodeURIComponent)
+                    .join(path.sep) +
+                "/dist/' />"
+            );
             document.write('<link rel="stylesheet" href="bootstrap.css" type="text/css" />');
             document.write('<link rel="stylesheet" href="bundle.css" type="text/css" />');
         </script>

--- a/resources/app.html
+++ b/resources/app.html
@@ -1,63 +1,71 @@
 <!DOCTYPE html>
 <html>
 
-    <head>
-        <meta charset="UTF-8" />
-        <style>
-            #app-loader {
-                position: absolute;
-                top: 50%;
-                left: 50%;
-                width: 100px;
-                height: 100px;
-                margin: -50px 0 0 -50px;
-                pointer-events: none;
-                border-radius: 50%;
-                border: 8px solid rgba(0, 128, 192, 0.2);
-                border-left: 8px solid #0080c0;
-                animation: rotator 2s infinite linear;
+<head>
+    <meta charset="UTF-8" />
+    <style>
+        #app-loader {
+            position: absolute;
+            top: 50%;
+            left: 50%;
+            width: 100px;
+            height: 100px;
+            margin: -50px 0 0 -50px;
+            pointer-events: none;
+            border-radius: 50%;
+            border: 8px solid rgba(0, 128, 192, 0.2);
+            border-left: 8px solid #0080c0;
+            animation: rotator 2s infinite linear;
+        }
+
+        @keyframes rotator {
+            0% {
+                transform: rotate(0deg);
             }
 
-            @keyframes rotator {
-                0% {
-                    transform: rotate(0deg);
-                }
-
-                100% {
-                    transform: rotate(360deg);
-                }
+            100% {
+                transform: rotate(360deg);
             }
-        </style>
+        }
+    </style>
 
-        <link rel="stylesheet" href="../dist/fonts.css" type="text/css"/>
+    <link rel="stylesheet" href="../dist/fonts.css" type="text/css" />
 
-        <script src="../dist/app.js" defer></script>
+    <script src="../dist/app.js" defer></script>
 
-        <script>
-            // We loaded all the assets we needed from the launcher now. 
-            // Time to change the base to the apps dist folder
-            const params = new URL(window.location).searchParams;
-            const appPath = params.get('appPath');
+    <script>
+        // We loaded all the assets we needed from the launcher now.
+        // Time to change the base to the apps dist folder
+        const params = new URL(window.location).searchParams;
+        const appPath = params.get('appPath');
 
-            const path = require('path');
-            document.write(
-                "<base href='" +
-                appPath
-                    .split(path.sep)
-                    .map(encodeURIComponent)
-                    .join(path.sep) +
-                "/dist/' />"
-            );
-            document.write('<link rel="stylesheet" href="bootstrap.css" type="text/css" />');
-            document.write('<link rel="stylesheet" href="bundle.css" type="text/css" />');
-        </script>
+        const path = require('path');
+        document.write(
+            "<base href='" +
+            appPath
+                .split(path.sep)
+                .map((val, index) =>
+                    // Don't encode Windows `<drive>:`
+                    process.platform === 'win32' && index === 0
+                        ? val
+                        : encodeURIComponent(val)
+                )
+                .join(path.sep) +
+            "/dist/' />"
+        );
+        document.write(
+            '<link rel="stylesheet" href="bootstrap.css" type="text/css" />'
+        );
+        document.write(
+            '<link rel="stylesheet" href="bundle.css" type="text/css" />'
+        );
+    </script>
+</head>
 
-    </head>
-    <body>
+<body>
+    <div id="webapp">
+        <div id="app-loader"></div>
+    </div>
+</body>
 
-
-        <div id="webapp">
-            <div id="app-loader"></div>
-        </div>
-    </body>
 </html>

--- a/src/launcher/features/apps/App/AppIcon.tsx
+++ b/src/launcher/features/apps/App/AppIcon.tsx
@@ -35,7 +35,12 @@ const AppIcon: React.FC<{ app: App }> = ({ app }) => (
             <img
                 src={app.iconPath
                     .split(path.sep)
-                    .map(encodeURIComponent)
+                    .map((val, index) =>
+                        // Don't encode Windows `<drive>:`
+                        process.platform === 'win32' && index === 0
+                            ? val
+                            : encodeURIComponent(val)
+                    )
                     .join(path.sep)}
                 alt=""
                 draggable={false}

--- a/src/launcher/features/apps/App/AppIcon.tsx
+++ b/src/launcher/features/apps/App/AppIcon.tsx
@@ -5,6 +5,7 @@
  */
 
 import React from 'react';
+import path from 'path';
 
 import { App, isInstalled } from '../../../../ipc/apps';
 import appCompatibilityWarning from '../../../util/appCompatibilityWarning';
@@ -31,7 +32,14 @@ const appBadge = (app: App) => {
 const AppIcon: React.FC<{ app: App }> = ({ app }) => (
     <div className="core-app-icon">
         {app.iconPath ? (
-            <img src={app.iconPath} alt="" draggable={false} />
+            <img
+                src={app.iconPath
+                    .split(path.sep)
+                    .map(encodeURIComponent)
+                    .join(path.sep)}
+                alt=""
+                draggable={false}
+            />
         ) : (
             <div className="icon-replacement" />
         )}

--- a/src/launcher/features/apps/__snapshots__/AppList.test.tsx.snap
+++ b/src/launcher/features/apps/__snapshots__/AppList.test.tsx.snap
@@ -25,7 +25,7 @@ exports[`AppList should disable buttons and display "Installing..." button text 
                 <img
                   alt=""
                   draggable="false"
-                  src="/path/to/uninstalled/icon.png"
+                  src="uninstalled.png"
                 />
               </div>
             </div>
@@ -123,7 +123,7 @@ exports[`AppList should disable buttons and display "Updating..." while updating
                 <img
                   alt=""
                   draggable="false"
-                  src="/path/to/updatable/icon.png"
+                  src="updatable.png"
                 />
               </div>
             </div>
@@ -232,7 +232,7 @@ exports[`AppList should disable buttons while removing an app 1`] = `
                 <img
                   alt=""
                   draggable="false"
-                  src="/path/to/installed/icon.png"
+                  src="installed.png"
                 />
               </div>
             </div>
@@ -330,7 +330,7 @@ exports[`AppList should render local, not-installed, installed, and updatable ap
                 <img
                   alt=""
                   draggable="false"
-                  src="/path/to/installed/icon.png"
+                  src="installed.png"
                 />
               </div>
             </div>
@@ -398,7 +398,7 @@ exports[`AppList should render local, not-installed, installed, and updatable ap
                 <img
                   alt=""
                   draggable="false"
-                  src="/path/to/updatable/icon.png"
+                  src="updatable.png"
                 />
               </div>
             </div>
@@ -476,7 +476,7 @@ exports[`AppList should render local, not-installed, installed, and updatable ap
                 <img
                   alt=""
                   draggable="false"
-                  src="/path/to/dummy/icon.png"
+                  src="dummy.png"
                 />
               </div>
             </div>
@@ -544,7 +544,7 @@ exports[`AppList should render local, not-installed, installed, and updatable ap
                 <img
                   alt=""
                   draggable="false"
-                  src="/path/to/uninstalled/icon.png"
+                  src="uninstalled.png"
                 />
               </div>
             </div>

--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -105,9 +105,9 @@ export const openAppWindow = (
     const appWindow = createWindow(
         {
             title: `${app.displayName || app.name} v${app.currentVersion}`,
-            url: `file://${getElectronResourcesDir()}/app.html?appPath=${
+            url: `file://${getElectronResourcesDir()}/app.html?appPath=${encodeURIComponent(
                 app.installed.path
-            }`,
+            )}`,
             icon: getAppIcon(app),
             x,
             y,

--- a/src/test/testFixtures.tsx
+++ b/src/test/testFixtures.tsx
@@ -14,7 +14,10 @@ import {
 import { LOCAL, OFFICIAL } from '../ipc/sources';
 
 const path = (appName: string) => `/path/to/${appName}`;
-const iconPath = (appName: string) => `/path/to/${appName}/icon.png`;
+// AppIcon.tsx rebuilds the path with path.sep
+// This creates a different version than the snapshots on at least one platform
+// The path is invalid anyway and so has not real use other than to illustrate that it is a path
+const iconPath = (appName: string) => `${appName}.png`;
 
 export const createLocalTestApp = (
     appName = 'dummy',


### PR DESCRIPTION
I have tested this with `&` and `=`. Only `&` would actually throw an error without this fix.