### PR TITLE
fix: handle launcherWindow undefined

### DIFF
--- a/src/ipc/infrastructure/mainToRenderer.ts
+++ b/src/ipc/infrastructure/mainToRenderer.ts
@@ -6,7 +6,7 @@
 
 import { BrowserWindow, ipcRenderer } from 'electron';
 
-let launcherWindow: BrowserWindow;
+let launcherWindow: BrowserWindow | undefined;
 
 export const registerLauncherWindowFromMain = (window: BrowserWindow) => {
     launcherWindow = window;
@@ -17,7 +17,7 @@ export const send =
         channel: string
     ) =>
     (...args: Parameters<T>) =>
-        launcherWindow.webContents.send(channel, ...args);
+        launcherWindow?.webContents.send(channel, ...args);
 
 export const on =
     <T extends (...args: any[]) => void>( // eslint-disable-line @typescript-eslint/no-explicit-any -- We have to explicitly allow any function here


### PR DESCRIPTION
This is relevant for the quickstart app and should technically be handled anyway. The invoke handler for this is exposed and an app can be started without ever opening/registering a launcher window.