### PR TITLE
Fix adding sources

### DIFF
--- a/Changelog.minor.md
+++ b/Changelog.minor.md
@@ -17,6 +17,14 @@ release the new version.
     -   Proxy dialogs were outdated.
     -   Multiple, partially misleading dialogs were displayed if users cancelled
         the proxy login.
+-   #853:
+    -   Add Source dialog:
+        -   Trim leading and trailing whitespace from URL.
+        -   Dialog style was outdated.
+        -   More expressive error messages for typical errors: `source.json` not
+            reachable at given URL, source already exists, or trying to add the
+            official source.
+    -   Name filter for apps: Trim leading and trailing whitespace.
 
 ## 4.1.2
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "nrfconnect",
-    "version": "4.1.2-pre2",
+    "version": "4.1.3-pre",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "nrfconnect",
-            "version": "4.1.2-pre2",
+            "version": "4.1.3-pre",
             "license": "Proprietary",
             "dependencies": {
                 "@electron/remote": "2.0.8",
@@ -41,7 +41,7 @@
                 "electron-builder": "^22.14.13",
                 "electron-devtools-installer": "3.2.0",
                 "electron-notarize": "0.3.0",
-                "pc-nrfconnect-shared": "github:NordicSemiconductor/pc-nrfconnect-shared#v54",
+                "pc-nrfconnect-shared": "github:NordicSemiconductor/pc-nrfconnect-shared#v63",
                 "playwright": "^1.16.3",
                 "xvfb-maybe": "0.2.1"
             }
@@ -2125,6 +2125,21 @@
             "resolved": "https://registry.npmjs.org/@mdi/font/-/font-7.2.96.tgz",
             "integrity": "sha512-e//lmkmpFUMZKhmCY9zdjRe4zNXfbOIJnn6xveHbaV2kSw5aJ5dLXUxcRt1Gxfi7ZYpFLUWlkG2MGSFAiqAu7w==",
             "dev": true
