### PR TITLE
Fix: Upgrading from 3.10 to 4.1

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,14 +1,12 @@
 ## 4.1.2 - unreleased
 
-### Changed
-
--   Minor fixes and improvements.
-
 ### Fixed
 
 -   Having special characters (such as `&`) in the path created errors when
     launching apps. Usually happened when these characters were part of the
     username.
+-   Updating nRF Connect for Desktop from 3.10 or older directly to 4.1 led to
+    an error message (Unable to retrieve the official source from …).
 
 ## 4.1.1 - 2023-05-10
 

--- a/src/main/apps/app.ts
+++ b/src/main/apps/app.ts
@@ -50,6 +50,9 @@ export const readAppInfoFile = (appSpec: AppSpec) =>
 export const readAppInfoFileIfExists = (appSpec: AppSpec) =>
     readJsonFile<AppInfo | null>(appInfoFile(appSpec), null);
 
+export const appInfoExists = (appSpec: AppSpec) =>
+    fs.existsSync(appInfoFile(appSpec));
+
 export const readAppInfo = (appSpec: AppSpec) => {
     const source = getSource(appSpec.source);
     if (source == null) {

--- a/src/main/apps/apps.ts
+++ b/src/main/apps/apps.ts
@@ -85,6 +85,10 @@ const addInstalledAppDatas = (downloadableApps: DownloadableApp[]) => {
     return { apps, appsWithErrors };
 };
 
+// appInfo.versions may contain a property `undefined` as the result of a broken migration.
+const hasValidAppInfo = (appInfo: AppInfo) =>
+    appInfo.versions.undefined == null;
+
 export const getDownloadableApps = () => {
     const sourcesWithErrors: SourceWithError[] = [];
     const apps: DownloadableApp[] = [];
@@ -102,6 +106,7 @@ export const getDownloadableApps = () => {
                     .map(getAppSpec(source))
                     .filter(appInfoExists)
                     .map(readAppInfo)
+                    .filter(hasValidAppInfo)
                     .map(addDownloadAppData(source.name))
             );
 

--- a/src/main/apps/apps.ts
+++ b/src/main/apps/apps.ts
@@ -25,6 +25,7 @@ import { downloadToJson } from '../net';
 import {
     addDownloadAppData,
     addInstalledAppData,
+    appInfoExists,
     getLocalApp,
     installedAppPath,
     isInstalled,
@@ -99,6 +100,7 @@ export const getDownloadableApps = () => {
             const result = addInstalledAppDatas(
                 getAllAppUrls(source)
                     .map(getAppSpec(source))
+                    .filter(appInfoExists)
                     .map(readAppInfo)
                     .map(addDownloadAppData(source.name))
             );

--- a/src/main/apps/legacyMetaFiles.test.ts
+++ b/src/main/apps/legacyMetaFiles.test.ts
@@ -23,6 +23,9 @@ jest.mock('../config', () => {
 
 const officialSource = {
     appsJson: {
+        '_deprecation note_': {
+            _1: 'Such a note was added when we deprecated downloading apps.json from GitHub.',
+        },
         'pc-nrfconnect-rssi': {
             displayName: 'RSSI Viewer',
             description:

--- a/src/main/apps/legacyMetaFiles.ts
+++ b/src/main/apps/legacyMetaFiles.ts
@@ -147,6 +147,10 @@ const migrateLegacyMetaFiles = (source: Source) => {
     writeSourceJson(source, convertAppsJsonToSourceJson(appsJson));
 
     appEntries(appsJson).forEach(([appName]) => {
+        if (updatesJson[appName] == null) {
+            return;
+        }
+
         const packageJson = readJsonFile<PackageJson | null>(
             path.join(getNodeModulesDir(source.name), appName, 'package.json'),
             null

--- a/src/main/apps/legacyMetaFiles.ts
+++ b/src/main/apps/legacyMetaFiles.ts
@@ -47,8 +47,12 @@ const legacyMetaFilesExist = (source: Source) =>
 
 const getSource = (appsJson: AppsJson) => appsJson._source ?? 'official'; // eslint-disable-line no-underscore-dangle
 
-const appEntries = (appsJson: AppsJson): [string, LegacyAppInfo][] =>
-    Object.entries(appsJson).filter(([key]) => !key.startsWith('_'));
+const isAppEntry = (
+    appInfo: [string, LegacyAppInfo]
+): appInfo is [AppName, LegacyAppInfo] => !appInfo[0].startsWith('_');
+
+const appEntries = (appsJson: AppsJson) =>
+    Object.entries(appsJson).filter(isAppEntry);
 
 export const convertAppsJsonToSourceJson = (appsJson: AppsJson) => ({
     name: getSource(appsJson),
@@ -149,12 +153,7 @@ const migrateLegacyMetaFiles = (source: Source) => {
         );
 
         writeAppInfo(
-            createNewAppInfo(
-                appName as AppName,
-                appsJson,
-                updatesJson,
-                packageJson
-            ),
+            createNewAppInfo(appName, appsJson, updatesJson, packageJson),
             source
         );
     });

--- a/src/main/apps/legacyMetaFiles.ts
+++ b/src/main/apps/legacyMetaFiles.ts
@@ -48,7 +48,7 @@ const legacyMetaFilesExist = (source: Source) =>
 const getSource = (appsJson: AppsJson) => appsJson._source ?? 'official'; // eslint-disable-line no-underscore-dangle
 
 const appEntries = (appsJson: AppsJson): [string, LegacyAppInfo][] =>
-    Object.entries(appsJson).filter(([key]) => key !== '_source');
+    Object.entries(appsJson).filter(([key]) => !key.startsWith('_'));
 
 export const convertAppsJsonToSourceJson = (appsJson: AppsJson) => ({
     name: getSource(appsJson),


### PR DESCRIPTION
Fixes https://nordicsemi.atlassian.net/browse/NCP-4000, https://trello.com/c/RQnktqXb.

Steps to reproduce the error:
1. Remove the folder %USERPROFILE%\.nrfconnect-apps (Windows) or ~/.nrfconnect-apps/ (macOS/Linux)
2. Run nRF Connect for Desktop 3.10 until it shows a list of apps. (Optional: install some apps, e.g. also the since then withdrawn Getting Started app)
3. Run nRF Connect for Desktop 4.1.1