### PR TITLE
Add support for custom html from the app

### DIFF
--- a/Changelog.minor.md
+++ b/Changelog.minor.md
@@ -23,6 +23,11 @@ release the new version.
 
 ### Fixed
 
+-   #850: Support for a custom html-template from the app.
+
+    If the app supplies an `html`-entry in `package.json`, this path will
+    instead be used to load the app.
+
 -   #835: Wrong state for when users jumped between launcher versions.
 
     To reproduce:

--- a/src/ipc/apps.ts
+++ b/src/ipc/apps.ts
@@ -33,6 +33,7 @@ interface Installed {
     currentVersion: string;
     engineVersion?: string;
     repositoryUrl?: string;
+    html?: string;
     installed: {
         path: string;
         shasum?: string;

--- a/src/main/apps/app.ts
+++ b/src/main/apps/app.ts
@@ -131,6 +131,7 @@ export const addInstalledAppData = (
 
         homepage: packageJson.homepage ?? app.homepage,
         repositoryUrl: packageJson.repository?.url,
+        // @ts-expect-error This will be in a future version of shared that is dependent on this beeing in the launcher first.
         html: packageJson.html,
     };
 };

--- a/src/main/apps/app.ts
+++ b/src/main/apps/app.ts
@@ -131,6 +131,7 @@ export const addInstalledAppData = (
 
         homepage: packageJson.homepage ?? app.homepage,
         repositoryUrl: packageJson.repository?.url,
+        html: packageJson.html,
     };
 };
 

--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -11,6 +11,7 @@ import {
     screen,
     WebContents,
 } from 'electron';
+import { join } from 'path';
 import { OpenAppOptions } from 'pc-nrfconnect-shared/main';
 
 import { AppDetails } from '../ipc/appDetails';
@@ -102,12 +103,16 @@ export const openAppWindow = (
         }
     }
 
+    const template = app.html
+        ? `file://${join(app.installed.path, app.html)}`
+        : `file://${getElectronResourcesDir()}/app.html?appPath=${encodeURIComponent(
+              app.installed.path
+          )}`;
+
     const appWindow = createWindow(
         {
             title: `${app.displayName || app.name} v${app.currentVersion}`,
-            url: `file://${getElectronResourcesDir()}/app.html?appPath=${encodeURIComponent(
-                app.installed.path
-            )}`,
+            url: template,
             icon: getAppIcon(app),
             x,
             y,


### PR DESCRIPTION
This will let the apps specify an `html`-property in their `package.json` that will let the app decide how to start itself. 