+        },
+        "node_modules/@mdi/js": {
+            "version": "7.2.96",
+            "resolved": "https://registry.npmjs.org/@mdi/js/-/js-7.2.96.tgz",
+            "integrity": "sha512-paR9M9ZT7rKbh2boksNUynuSZMHhqRYnEZOm/KrZTjQ4/FzyhjLHuvw/8XYzP+E7fS4+/Ms/82EN1pl/OFsiIA==",
+            "dev": true
+        },
+        "node_modules/@mdi/react": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@mdi/react/-/react-1.6.1.tgz",
+            "integrity": "sha512-4qZeDcluDFGFTWkHs86VOlHkm6gnKaMql13/gpIcUQ8kzxHgpj31NuCkD8abECVfbULJ3shc7Yt4HJ6Wu6SN4w==",
+            "dev": true,
+            "dependencies": {
+                "prop-types": "^15.7.2"
+            }
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
@@ -14467,14 +14482,16 @@
             }
         },
         "node_modules/pc-nrfconnect-shared": {
-            "version": "54.0.0",
-            "resolved": "git+ssh://git@github.com/NordicSemiconductor/pc-nrfconnect-shared.git#c408c7448754d5e446cc6639fb22e7c42c11b91f",
+            "version": "63.0.0",
+            "resolved": "git+ssh://git@github.com/NordicSemiconductor/pc-nrfconnect-shared.git#530606bc2aff22b1c7d5996b1a5f164d714d0f55",
             "dev": true,
             "hasInstallScript": true,
             "license": "ISC",
             "dependencies": {
                 "@electron/remote": "^2.0.4",
                 "@mdi/font": "7.2.96",
+                "@mdi/js": "^7.2.96",
+                "@mdi/react": "^1.6.1",
                 "@reduxjs/toolkit": "1.9.3",
                 "@svgr/core": "^7.0.0",
                 "@svgr/plugin-jsx": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
         "electron-builder": "^22.14.13",
         "electron-devtools-installer": "3.2.0",
         "electron-notarize": "0.3.0",
-        "pc-nrfconnect-shared": "github:NordicSemiconductor/pc-nrfconnect-shared#v54",
+        "pc-nrfconnect-shared": "github:NordicSemiconductor/pc-nrfconnect-shared#v63",
         "playwright": "^1.16.3",
         "xvfb-maybe": "0.2.1"
     },

--- a/src/ipc/sources.ts
+++ b/src/ipc/sources.ts
@@ -32,10 +32,19 @@ export const getSources = invoke<GetSources>(channel.get);
 export const registerGetSources = handle<GetSources>(channel.get);
 
 // Add
-type AddSource = (url: SourceUrl) => {
-    source: Source;
-    apps: DownloadableApp[];
-};
+type AddSourceResult =
+    | {
+          type: 'success';
+          source: Source;
+          apps: DownloadableApp[];
+      }
+    | {
+          type: 'error';
+          errorType: 'Source already exists';
+          existingSource: Source;
+      };
+
+type AddSource = (url: SourceUrl) => AddSourceResult;
 
 export const addSource = invoke<AddSource>(channel.add);
 export const registerAddSource = handle<AddSource>(channel.add);

--- a/src/ipc/sources.ts
+++ b/src/ipc/sources.ts
@@ -32,17 +32,27 @@ export const getSources = invoke<GetSources>(channel.get);
 export const registerGetSources = handle<GetSources>(channel.get);
 
 // Add
-type AddSourceResult =
+export type AddSourceError =
     | {
-          type: 'success';
-          source: Source;
-          apps: DownloadableApp[];
+          type: 'error';
+          errorType: 'Unable to retrieve source.json';
+          message: string;
+      }
+    | {
+          type: 'error';
+          errorType: 'Official sources cannot be added';
       }
     | {
           type: 'error';
           errorType: 'Source already exists';
           existingSource: Source;
       };
+export type AddSourceSuccess = {
+    type: 'success';
+    source: Source;
+    apps: DownloadableApp[];
+};
+export type AddSourceResult = AddSourceSuccess | AddSourceError;
 
 type AddSource = (url: SourceUrl) => AddSourceResult;
 

--- a/src/launcher/features/filter/filterSlice.ts
+++ b/src/launcher/features/filter/filterSlice.ts
@@ -72,7 +72,7 @@ const matchesSourceFilter = (app: App, state: RootState) =>
     !state.filter.hiddenSources.has(app.source);
 
 const matchesNameFilter = (app: App, state: RootState) => {
-    const filter = state.filter.nameFilter;
+    const filter = state.filter.nameFilter.trim();
 
     try {
         return new RegExp(filter, 'i').test(app.displayName);

--- a/src/launcher/features/sources/AddSourceDialog.tsx
+++ b/src/launcher/features/sources/AddSourceDialog.tsx
@@ -28,8 +28,8 @@ export default () => {
             </Modal.Header>
             <Form
                 onSubmit={e => {
-                    if (url.length > 0) {
-                        dispatch(addSource(url));
+                    if (url.trim().length > 0) {
+                        dispatch(addSource(url.trim()));
                         dispatch(hideAddSource());
                         setUrl('');
                     }

--- a/src/launcher/features/sources/AddSourceDialog.tsx
+++ b/src/launcher/features/sources/AddSourceDialog.tsx
@@ -6,7 +6,7 @@
 
 import React, { useState } from 'react';
 import Form from 'react-bootstrap/Form';
-import { ConfirmationDialog } from 'pc-nrfconnect-shared';
+import { ConfirmationDialog, useFocusedOnVisible } from 'pc-nrfconnect-shared';
 
 import { useLauncherDispatch, useLauncherSelector } from '../../util/hooks';
 import { addSource } from './sourcesEffects';
@@ -16,6 +16,8 @@ export default () => {
     const dispatch = useLauncherDispatch();
     const isVisible = useLauncherSelector(getIsAddSourceVisible);
     const [url, setUrl] = useState('');
+
+    const ref = useFocusedOnVisible<HTMLInputElement>(isVisible);
 
     const cancel = () => dispatch(hideAddSource());
 
@@ -36,6 +38,7 @@ export default () => {
             onCancel={cancel}
         >
             <Form.Control
+                ref={ref}
                 value={url}
                 onChange={event => setUrl(event.target.value)}
                 placeholder="https://..."

--- a/src/launcher/features/sources/AddSourceDialog.tsx
+++ b/src/launcher/features/sources/AddSourceDialog.tsx
@@ -37,15 +37,14 @@ export default () => {
             onConfirm={maybeAddSource}
             onCancel={cancel}
         >
+            <p>
+                Enter the URL of a source&rsquo;s <code>source.json</code> file:
+            </p>
             <Form.Control
                 ref={ref}
                 value={url}
                 onChange={event => setUrl(event.target.value)}
-                placeholder="https://..."
             />
-            <small className="text-muted">
-                The source file must be in .json format
-            </small>
         </ConfirmationDialog>
     );
 };

--- a/src/launcher/features/sources/AddSourceDialog.tsx
+++ b/src/launcher/features/sources/AddSourceDialog.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-import React from 'react';
+import React, { useState } from 'react';
 import Button from 'react-bootstrap/Button';
 import ButtonToolbar from 'react-bootstrap/ButtonToolbar';
 import Form from 'react-bootstrap/Form';
@@ -17,6 +17,7 @@ import { getIsAddSourceVisible, hideAddSource } from './sourcesSlice';
 export default () => {
     const dispatch = useLauncherDispatch();
     const isVisible = useLauncherSelector(getIsAddSourceVisible);
+    const [url, setUrl] = useState('');
 
     const cancel = () => dispatch(hideAddSource());
 
@@ -27,17 +28,18 @@ export default () => {
             </Modal.Header>
             <Form
                 onSubmit={e => {
-                    const url = e.currentTarget.inputField.value;
-                    dispatch(addSource(url));
-                    dispatch(hideAddSource());
+                    if (url.length > 0) {
+                        dispatch(addSource(url));
+                        dispatch(hideAddSource());
+                        setUrl('');
+                    }
                     e.preventDefault();
                 }}
             >
                 <Modal.Body>
                     <Form.Control
-                        as="input"
-                        type="text"
-                        name="inputField"
+                        value={url}
+                        onChange={event => setUrl(event.target.value)}
                         placeholder="https://..."
                     />
                     <small className="text-muted">
@@ -46,7 +48,11 @@ export default () => {
                 </Modal.Body>
                 <Modal.Footer>
                     <ButtonToolbar className="wide-btns">
-                        <Button type="submit" variant="outline-primary">
+                        <Button
+                            type="submit"
+                            variant="outline-primary"
+                            disabled={url == null}
+                        >
                             Add
                         </Button>
                         <Button variant="outline-secondary" onClick={cancel}>

--- a/src/launcher/features/sources/AddSourceDialog.tsx
+++ b/src/launcher/features/sources/AddSourceDialog.tsx
@@ -5,10 +5,8 @@
  */
 
 import React, { useState } from 'react';
-import Button from 'react-bootstrap/Button';
-import ButtonToolbar from 'react-bootstrap/ButtonToolbar';
 import Form from 'react-bootstrap/Form';
-import Modal from 'react-bootstrap/Modal';
+import { ConfirmationDialog } from 'pc-nrfconnect-shared';
 
 import { useLauncherDispatch, useLauncherSelector } from '../../util/hooks';
 import { addSource } from './sourcesEffects';
@@ -21,46 +19,30 @@ export default () => {
 
     const cancel = () => dispatch(hideAddSource());
 
+    const maybeAddSource = () => {
+        if (url.trim().length > 0) {
+            dispatch(addSource(url.trim()));
+            dispatch(hideAddSource());
+            setUrl('');
+        }
+    };
+
     return (
-        <Modal show={isVisible} onHide={cancel} backdrop="static">
-            <Modal.Header>
-                <Modal.Title>Add source</Modal.Title>
-            </Modal.Header>
-            <Form
-                onSubmit={e => {
-                    if (url.trim().length > 0) {
-                        dispatch(addSource(url.trim()));
-                        dispatch(hideAddSource());
-                        setUrl('');
-                    }
-                    e.preventDefault();
-                }}
-            >
-                <Modal.Body>
-                    <Form.Control
-                        value={url}
-                        onChange={event => setUrl(event.target.value)}
-                        placeholder="https://..."
-                    />
-                    <small className="text-muted">
-                        The source file must be in .json format
-                    </small>
-                </Modal.Body>
-                <Modal.Footer>
-                    <ButtonToolbar className="wide-btns">
-                        <Button
-                            type="submit"
-                            variant="outline-primary"
-                            disabled={url == null}
-                        >
-                            Add
-                        </Button>
-                        <Button variant="outline-secondary" onClick={cancel}>
-                            Close
-                        </Button>
-                    </ButtonToolbar>
-                </Modal.Footer>
-            </Form>
-        </Modal>
+        <ConfirmationDialog
+            isVisible={isVisible}
+            title="Add source"
+            confirmLabel="Add"
+            onConfirm={maybeAddSource}
+            onCancel={cancel}
+        >
+            <Form.Control
+                value={url}
+                onChange={event => setUrl(event.target.value)}
+                placeholder="https://..."
+            />
+            <small className="text-muted">
+                The source file must be in .json format
+            </small>
+        </ConfirmationDialog>
     );
 };

--- a/src/launcher/features/sources/sourcesEffects.ts
+++ b/src/launcher/features/sources/sourcesEffects.ts
@@ -5,11 +5,13 @@
  */
 
 import { ErrorDialogActions } from 'pc-nrfconnect-shared';
+import { AnyAction } from 'redux';
 
 import { SourceWithError } from '../../../ipc/apps';
 import { cleanIpcErrorMessage } from '../../../ipc/error';
 import {
     addSource as addSourceInMain,
+    AddSourceError,
     OFFICIAL,
     removeSource as removeSourceInMain,
     Source,
@@ -25,6 +27,26 @@ import {
     removeSource as removeSourceAction,
 } from './sourcesSlice';
 
+const showError = (url: string, addSourceError: AddSourceError): AnyAction => {
+    switch (addSourceError.errorType) {
+        case 'Official sources cannot be added':
+            return ErrorDialogActions.showDialog(
+                `The url \`${url}\` points to the official source and that cannot be added again.`
+            );
+        case 'Source already exists':
+            return ErrorDialogActions.showDialog(
+                `No source added because there already is one with the name “${addSourceError.existingSource.name}”.`
+            );
+
+        case 'Unable to retrieve source.json':
+            return ErrorDialogActions.showDialog(
+                `Unable to retrieve a valid \`source.json\` under the URL \`${url}\`. No source was added.`,
+                undefined,
+                cleanIpcErrorMessage(addSourceError.message)
+            );
+    }
+};
+
 export const addSource =
     (url: SourceUrl): AppThunk =>
     dispatch => {
@@ -35,19 +57,13 @@ export const addSource =
                     dispatch(showSource(result.source.name));
                     dispatch(addDownloadableApps(result.apps));
                 } else {
-                    dispatch(
-                        ErrorDialogActions.showDialog(
-                            'No source added because there already is one ' +
-                                `with the name “${result.existingSource.name}”.`
-                        )
-                    );
+                    dispatch(showError(url, result));
                 }
             })
             .catch(error =>
                 dispatch(
                     ErrorDialogActions.showDialog(
-                        'Unable to retrieve a valid `source.json` under ' +
-                            `the URL \`${url}\`. No source was added.`,
+                        'Unknown error. No source was added.',
                         undefined,
                         cleanIpcErrorMessage(error.message)
                     )

--- a/src/launcher/features/sources/sourcesEffects.ts
+++ b/src/launcher/features/sources/sourcesEffects.ts
@@ -46,10 +46,10 @@ export const addSource =
             .catch(error =>
                 dispatch(
                     ErrorDialogActions.showDialog(
-                        cleanIpcErrorMessage(
-                            error.message,
-                            'Error while trying to add a source: '
-                        )
+                        'Unable to retrieve a valid `source.json` under ' +
+                            `the URL \`${url}\`. No source was added.`,
+                        undefined,
+                        cleanIpcErrorMessage(error.message)
                     )
                 )
             );

--- a/src/launcher/features/sources/sourcesEffects.ts
+++ b/src/launcher/features/sources/sourcesEffects.ts
@@ -29,10 +29,19 @@ export const addSource =
     (url: SourceUrl): AppThunk =>
     dispatch => {
         addSourceInMain(url)
-            .then(({ source, apps }) => {
-                dispatch(addSourceAction(source));
-                dispatch(showSource(source.name));
-                dispatch(addDownloadableApps(apps));
+            .then(result => {
+                if (result.type === 'success') {
+                    dispatch(addSourceAction(result.source));
+                    dispatch(showSource(result.source.name));
+                    dispatch(addDownloadableApps(result.apps));
+                } else {
+                    dispatch(
+                        ErrorDialogActions.showDialog(
+                            'No source added because there already is one ' +
+                                `with the name “${result.existingSource.name}”.`
+                        )
+                    );
+                }
             })
             .catch(error =>
                 dispatch(

--- a/src/main/apps/sourceChanges.ts
+++ b/src/main/apps/sourceChanges.ts
@@ -20,6 +20,7 @@ import { downloadAppInfos } from './apps';
 import {
     addToSourceList,
     downloadSourceJson,
+    getSource,
     initialise,
     removeFromSourceList,
     writeSourceJson,
@@ -46,6 +47,15 @@ const downloadSource = async (
 export const addSource = async (url: SourceUrl) => {
     const { source, sourceJson } = await downloadSource(url);
 
+    const existingSource = getSource(source.name);
+    if (existingSource != null) {
+        return {
+            type: 'error',
+            errorType: 'Source already exists',
+            existingSource,
+        } as const;
+    }
+
     initialise(source);
     writeSourceJson(source, sourceJson);
 
@@ -55,7 +65,7 @@ export const addSource = async (url: SourceUrl) => {
         addDownloadAppData(source.name)
     );
 
-    return { source, apps };
+    return { type: 'success', source, apps } as const;
 };
 
 const isRemovableSource = (

--- a/src/main/apps/sourceChanges.ts
+++ b/src/main/apps/sourceChanges.ts
@@ -8,6 +8,7 @@ import fs from 'fs-extra';
 import { SourceJson } from 'pc-nrfconnect-shared';
 
 import {
+    AddSourceResult,
     allStandardSourceNames,
     OFFICIAL,
     Source,
@@ -15,6 +16,7 @@ import {
     SourceUrl,
 } from '../../ipc/sources';
 import { getAppsRootDir } from '../config';
+import describeError from '../describeError';
 import { addDownloadAppData } from './app';
 import { downloadAppInfos } from './apps';
 import {
@@ -32,10 +34,6 @@ const downloadSource = async (
     const sourceJson = await downloadSourceJson(url);
     const source: Source = { name: sourceJson.name, url };
 
-    if (source.name === OFFICIAL) {
-        throw new Error('The official source cannot be added.');
-    }
-
     const isLegacyUrl = url.endsWith('/apps.json') && sourceJson.apps == null;
     if (isLegacyUrl) {
         return downloadSource(url.replace(/apps.json$/, 'source.json'));
@@ -44,8 +42,22 @@ const downloadSource = async (
     return { source, sourceJson };
 };
 
-export const addSource = async (url: SourceUrl) => {
-    const { source, sourceJson } = await downloadSource(url);
+export const addSource = async (url: SourceUrl): Promise<AddSourceResult> => {
+    let downloadResult;
+    try {
+        downloadResult = await downloadSource(url);
+    } catch (error) {
+        return {
+            type: 'error',
+            errorType: 'Unable to retrieve source.json',
+            message: describeError(error),
+        };
+    }
+    const { source, sourceJson } = downloadResult;
+
+    if (source.name === OFFICIAL) {
+        return { type: 'error', errorType: 'Official sources cannot be added' };
+    }
 
     const existingSource = getSource(source.name);
     if (existingSource != null) {
@@ -53,7 +65,7 @@ export const addSource = async (url: SourceUrl) => {
             type: 'error',
             errorType: 'Source already exists',
             existingSource,
-        } as const;
+        };
     }
 
     initialise(source);
@@ -65,7 +77,7 @@ export const addSource = async (url: SourceUrl) => {
         addDownloadAppData(source.name)
     );
 
-    return { type: 'success', source, apps } as const;
+    return { type: 'success', source, apps };
 };
 
 const isRemovableSource = (


### PR DESCRIPTION
Addresses https://trello.com/c/cYOI5gkg and https://trello.com/c/vqYYyynf:

Fixes several aspects of the “Add source” dialog:

- Leading and trailing whitespace is trimmed from the entered URL.
- The dialog now uses the common style.
- More expressive error messages for typical errors: 
  - `source.json` not reachable at given URL
  - source already exists
  - trying to add the official source.

The dialog now looks like this:
![image](https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/assets/260705/23a88623-f4d5-4e1c-99c1-82593574e8a2)

Also sneaks in a small fix for the name filter for apps: There leading and trailing whitespace are now also ignored.


