### PR TITLE
Fix shortcuts with differing directories

### DIFF
--- a/Changelog.minor.md
+++ b/Changelog.minor.md
@@ -31,6 +31,22 @@ release the new version.
             official source.
     -   Name filter for apps: Trim leading and trailing whitespace.
 -   #855: Bump device-lib-js to 0.6.13
+-   #856: Fix shortcuts when different directories were specified.
+
+    To reproduce:
+
+    1. Determine an app (e.g. DTM) which is not installed when running the
+       launcher normally, with default directories.
+    1. Start the launcher with the options `--user-data-dir` and
+       `--apps-root-dir`, e.g. on macOS with
+       `--user-data-dir /tmp/nrf_data --apps-root-dir /tmp/nrf_apps`.
+    1. The launcher open without any apps installed. Install one and create a
+       shortcut to it.
+    1. Open the shortcut.
+
+    Previously the app didn't open, instead an error message was shown: “Error
+    when starting application – Error: Tried to open app …, but it is not
+    installed”. Now the app opens correctly.
 
 ## 4.1.2
 

--- a/src/main/apps/createDesktopShortcut.ts
+++ b/src/main/apps/createDesktopShortcut.ts
@@ -35,31 +35,39 @@ const sourceName = (app: LaunchableApp) => {
 const getFileName = (app: LaunchableApp) =>
     `${app.displayName || app.name}${sourceName(app)}`;
 
-const maybeAppsRootDir = () => {
+const arg = (name: string, argument: string) => [`--${name}`, `"${argument}"`];
+
+const appNameArg = (app: LaunchableApp) =>
+    arg(
+        isDownloadable(app) ? 'open-downloadable-app' : 'open-local-app',
+        app.name
+    );
+
+const sourceArg = (app: LaunchableApp) => arg('source', app.source);
+
+const maybeAppsRootDirArg = () => {
     if (argv['apps-root-dir'] == null) {
         return [];
     }
 
-    return ['--apps-root-dir', `"${argv['apps-root-dir']}"`];
+    return arg('apps-root-dir', argv['apps-root-dir']);
 };
 
-const maybeUserDataDir = () => {
+const maybeUserDataDirArg = () => {
     if (argv['user-data-dir'] == null) {
         return [];
     }
 
-    return ['--user-data-dir', `"${argv['user-data-dir']}"`];
+    return arg('user-data-dir', argv['user-data-dir']);
 };
 
 const getArgs = (app: LaunchableApp) =>
     [
         '--args',
-        isDownloadable(app) ? '--open-downloadable-app' : '--open-local-app',
-        app.name,
-        '--source',
-        `"${app.source}"`,
-        maybeAppsRootDir(),
-        maybeUserDataDir(),
+        appNameArg(app),
+        sourceArg(app),
+        maybeAppsRootDirArg(),
+        maybeUserDataDirArg(),
     ]
         .flat()
         .join(' ');

--- a/src/main/apps/createDesktopShortcut.ts
+++ b/src/main/apps/createDesktopShortcut.ts
@@ -12,6 +12,7 @@ import { uuid } from 'short-uuid';
 import { isDownloadable, LaunchableApp } from '../../ipc/apps';
 import { showErrorDialog } from '../../ipc/showErrorDialog';
 import { OFFICIAL } from '../../ipc/sources';
+import argv from '../argv';
 import { chmod, chmodDir, copy, readFile, untar, writeFile } from '../fileUtil';
 import { getShortcutIcon } from '../icons';
 
@@ -34,6 +35,22 @@ const sourceName = (app: LaunchableApp) => {
 const getFileName = (app: LaunchableApp) =>
     `${app.displayName || app.name}${sourceName(app)}`;
 
+const maybeAppsRootDir = () => {
+    if (argv['apps-root-dir'] == null) {
+        return [];
+    }
+
+    return ['--apps-root-dir', `"${argv['apps-root-dir']}"`];
+};
+
+const maybeUserDataDir = () => {
+    if (argv['user-data-dir'] == null) {
+        return [];
+    }
+
+    return ['--user-data-dir', `"${argv['user-data-dir']}"`];
+};
+
 const getArgs = (app: LaunchableApp) =>
     [
         '--args',
@@ -41,7 +58,11 @@ const getArgs = (app: LaunchableApp) =>
         app.name,
         '--source',
         `"${app.source}"`,
-    ].join(' ');
+        maybeAppsRootDir(),
+        maybeUserDataDir(),
+    ]
+        .flat()
+        .join(' ');
 
 const createShortcutForWindows = (app: LaunchableApp) => {
     const fileName = getFileName(app);

--- a/src/main/argv.ts
+++ b/src/main/argv.ts
@@ -60,6 +60,7 @@ const isBundledApp = !process.defaultApp;
 const args = process.argv.slice(isBundledApp ? 1 : 2);
 
 const argv = parseArgs<CommandLineArguments>(args, {
+    '--': true,
     boolean: [
         'skip-splash-screen',
         'skip-update-apps',
@@ -68,6 +69,9 @@ const argv = parseArgs<CommandLineArguments>(args, {
         'remove-devtools',
     ],
 });
+
+// eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- Because '--': true is set above, this will always be non-null.
+export const additionalArguments: string[] = argv['--']!;
 
 type StartupApp =
     | {

--- a/src/main/argv.ts
+++ b/src/main/argv.ts
@@ -56,7 +56,10 @@ interface CommandLineArguments {
     'remove-devtools': boolean;
 }
 
-const argv = parseArgs<CommandLineArguments>(process.argv.slice(2), {
+const isBundledApp = !process.defaultApp;
+const args = process.argv.slice(isBundledApp ? 1 : 2);
+
+const argv = parseArgs<CommandLineArguments>(args, {
     boolean: [
         'skip-splash-screen',
         'skip-update-apps',

--- a/src/main/browser.ts
+++ b/src/main/browser.ts
@@ -11,7 +11,7 @@ import {
     shell,
 } from 'electron';
 
-import argv from './argv';
+import { additionalArguments } from './argv';
 import { getElectronResourcesDir } from './config';
 
 type BrowserWindowOptions = BrowserWindowConstructorOptions & {
@@ -44,11 +44,14 @@ const createSplashScreen = (icon: BrowserWindowOptions['icon']) => {
 };
 
 const mergeAdditionalArguments = (nonCommandlineArguments: string[]) => {
-    if (argv._.length === 0 && nonCommandlineArguments.length === 0) {
+    if (
+        additionalArguments.length === 0 &&
+        nonCommandlineArguments.length === 0
+    ) {
         return [];
     }
 
-    return ['--', ...nonCommandlineArguments, ...argv._];
+    return ['--', ...nonCommandlineArguments, ...additionalArguments];
 };
 
 export const createWindow = (


### PR DESCRIPTION
To reproduce:

1. Determine an app (e.g. DTM) which is not installed when running the   launcher normally, with default directories.
2. Start the launcher with the options `--user-data-dir` and   `--apps-root-dir`, e.g. on macOS with `--user-data-dir /tmp/nrf_data --apps-root-dir /tmp/nrf_apps`.
3. The launcher open without any apps installed. Install one and create   a shortcut to it.
4. Open the shortcut.

Previously the app didn't open, instead an error message was shown: “Error when starting application – Error: Tried to open app …, but it is not installed”. Now the app opens correctly.