### PR TITLE
Fix: Multiple requests with authenticated proxies

### DIFF
--- a/Changelog.minor.md
+++ b/Changelog.minor.md
@@ -7,7 +7,14 @@ because it is so minor that the users will rarely care about them.
 It is still helpful that we collect them, e.g. so that we can check them when
 release the new version.
 
-## 4.1.2-pre
+## 4.1.3-pre
+
+### Fixed
+
+-   #851: Proxies with authentication were not handled correctly when multiple
+    requests were done at the same time.
+
+## 4.1.2
 
 ### Changed
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nrfconnect",
-    "version": "4.1.2",
+    "version": "4.1.3-pre",
     "description": "nRF Connect for Desktop",
     "repository": {
         "type": "git",

--- a/src/launcher/features/proxyLogin/ProxyErrorDialog.tsx
+++ b/src/launcher/features/proxyLogin/ProxyErrorDialog.tsx
@@ -9,12 +9,11 @@ import Button from 'react-bootstrap/Button';
 import Modal from 'react-bootstrap/Modal';
 
 import { useLauncherDispatch, useLauncherSelector } from '../../util/hooks';
-import { getProxyLogin, loginErrorDialogClosed } from './proxyLoginSlice';
+import { getIsErrorVisible, loginErrorDialogClosed } from './proxyLoginSlice';
 
 export default () => {
     const dispatch = useLauncherDispatch();
-    const { isErrorDialogVisible: isVisible } =
-        useLauncherSelector(getProxyLogin);
+    const isVisible = useLauncherSelector(getIsErrorVisible);
 
     return (
         <Modal show={isVisible} backdrop>

--- a/src/launcher/features/proxyLogin/ProxyLoginDialog.test.tsx
+++ b/src/launcher/features/proxyLogin/ProxyLoginDialog.test.tsx
@@ -59,7 +59,7 @@ describe('ProxyLoginDialog', () => {
         expect(
             render(<ProxyLoginDialog />, [
                 loginRequestedByServer({ requestId, authInfo }),
-                loginRequestSent('the username'),
+                loginRequestSent(),
             ]).baseElement
         ).toMatchSnapshot();
     });

--- a/src/launcher/features/proxyLogin/ProxyLoginDialog.tsx
+++ b/src/launcher/features/proxyLogin/ProxyLoginDialog.tsx
@@ -23,19 +23,21 @@ export default () => {
     const dispatch = useLauncherDispatch();
     const [password, setPassword] = useState('');
 
-    const { isVisible, username, host, requestId } =
+    const { isVisible, username, host, requestIds } =
         useLauncherSelector(getProxyLoginRequest);
 
     const cancel = useCallback(() => {
-        answerProxyLoginRequest(requestId!); // eslint-disable-line @typescript-eslint/no-non-null-assertion
+        requestIds.forEach(id => answerProxyLoginRequest(id));
         dispatch(loginCancelledByUser());
-    }, [dispatch, requestId]);
+    }, [dispatch, requestIds]);
 
     const submit = useCallback(() => {
-        answerProxyLoginRequest(requestId!, username, password); // eslint-disable-line @typescript-eslint/no-non-null-assertion
+        requestIds.forEach(id =>
+            answerProxyLoginRequest(id, username, password)
+        );
         dispatch(loginRequestSent());
         setPassword('');
-    }, [dispatch, password, requestId, username]);
+    }, [dispatch, password, requestIds, username]);
 
     const inputIsValid = useMemo(
         () => username !== '' && password !== '',

--- a/src/launcher/features/proxyLogin/ProxyLoginDialog.tsx
+++ b/src/launcher/features/proxyLogin/ProxyLoginDialog.tsx
@@ -14,7 +14,7 @@ import { answerProxyLoginRequest } from '../../../ipc/proxyLogin';
 import { useLauncherDispatch, useLauncherSelector } from '../../util/hooks';
 import {
     changeUserName,
-    getProxyLogin,
+    getProxyLoginRequest,
     loginCancelledByUser,
     loginRequestSent,
 } from './proxyLoginSlice';
@@ -23,12 +23,8 @@ export default () => {
     const dispatch = useLauncherDispatch();
     const [password, setPassword] = useState('');
 
-    const {
-        requestId,
-        loginDialogMessage: message,
-        username,
-        isLoginDialogVisible: isVisible,
-    } = useLauncherSelector(getProxyLogin);
+    const { isVisible, username, host, requestId } =
+        useLauncherSelector(getProxyLoginRequest);
 
     const cancel = useCallback(() => {
         answerProxyLoginRequest(requestId!); // eslint-disable-line @typescript-eslint/no-non-null-assertion
@@ -37,7 +33,7 @@ export default () => {
 
     const submit = useCallback(() => {
         answerProxyLoginRequest(requestId!, username, password); // eslint-disable-line @typescript-eslint/no-non-null-assertion
-        dispatch(loginRequestSent(username));
+        dispatch(loginRequestSent());
         setPassword('');
     }, [dispatch, password, requestId, username]);
 
@@ -61,7 +57,10 @@ export default () => {
                 <Modal.Title>Proxy authentication required</Modal.Title>
             </Modal.Header>
             <Modal.Body>
-                <p>{message}</p>
+                <p>
+                    The proxy server {host} requires authentication. Please
+                    enter username and password
+                </p>
                 <Form.Group controlId="username">
                     <Form.Label>Username:</Form.Label>
                     <InputGroup>

--- a/src/launcher/features/proxyLogin/__snapshots__/ProxyLoginDialog.test.tsx.snap
+++ b/src/launcher/features/proxyLogin/__snapshots__/ProxyLoginDialog.test.tsx.snap
@@ -37,7 +37,9 @@ exports[`ProxyLoginDialog is displayed after a login is requested 1`] = `
           class="modal-body"
         >
           <p>
-            The proxy server test host (realm: test realm) requires authentication. Please enter username and password
+            The proxy server 
+            test host (realm: test realm)
+             requires authentication. Please enter username and password
           </p>
           <div
             class="form-group"
@@ -164,7 +166,9 @@ exports[`ProxyLoginDialog is updated if users enter a username 1`] = `
           class="modal-body"
         >
           <p>
-            The proxy server test host (realm: test realm) requires authentication. Please enter username and password
+            The proxy server 
+            test host (realm: test realm)
+             requires authentication. Please enter username and password
           </p>
           <div
             class="form-group"

--- a/src/launcher/features/proxyLogin/proxyLoginSlice.test.ts
+++ b/src/launcher/features/proxyLogin/proxyLoginSlice.test.ts
@@ -83,4 +83,27 @@ describe('proxy login', () => {
 
         expect(isVisible).toBe(false);
     });
+
+    it('stores multiple request ids', () => {
+        const state = dispatchTo(reducer, [
+            loginRequestedByServer({ requestId: 'test ID', authInfo }),
+            loginRequestedByServer({ requestId: 'another test ID', authInfo }),
+        ]);
+
+        const { requestIds } = getProxyLoginRequest(asRootState(state));
+
+        expect(requestIds).toEqual(['test ID', 'another test ID']);
+    });
+
+    it('clears all request ids', () => {
+        const state = dispatchTo(reducer, [
+            loginRequestedByServer({ requestId: 'test ID', authInfo }),
+            loginRequestedByServer({ requestId: 'another test ID', authInfo }),
+            loginRequestSent(),
+        ]);
+
+        const { requestIds } = getProxyLoginRequest(asRootState(state));
+
+        expect(requestIds).toEqual([]);
+    });
 });

--- a/src/launcher/features/proxyLogin/proxyLoginSlice.ts
+++ b/src/launcher/features/proxyLogin/proxyLoginSlice.ts
@@ -14,7 +14,7 @@ export type State = {
     loginRequest: {
         username: string;
         host: string;
-        requestId?: string;
+        requestIds: string[];
     };
     loginError: {
         isDialogVisible: boolean;
@@ -25,6 +25,7 @@ const initialState: State = {
     loginRequest: {
         username: '',
         host: '',
+        requestIds: [],
     },
     loginError: {
         isDialogVisible: false,
@@ -41,17 +42,17 @@ const slice = createSlice({
                 payload: { authInfo, requestId },
             }: PayloadAction<{ requestId: string; authInfo: AuthInfo }>
         ) {
-            state.loginRequest.requestId = requestId;
+            state.loginRequest.requestIds.push(requestId);
             state.loginRequest.host = authInfo.realm
                 ? `${authInfo.host} (realm: ${authInfo.realm})`
                 : authInfo.host;
         },
         loginCancelledByUser(state) {
-            state.loginRequest.requestId = undefined;
+            state.loginRequest.requestIds = [];
             state.loginError.isDialogVisible = true;
         },
         loginRequestSent(state) {
-            state.loginRequest.requestId = undefined;
+            state.loginRequest.requestIds = [];
         },
         changeUserName(state, { payload: username }: PayloadAction<string>) {
             state.loginRequest.username = username;
@@ -74,7 +75,7 @@ export const {
 
 export const getProxyLoginRequest = (state: RootState) => ({
     ...state.proxyLogin.loginRequest,
-    isVisible: state.proxyLogin.loginRequest.requestId != null,
+    isVisible: state.proxyLogin.loginRequest.requestIds.length > 0,
 });
 
 export const getIsErrorVisible = (state: RootState) =>


### PR DESCRIPTION
Addresses one aspect of https://trello.com/c/PvzJV1fs

When a proxy requested authentication in multiple requests at the same time, only one request was actually continued after the user entered the credentials (or cancelled the login).

One way to reproduce the problem:
1. Add   https://developer.nordicsemi.com/.pc-tools/nrfconnect-apps/internal/apps.json   as a source, so that there are effectively two sources (internal and   official).
2. Turn on “Check for updates at startup”
3. Restart with a proxy that requires authentication
4. When asked for credentials, enter the correct credentials

Expected result:
- All sources are updated and on the settings page, the button ”Check  for updates can be clicked”

Actual result:
- Only one source is updated and on the settings page, the button  ”Checking…” remains disabled

Please note, that when cancelling the login, still a wrong error message appears. This is a separate issue and will be fixed in a separate PR.