### PR TITLE
Fix dialogs when proxy requires authentication

### DIFF
--- a/Changelog.minor.md
+++ b/Changelog.minor.md
@@ -13,6 +13,10 @@ release the new version.
 
 -   #851: Proxies with authentication were not handled correctly when multiple
     requests were done at the same time.
+-   #852:
+    -   Proxy dialogs were outdated.
+    -   Multiple, partially misleading dialogs were displayed if users cancelled
+        the proxy login.
 
 ## 4.1.2
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "prepare": "husky install",
         "app": "cross-env NODE_OPTIONS=--enable-source-maps electron .",
         "app:debug": "cross-env NODE_OPTIONS=--enable-source-maps electron --remote-debugging-port=9223 .",
-        "watch": "run-p --silent --continue-on-error --print-label watch:**",
+        "watch:build": "run-p --silent --continue-on-error --print-label watch:build:*",
         "watch:build:main": "node scripts/esbuild --watch",
         "watch:build:renderer": "node scripts/esbuild-renderer --watch",
         "watch:types": "tsc --noEmit --pretty --watch --preserveWatchOutput",

--- a/src/ipc/config.ts
+++ b/src/ipc/config.ts
@@ -22,7 +22,7 @@ export interface Configuration {
     isRunningLauncherFromSource: boolean;
     isSkipSplashScreen: boolean;
     isSkipUpdateApps: boolean;
-    isSkipUpdateCore: boolean;
+    isSkipUpdateLauncher: boolean;
     settingsJsonPath: string;
     sourcesJsonPath: string;
     startupApp?: StartupApp;

--- a/src/launcher/features/apps/appsEffects.ts
+++ b/src/launcher/features/apps/appsEffects.ts
@@ -19,7 +19,7 @@ import {
     removeLocalApp as removeLocalAppInMain,
 } from '../../../ipc/apps';
 import { openApp } from '../../../ipc/openWindow';
-import type { AppDispatch } from '../../store';
+import type { AppThunk } from '../../store';
 import appCompatibilityWarning from '../../util/appCompatibilityWarning';
 import mainConfig from '../../util/mainConfig';
 import { handleSourcesWithErrors } from '../sources/sourcesEffects';
@@ -56,7 +56,8 @@ const buildErrorMessage = (apps: AppWithError[]) => {
 };
 
 export const handleAppsWithErrors =
-    (apps: AppWithError[]) => (dispatch: AppDispatch) => {
+    (apps: AppWithError[]): AppThunk =>
+    dispatch => {
         if (apps.length === 0) {
             return;
         }
@@ -82,7 +83,7 @@ export const handleAppsWithErrors =
         );
     };
 
-export const downloadLatestAppInfos = () => async (dispatch: AppDispatch) => {
+export const downloadLatestAppInfos = (): AppThunk => async dispatch => {
     try {
         dispatch(updateDownloadableAppInfosStarted());
         const { apps, appsWithErrors, sourcesWithErrors } =
@@ -103,7 +104,8 @@ export const downloadLatestAppInfos = () => async (dispatch: AppDispatch) => {
 };
 
 export const installLocalApp =
-    (appPackagePath: string) => async (dispatch: AppDispatch) => {
+    (appPackagePath: string): AppThunk =>
+    async dispatch => {
         const installResult = await installLocalAppInMain(appPackagePath);
         if (installResult.type === 'success') {
             dispatch(addLocalApp(installResult.app));
@@ -138,8 +140,8 @@ export const installLocalApp =
     };
 
 const install =
-    (app: DownloadableApp, version?: string) =>
-    async (dispatch: AppDispatch) => {
+    (app: DownloadableApp, version?: string): AppThunk =>
+    async dispatch => {
         try {
             const installedApp = await installDownloadableAppInMain(
                 app,
@@ -157,7 +159,8 @@ const install =
     };
 
 export const installDownloadableApp =
-    (app: DownloadableApp, version?: string) => (dispatch: AppDispatch) => {
+    (app: DownloadableApp, version?: string): AppThunk =>
+    dispatch => {
         if (version == null) {
             sendAppUsageData(EventAction.INSTALL_APP, app.source, app.name);
         } else {
@@ -173,7 +176,8 @@ export const installDownloadableApp =
     };
 
 export const updateDownloadableApp =
-    (app: DownloadableApp) => (dispatch: AppDispatch) => {
+    (app: DownloadableApp): AppThunk =>
+    dispatch => {
         sendAppUsageData(EventAction.UPDATE_APP, app.source, app.name);
 
         dispatch(updateDownloadableAppStarted(app));
@@ -181,7 +185,8 @@ export const updateDownloadableApp =
     };
 
 export const removeDownloadableApp =
-    (app: AppSpec) => async (dispatch: AppDispatch) => {
+    (app: AppSpec): AppThunk =>
+    async dispatch => {
         sendAppUsageData(EventAction.REMOVE_APP, app.source, app.name);
 
         dispatch(removeDownloadableAppStarted(app));
@@ -207,7 +212,8 @@ export const launch = (app: LaunchableApp) => {
 };
 
 export const checkEngineAndLaunch =
-    (app: LaunchableApp) => (dispatch: AppDispatch) => {
+    (app: LaunchableApp): AppThunk =>
+    dispatch => {
         const compatibilityWarning = appCompatibilityWarning(app);
         const launchAppWithoutWarning =
             compatibilityWarning == null ||

--- a/src/launcher/features/initialisation/initialiseLauncherState.ts
+++ b/src/launcher/features/initialisation/initialiseLauncherState.ts
@@ -8,7 +8,7 @@ import { describeError, ErrorDialogActions } from 'pc-nrfconnect-shared';
 
 import { getDownloadableApps, getLocalApps } from '../../../ipc/apps';
 import { getSources } from '../../../ipc/sources';
-import type { AppDispatch, RootState } from '../../store';
+import type { AppThunk } from '../../store';
 import mainConfig from '../../util/mainConfig';
 import {
     downloadLatestAppInfos,
@@ -24,7 +24,7 @@ import {
     sendEnvInfo,
 } from '../usageData/usageDataEffects';
 
-const loadSources = () => async (dispatch: AppDispatch) => {
+const loadSources = (): AppThunk => async dispatch => {
     try {
         dispatch(setSources(await getSources()));
     } catch (error) {
@@ -36,7 +36,7 @@ const loadSources = () => async (dispatch: AppDispatch) => {
     }
 };
 
-export const loadApps = () => async (dispatch: AppDispatch) => {
+export const loadApps = (): AppThunk => async dispatch => {
     try {
         dispatch(setAllLocalApps(await getLocalApps()));
 
@@ -51,18 +51,18 @@ export const loadApps = () => async (dispatch: AppDispatch) => {
     }
 };
 
-const downloadLatestAppInfoAtStartup =
-    () => (dispatch: AppDispatch, getState: () => RootState) => {
-        const shouldCheckForUpdatesAtStartup =
-            getShouldCheckForUpdatesAtStartup(getState());
+const downloadLatestAppInfoAtStartup = (): AppThunk => (dispatch, getState) => {
+    const shouldCheckForUpdatesAtStartup = getShouldCheckForUpdatesAtStartup(
+        getState()
+    );
 
-        if (shouldCheckForUpdatesAtStartup && !mainConfig().isSkipUpdateApps) {
-            dispatch(downloadLatestAppInfos());
-        }
-    };
+    if (shouldCheckForUpdatesAtStartup && !mainConfig().isSkipUpdateApps) {
+        dispatch(downloadLatestAppInfos());
+    }
+};
 
 const checkForCoreUpdatesAtStartup =
-    () => async (dispatch: AppDispatch, getState: () => RootState) => {
+    (): AppThunk => async (dispatch, getState) => {
         const shouldCheckForUpdatesAtStartup =
             getShouldCheckForUpdatesAtStartup(getState());
 
@@ -75,7 +75,7 @@ const checkForCoreUpdatesAtStartup =
         }
     };
 
-export default () => async (dispatch: AppDispatch) => {
+export default (): AppThunk => async dispatch => {
     dispatch(checkUsageDataSetting());
 
     await dispatch(loadSources());

--- a/src/launcher/features/initialisation/initialiseLauncherState.ts
+++ b/src/launcher/features/initialisation/initialiseLauncherState.ts
@@ -15,7 +15,7 @@ import {
     handleAppsWithErrors,
 } from '../apps/appsEffects';
 import { addDownloadableApps, setAllLocalApps } from '../apps/appsSlice';
-import { checkForCoreUpdates } from '../launcherUpdate/launcherUpdateEffects';
+import { checkForLauncherUpdate } from '../launcherUpdate/launcherUpdateEffects';
 import { getShouldCheckForUpdatesAtStartup } from '../settings/settingsSlice';
 import { handleSourcesWithErrors } from '../sources/sourcesEffects';
 import { setSources } from '../sources/sourcesSlice';
@@ -61,17 +61,17 @@ const downloadLatestAppInfoAtStartup = (): AppThunk => (dispatch, getState) => {
     }
 };
 
-const checkForCoreUpdatesAtStartup =
+const checkForLauncherUpdateAtStartup =
     (): AppThunk => async (dispatch, getState) => {
         const shouldCheckForUpdatesAtStartup =
             getShouldCheckForUpdatesAtStartup(getState());
 
         if (
             shouldCheckForUpdatesAtStartup &&
-            !mainConfig().isSkipUpdateCore &&
+            !mainConfig().isSkipUpdateLauncher &&
             process.env.NODE_ENV !== 'development'
         ) {
-            await dispatch(checkForCoreUpdates());
+            await dispatch(checkForLauncherUpdate());
         }
     };
 
@@ -82,7 +82,7 @@ export default (): AppThunk => async dispatch => {
     await dispatch(loadApps());
 
     dispatch(downloadLatestAppInfoAtStartup());
-    dispatch(checkForCoreUpdatesAtStartup());
+    dispatch(checkForLauncherUpdateAtStartup());
 
     sendEnvInfo();
 };

--- a/src/launcher/features/launcherUpdate/launcherUpdateEffects.ts
+++ b/src/launcher/features/launcherUpdate/launcherUpdateEffects.ts
@@ -11,12 +11,12 @@ import {
 } from 'pc-nrfconnect-shared';
 
 import { cancelUpdate, checkForUpdate } from '../../../ipc/launcherUpdate';
-import type { AppDispatch } from '../../store';
+import type { AppThunk } from '../../store';
 import { downloadLatestAppInfos } from '../apps/appsEffects';
 import { showUpdateCheckComplete } from '../settings/settingsSlice';
 import { reset, updateAvailable } from './launcherUpdateSlice';
 
-export const checkForCoreUpdates = () => async (dispatch: AppDispatch) => {
+export const checkForCoreUpdates = (): AppThunk => async dispatch => {
     try {
         const { isUpdateAvailable, newVersion } = await checkForUpdate();
 
@@ -30,12 +30,12 @@ export const checkForCoreUpdates = () => async (dispatch: AppDispatch) => {
     }
 };
 
-export const cancelDownload = () => (dispatch: AppDispatch) => {
+export const cancelDownload = (): AppThunk => dispatch => {
     cancelUpdate();
     dispatch(reset());
 };
 
-export const checkForUpdatesManually = () => async (dispatch: AppDispatch) => {
+export const checkForUpdatesManually = (): AppThunk => async dispatch => {
     try {
         await dispatch(downloadLatestAppInfos());
         dispatch(showUpdateCheckComplete());

--- a/src/launcher/features/launcherUpdate/launcherUpdateEffects.ts
+++ b/src/launcher/features/launcherUpdate/launcherUpdateEffects.ts
@@ -13,6 +13,7 @@ import {
 import { cancelUpdate, checkForUpdate } from '../../../ipc/launcherUpdate';
 import type { AppThunk } from '../../store';
 import { downloadLatestAppInfos } from '../apps/appsEffects';
+import { getIsErrorVisible as getIsProxyErrorShown } from '../proxyLogin/proxyLoginSlice';
 import { showUpdateCheckComplete } from '../settings/settingsSlice';
 import { reset, updateAvailable } from './launcherUpdateSlice';
 
@@ -35,15 +36,18 @@ export const cancelDownload = (): AppThunk => dispatch => {
     dispatch(reset());
 };
 
-export const checkForUpdatesManually = (): AppThunk => async dispatch => {
-    try {
-        await dispatch(downloadLatestAppInfos());
-        dispatch(showUpdateCheckComplete());
+export const checkForUpdatesManually =
+    (): AppThunk => async (dispatch, getState) => {
+        try {
+            await dispatch(downloadLatestAppInfos());
+            if (!getIsProxyErrorShown(getState())) {
+                dispatch(showUpdateCheckComplete());
 
-        dispatch(checkForLauncherUpdate());
-    } catch (error) {
-        ErrorDialogActions.showDialog(
-            `Unable to check for updates: ${describeError(error)}`
-        );
-    }
-};
+                dispatch(checkForLauncherUpdate());
+            }
+        } catch (error) {
+            ErrorDialogActions.showDialog(
+                `Unable to check for updates: ${describeError(error)}`
+            );
+        }
+    };

--- a/src/launcher/features/launcherUpdate/launcherUpdateEffects.ts
+++ b/src/launcher/features/launcherUpdate/launcherUpdateEffects.ts
@@ -16,7 +16,7 @@ import { downloadLatestAppInfos } from '../apps/appsEffects';
 import { showUpdateCheckComplete } from '../settings/settingsSlice';
 import { reset, updateAvailable } from './launcherUpdateSlice';
 
-export const checkForCoreUpdates = (): AppThunk => async dispatch => {
+export const checkForLauncherUpdate = (): AppThunk => async dispatch => {
     try {
         const { isUpdateAvailable, newVersion } = await checkForUpdate();
 
@@ -40,7 +40,7 @@ export const checkForUpdatesManually = (): AppThunk => async dispatch => {
         await dispatch(downloadLatestAppInfos());
         dispatch(showUpdateCheckComplete());
 
-        dispatch(checkForCoreUpdates());
+        dispatch(checkForLauncherUpdate());
     } catch (error) {
         ErrorDialogActions.showDialog(
             `Unable to check for updates: ${describeError(error)}`

--- a/src/launcher/features/proxyLogin/ProxyErrorDialog.tsx
+++ b/src/launcher/features/proxyLogin/ProxyErrorDialog.tsx
@@ -5,8 +5,7 @@
  */
 
 import React from 'react';
-import Button from 'react-bootstrap/Button';
-import Modal from 'react-bootstrap/Modal';
+import { ErrorDialog } from 'pc-nrfconnect-shared';
 
 import { useLauncherDispatch, useLauncherSelector } from '../../util/hooks';
 import { getIsErrorVisible, loginErrorDialogClosed } from './proxyLoginSlice';
@@ -16,30 +15,31 @@ export default () => {
     const isVisible = useLauncherSelector(getIsErrorVisible);
 
     return (
-        <Modal show={isVisible} backdrop>
-            <Modal.Header>
-                <Modal.Title>Proxy error</Modal.Title>
-            </Modal.Header>
-            <Modal.Body>
-                <p>
-                    It appears that you are having problems authenticating with
-                    a proxy server. This will prevent you from using certain
-                    features of nRF Connect for Desktop, such as installing apps
-                    from the &quot;Add/remove apps&quot; screen.
-                </p>
-                <p>
-                    If you are unable to resolve the issue, then go to Settings
-                    and disable &quot;Check for updates at startup&quot;. Then
-                    restart nRF Connect for Desktop and install apps manually by
-                    following the instructions at
-                    https://github.com/NordicSemiconductor/pc-nrfconnect-launcher.
-                </p>
-            </Modal.Body>
-            <Modal.Footer>
-                <Button onClick={() => dispatch(loginErrorDialogClosed())}>
-                    OK
-                </Button>
-            </Modal.Footer>
-        </Modal>
+        <ErrorDialog
+            isVisible={isVisible}
+            onHide={() => dispatch(loginErrorDialogClosed())}
+            title="Proxy error"
+        >
+            <p>
+                It appears that you are having problems authenticating with a
+                proxy server. This will prevent you from using certain features
+                of nRF Connect for Desktop, such as installing downloadable apps
+                or checking for updates.
+            </p>
+            <p>
+                If you are unable to resolve the issue, then go to Settings and
+                disable &quot;Check for updates at startup&quot;. Then restart
+                nRF Connect for Desktop and install apps manually by following
+                the instructions at{' '}
+                <a
+                    target="_blank"
+                    href="https://github.com/NordicSemiconductor/pc-nrfconnect-launcher"
+                    rel="noreferrer"
+                >
+                    https://github.com/NordicSemiconductor/pc-nrfconnect-launcher
+                </a>
+                .
+            </p>
+        </ErrorDialog>
     );
 };

--- a/src/launcher/features/proxyLogin/ProxyLoginDialog.tsx
+++ b/src/launcher/features/proxyLogin/ProxyLoginDialog.tsx
@@ -5,10 +5,9 @@
  */
 
 import React, { useCallback, useMemo, useState } from 'react';
-import Button from 'react-bootstrap/Button';
 import Form from 'react-bootstrap/Form';
 import InputGroup from 'react-bootstrap/InputGroup';
-import Modal from 'react-bootstrap/Modal';
+import { ConfirmationDialog } from 'pc-nrfconnect-shared';
 
 import { answerProxyLoginRequest } from '../../../ipc/proxyLogin';
 import { useLauncherDispatch, useLauncherSelector } from '../../util/hooks';
@@ -31,7 +30,7 @@ export default () => {
         dispatch(loginCancelledByUser());
     }, [dispatch, requestIds]);
 
-    const submit = useCallback(() => {
+    const login = useCallback(() => {
         requestIds.forEach(id =>
             answerProxyLoginRequest(id, username, password)
         );
@@ -47,53 +46,48 @@ export default () => {
     const submitOnEnter: React.KeyboardEventHandler = useCallback(
         event => {
             if (event.key === 'Enter' && inputIsValid) {
-                submit();
+                login();
             }
         },
-        [inputIsValid, submit]
+        [inputIsValid, login]
     );
 
     return (
-        <Modal show={isVisible} backdrop>
-            <Modal.Header closeButton={false}>
-                <Modal.Title>Proxy authentication required</Modal.Title>
-            </Modal.Header>
-            <Modal.Body>
-                <p>
-                    The proxy server {host} requires authentication. Please
-                    enter username and password
-                </p>
-                <Form.Group controlId="username">
-                    <Form.Label>Username:</Form.Label>
-                    <InputGroup>
-                        <Form.Control
-                            autoFocus
-                            value={username}
-                            onChange={event =>
-                                dispatch(changeUserName(event.target.value))
-                            }
-                            onKeyPress={submitOnEnter}
-                        />
-                    </InputGroup>
-                </Form.Group>
-                <Form.Group controlId="password">
-                    <Form.Label>Password:</Form.Label>
-                    <InputGroup>
-                        <Form.Control
-                            value={password}
-                            type="password"
-                            onChange={event => setPassword(event.target.value)}
-                            onKeyPress={submitOnEnter}
-                        />
-                    </InputGroup>
-                </Form.Group>
-            </Modal.Body>
-            <Modal.Footer>
-                <Button onClick={cancel}>Cancel</Button>
-                <Button onClick={submit} disabled={!inputIsValid}>
-                    Login
-                </Button>
-            </Modal.Footer>
-        </Modal>
+        <ConfirmationDialog
+            isVisible={isVisible}
+            title="Proxy authentication required"
+            confirmLabel="Login"
+            onConfirm={login}
+            onCancel={cancel}
+        >
+            <p>
+                The proxy server {host} requires authentication. Please enter
+                username and password
+            </p>
+            <Form.Group controlId="username">
+                <Form.Label>Username:</Form.Label>
+                <InputGroup>
+                    <Form.Control
+                        autoFocus
+                        value={username}
+                        onChange={event =>
+                            dispatch(changeUserName(event.target.value))
+                        }
+                        onKeyPress={submitOnEnter}
+                    />
+                </InputGroup>
+            </Form.Group>
+            <Form.Group controlId="password">
+                <Form.Label>Password:</Form.Label>
+                <InputGroup>
+                    <Form.Control
+                        value={password}
+                        type="password"
+                        onChange={event => setPassword(event.target.value)}
+                        onKeyPress={submitOnEnter}
+                    />
+                </InputGroup>
+            </Form.Group>
+        </ConfirmationDialog>
     );
 };

--- a/src/launcher/features/proxyLogin/__snapshots__/ProxyErrorDialog.test.tsx.snap
+++ b/src/launcher/features/proxyLogin/__snapshots__/ProxyErrorDialog.test.tsx.snap
@@ -13,14 +13,14 @@ exports[`ProxyErrorDialog is displayed after users canceled the login 1`] = `
   />
   <div
     aria-modal="true"
-    class="fade modal show"
+    class="fade dialog  modal show"
     data-focus-visible-added=""
     role="dialog"
     style="display: block;"
     tabindex="-1"
   >
     <div
-      class="modal-dialog"
+      class="modal-dialog modal-dialog-centered"
     >
       <div
         class="modal-content"
@@ -28,30 +28,42 @@ exports[`ProxyErrorDialog is displayed after users canceled the login 1`] = `
         <div
           class="modal-header"
         >
-          <div
-            class="modal-title h4"
-          >
-            Proxy error
+          <div>
+            <b>
+              Proxy error
+            </b>
           </div>
+          <span
+            class="mdi mdi-alert"
+          />
         </div>
         <div
           class="modal-body"
         >
           <p>
-            It appears that you are having problems authenticating with a proxy server. This will prevent you from using certain features of nRF Connect for Desktop, such as installing apps from the "Add/remove apps" screen.
+            It appears that you are having problems authenticating with a proxy server. This will prevent you from using certain features of nRF Connect for Desktop, such as installing downloadable apps or checking for updates.
           </p>
           <p>
-            If you are unable to resolve the issue, then go to Settings and disable "Check for updates at startup". Then restart nRF Connect for Desktop and install apps manually by following the instructions at https://github.com/NordicSemiconductor/pc-nrfconnect-launcher.
+            If you are unable to resolve the issue, then go to Settings and disable "Check for updates at startup". Then restart nRF Connect for Desktop and install apps manually by following the instructions at
+             
+            <a
+              href="https://github.com/NordicSemiconductor/pc-nrfconnect-launcher"
+              rel="noreferrer"
+              target="_blank"
+            >
+              https://github.com/NordicSemiconductor/pc-nrfconnect-launcher
+            </a>
+            .
           </p>
         </div>
         <div
           class="modal-footer"
         >
           <button
-            class="btn btn-primary"
+            class=""
             type="button"
           >
-            OK
+            Close
           </button>
         </div>
       </div>

--- a/src/launcher/features/proxyLogin/__snapshots__/ProxyLoginDialog.test.tsx.snap
+++ b/src/launcher/features/proxyLogin/__snapshots__/ProxyLoginDialog.test.tsx.snap
@@ -13,13 +13,13 @@ exports[`ProxyLoginDialog is displayed after a login is requested 1`] = `
   />
   <div
     aria-modal="true"
-    class="fade modal show"
+    class="fade dialog  modal show"
     role="dialog"
     style="display: block;"
     tabindex="-1"
   >
     <div
-      class="modal-dialog"
+      class="modal-dialog modal-dialog-centered"
     >
       <div
         class="modal-content"
@@ -27,10 +27,10 @@ exports[`ProxyLoginDialog is displayed after a login is requested 1`] = `
         <div
           class="modal-header"
         >
-          <div
-            class="modal-title h4"
-          >
-            Proxy authentication required
+          <div>
+            <b>
+              Proxy authentication required
+            </b>
           </div>
         </div>
         <div
@@ -86,17 +86,16 @@ exports[`ProxyLoginDialog is displayed after a login is requested 1`] = `
           class="modal-footer"
         >
           <button
-            class="btn btn-primary"
-            type="button"
-          >
-            Cancel
-          </button>
-          <button
-            class="btn btn-primary"
-            disabled=""
+            class=""
             type="button"
           >
             Login
+          </button>
+          <button
+            class=""
+            type="button"
+          >
+            Cancel
           </button>
         </div>
       </div>
@@ -142,13 +141,13 @@ exports[`ProxyLoginDialog is updated if users enter a username 1`] = `
   />
   <div
     aria-modal="true"
-    class="fade modal show"
+    class="fade dialog  modal show"
     role="dialog"
     style="display: block;"
     tabindex="-1"
   >
     <div
-      class="modal-dialog"
+      class="modal-dialog modal-dialog-centered"
     >
       <div
         class="modal-content"
@@ -156,10 +155,10 @@ exports[`ProxyLoginDialog is updated if users enter a username 1`] = `
         <div
           class="modal-header"
         >
-          <div
-            class="modal-title h4"
-          >
-            Proxy authentication required
+          <div>
+            <b>
+              Proxy authentication required
+            </b>
           </div>
         </div>
         <div
@@ -215,17 +214,16 @@ exports[`ProxyLoginDialog is updated if users enter a username 1`] = `
           class="modal-footer"
         >
           <button
-            class="btn btn-primary"
-            type="button"
-          >
-            Cancel
-          </button>
-          <button
-            class="btn btn-primary"
-            disabled=""
+            class=""
             type="button"
           >
             Login
+          </button>
+          <button
+            class=""
+            type="button"
+          >
+            Cancel
           </button>
         </div>
       </div>

--- a/src/launcher/features/sources/sourcesEffects.ts
+++ b/src/launcher/features/sources/sourcesEffects.ts
@@ -19,6 +19,7 @@ import {
 import type { AppThunk } from '../../store';
 import { addDownloadableApps, removeAppsOfSource } from '../apps/appsSlice';
 import { hideSource, showSource } from '../filter/filterSlice';
+import { getIsErrorVisible as getIsProxyErrorShown } from '../proxyLogin/proxyLoginSlice';
 import {
     addSource as addSourceAction,
     removeSource as removeSourceAction,
@@ -100,7 +101,10 @@ const showProblemWithExtraSource =
 
 export const handleSourcesWithErrors =
     (sources: SourceWithError[]): AppThunk =>
-    dispatch => {
+    (dispatch, getState) => {
+        if (getIsProxyErrorShown(getState())) {
+            return;
+        }
         sources.forEach(({ source, reason }) => {
             if (source.name === OFFICIAL) {
                 dispatch(showProblemWithOfficialSource(source, reason));

--- a/src/launcher/features/sources/sourcesEffects.ts
+++ b/src/launcher/features/sources/sourcesEffects.ts
@@ -16,7 +16,7 @@ import {
     SourceName,
     SourceUrl,
 } from '../../../ipc/sources';
-import type { AppDispatch } from '../../store';
+import type { AppThunk } from '../../store';
 import { addDownloadableApps, removeAppsOfSource } from '../apps/appsSlice';
 import { hideSource, showSource } from '../filter/filterSlice';
 import {
@@ -24,43 +24,47 @@ import {
     removeSource as removeSourceAction,
 } from './sourcesSlice';
 
-export const addSource = (url: SourceUrl) => (dispatch: AppDispatch) => {
-    addSourceInMain(url)
-        .then(({ source, apps }) => {
-            dispatch(addSourceAction(source));
-            dispatch(showSource(source.name));
-            dispatch(addDownloadableApps(apps));
-        })
-        .catch(error =>
-            dispatch(
-                ErrorDialogActions.showDialog(
-                    cleanIpcErrorMessage(
-                        error.message,
-                        'Error while trying to add a source: '
+export const addSource =
+    (url: SourceUrl): AppThunk =>
+    dispatch => {
+        addSourceInMain(url)
+            .then(({ source, apps }) => {
+                dispatch(addSourceAction(source));
+                dispatch(showSource(source.name));
+                dispatch(addDownloadableApps(apps));
+            })
+            .catch(error =>
+                dispatch(
+                    ErrorDialogActions.showDialog(
+                        cleanIpcErrorMessage(
+                            error.message,
+                            'Error while trying to add a source: '
+                        )
                     )
                 )
-            )
-        );
-};
+            );
+    };
 
-export const removeSource = (name: SourceName) => (dispatch: AppDispatch) => {
-    removeSourceInMain(name)
-        .then(() => {
-            dispatch(removeAppsOfSource(name));
-            dispatch(removeSourceAction(name));
-            dispatch(hideSource(name));
-        })
-        .catch(error =>
-            dispatch(
-                ErrorDialogActions.showDialog(
-                    cleanIpcErrorMessage(
-                        error.message,
-                        `Error while trying to remove the source '${name}': `
+export const removeSource =
+    (name: SourceName): AppThunk =>
+    dispatch => {
+        removeSourceInMain(name)
+            .then(() => {
+                dispatch(removeAppsOfSource(name));
+                dispatch(removeSourceAction(name));
+                dispatch(hideSource(name));
+            })
+            .catch(error =>
+                dispatch(
+                    ErrorDialogActions.showDialog(
+                        cleanIpcErrorMessage(
+                            error.message,
+                            `Error while trying to remove the source '${name}': `
+                        )
                     )
                 )
-            )
-        );
-};
+            );
+    };
 
 const showProblemWithOfficialSource = (source: Source, reason?: string) =>
     ErrorDialogActions.showDialog(
@@ -72,7 +76,8 @@ const showProblemWithOfficialSource = (source: Source, reason?: string) =>
     );
 
 const showProblemWithExtraSource =
-    (source: Source, reason?: string) => (dispatch: AppDispatch) => {
+    (source: Source, reason?: string): AppThunk =>
+    dispatch => {
         dispatch(
             ErrorDialogActions.showDialog(
                 `Unable to retrieve the source “${source.name}” ` +
@@ -94,7 +99,8 @@ const showProblemWithExtraSource =
     };
 
 export const handleSourcesWithErrors =
-    (sources: SourceWithError[]) => (dispatch: AppDispatch) => {
+    (sources: SourceWithError[]): AppThunk =>
+    dispatch => {
         sources.forEach(({ source, reason }) => {
             if (source.name === OFFICIAL) {
                 dispatch(showProblemWithOfficialSource(source, reason));

--- a/src/launcher/features/usageData/usageDataEffects.ts
+++ b/src/launcher/features/usageData/usageDataEffects.ts
@@ -8,7 +8,7 @@ import { usageData } from 'pc-nrfconnect-shared';
 import si from 'systeminformation';
 
 import pkgJson from '../../../../package.json';
-import type { AppDispatch, RootState } from '../../store';
+import type { AppThunk } from '../../store';
 import {
     getIsSendingUsageData,
     hideUsageDataDialog,
@@ -37,36 +37,35 @@ const EventLabel = {
 
 export const isUsageDataOn = () => usageData.isEnabled();
 
-export const confirmSendingUsageData = () => (dispatch: AppDispatch) => {
+export const confirmSendingUsageData = (): AppThunk => dispatch => {
     usageData.enable();
     dispatch(setUsageDataOn());
     dispatch(hideUsageDataDialog());
 };
 
-export const cancelSendingUsageData = () => (dispatch: AppDispatch) => {
+export const cancelSendingUsageData = (): AppThunk => dispatch => {
     usageData.disable();
     dispatch(setUsageDataOff());
     dispatch(hideUsageDataDialog());
 };
 
-export const toggleSendingUsageData =
-    () => (dispatch: AppDispatch, getState: () => RootState) => {
-        const isSendingUsageData = getIsSendingUsageData(getState());
-        dispatch(hideUsageDataDialog());
-        if (isSendingUsageData) {
-            usageData.disable();
-            dispatch(setUsageDataOff());
-            return;
-        }
-        usageData.enable();
-        dispatch(setUsageDataOn());
-    };
+export const toggleSendingUsageData = (): AppThunk => (dispatch, getState) => {
+    const isSendingUsageData = getIsSendingUsageData(getState());
+    dispatch(hideUsageDataDialog());
+    if (isSendingUsageData) {
+        usageData.disable();
+        dispatch(setUsageDataOff());
+        return;
+    }
+    usageData.enable();
+    dispatch(setUsageDataOn());
+};
 
 const initUsageData = (label: string) => {
     usageData.sendUsageData(EventAction.LAUNCH_LAUNCHER, label);
 };
 
-export const checkUsageDataSetting = () => (dispatch: AppDispatch) => {
+export const checkUsageDataSetting = (): AppThunk => dispatch => {
     usageData.init(pkgJson);
     const isSendingUsageData = usageData.isEnabled();
     if (typeof isSendingUsageData !== 'boolean') {

--- a/src/launcher/store.ts
+++ b/src/launcher/store.ts
@@ -7,6 +7,8 @@
 import { configureStore } from '@reduxjs/toolkit';
 import { enableMapSet } from 'immer';
 import { errorDialogReducer as errorDialog } from 'pc-nrfconnect-shared';
+import { AnyAction } from 'redux';
+import { ThunkAction } from 'redux-thunk';
 
 import appDialogs from './features/apps/appDialogsSlice';
 import apps from './features/apps/appsSlice';
@@ -43,5 +45,12 @@ const store = configureStore({
 
 export type RootState = ReturnType<typeof store.getState>;
 export type AppDispatch = typeof store.dispatch;
+
+export type AppThunk<ReturnType = void> = ThunkAction<
+    ReturnType,
+    RootState,
+    unknown,
+    AnyAction
+>;
 
 export default store;

--- a/src/main/apps/sources.ts
+++ b/src/main/apps/sources.ts
@@ -137,14 +137,10 @@ export const downloadSourceJson = (sourceUrl: SourceUrl) =>
     downloadToJson<SourceJson>(sourceUrl, true);
 
 const downloadSourceJsonToFile = async (source: Source) => {
-    try {
-        const sourceJson = await downloadSourceJson(source.url);
-        writeJsonFile(getSourceJsonPath(source), sourceJson);
+    const sourceJson = await downloadSourceJson(source.url);
+    writeJsonFile(getSourceJsonPath(source), sourceJson);
 
-        return sourceJson;
-    } catch (error) {
-        throw source;
-    }
+    return sourceJson;
 };
 
 const readSourceJson = (source: Source) =>

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -59,21 +59,21 @@ const getStartupApp = (argv: Argv): StartupApp | undefined => {
  * Init the config values based on the given command line arguments.
  *
  * Supported command line arguments:
- * --apps-root-dir       The directory where app data is stored.
- *                       Default: "<homeDir>/.nrfconnect-apps"
- * --user-data-dir       Path to the user data dir. If this is not
- *                       set, the environment variable NRF_USER_DATA_DIR
- *                       is also used.
- *                       See also https://www.electronjs.org/docs/api/app#appgetpathname
- *                       Default: The appData directory appended with 'nrfconnect'.
- * --settings-json-path  Path to the user's settings file.
- *                       Default: "<userDataDir>/settings.json"
- * --skip-update-apps    Do not download info/updates about apps.
- *                       Default: false
- * --skip-update-core    Skip checking for updates for nRF Connect for Desktop.
- *                       Default: false
- * --skip-splash-screen  Skip the splash screen at startup.
- *                       Default: false
+ * --apps-root-dir         The directory where app data is stored.
+ *                         Default: "<homeDir>/.nrfconnect-apps"
+ * --user-data-dir         Path to the user data dir. If this is not
+ *                         set, the environment variable NRF_USER_DATA_DIR
+ *                         is also used.
+ *                         See also https://www.electronjs.org/docs/api/app#appgetpathname
+ *                         Default: The appData directory appended with 'nrfconnect'.
+ * --settings-json-path    Path to the user's settings file.
+ *                         Default: "<userDataDir>/settings.json"
+ * --skip-update-apps      Do not download info/updates about apps.
+ *                         Default: false
+ * --skip-update-launcher  Skip checking for updates for nRF Connect for Desktop.
+ *                         Default: false
+ * --skip-splash-screen    Skip the splash screen at startup.
+ *                         Default: false
  */
 export const init = (argv: Argv) => {
     const appsRootDir =
@@ -87,7 +87,7 @@ export const init = (argv: Argv) => {
         ),
         isSkipSplashScreen: !!argv['skip-splash-screen'],
         isSkipUpdateApps: !!argv['skip-update-apps'],
-        isSkipUpdateCore: !!argv['skip-update-core'],
+        isSkipUpdateLauncher: !!argv['skip-update-launcher'],
         settingsJsonPath:
             argv['settings-json-path'] ||
             path.join(app.getPath('userData'), 'settings.json'),

--- a/src/main/net.ts
+++ b/src/main/net.ts
@@ -84,15 +84,10 @@ const downloadToBuffer = (
         request.end();
     });
 
-export const downloadToString = async (
-    url: string,
-    enableProxyLogin: boolean
-) => (await downloadToBuffer(url, enableProxyLogin)).toString();
-
 export const downloadToJson = async <T>(
     url: string,
     enableProxyLogin: boolean
-) => <T>JSON.parse(await downloadToString(url, enableProxyLogin));
+) => <T>JSON.parse((await downloadToBuffer(url, enableProxyLogin)).toString());
 
 export const downloadToFile = async (
     url: string,

--- a/test-e2e/setupTestApp.ts
+++ b/test-e2e/setupTestApp.ts
@@ -13,7 +13,7 @@ const startApp = async (extraArgs: string[]) => {
     const projectPath = path.resolve(__dirname, '../');
     const electronArgs = [
         projectPath,
-        '--skip-update-core',
+        '--skip-update-launcher',
         '--skip-splash-screen',
         ...extraArgs,
     ];


### PR DESCRIPTION
Addresses one aspect of https://trello.com/c/PvzJV1fs.

When cancelling the proxy authentication while getting the latest app infos at least two dialogs were shown:
- The `ProxyErrorDialog`
- An `ErrorDialog` for the sources that could not be updated

Now the second dialog is not shown any longer.

When clicking on “Check for updates” in the settings, the `UpdateCheckCompleteDialog` was also shown, wrongly stating that all apps are up to date. This is also not shown any longer.

Additionally the `ProxyLoginDialog` and `ProxyErrorDialog` were updated to the latest styles. They now look like this:

![image](https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/assets/260705/f6fcb487-87f6-4701-accf-410e4bd3b85f)

![image](https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/assets/260705/711fff56-c5c3-4f18-8e7b-53c4099135fc)

