### PR TITLE
Show empty apps list help

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,8 @@
 
 -   Successfully installing an app will focus it and highlight it for
     visibility.
+-   Show help if the app list is empty (usually because all apps have been
+    filtered out).
 
 ## 4.1.2 - 2023-06-15
 

--- a/resources/css/launcher.scss
+++ b/resources/css/launcher.scss
@@ -29,9 +29,8 @@ body {
 }
 
 #webapp {
-    display: grid;
-    grid-template-rows: 0fr 1fr;
-    height: 100vh;
+    display: flex;
+    flex-direction: column;
 
     .nav {
         background-color: theme-color('primary');
@@ -60,8 +59,19 @@ body {
     }
 
     .tab-content {
-        padding: 0 0 16px 32px;
+        padding: 16px 32px 16px 32px;
         overflow: hidden;
+
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+
+        .tab-pane.active {
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+        }
+
         .progress {
             position: absolute;
             width: 100%;
@@ -79,15 +89,15 @@ body {
     }
 
     .with-scrollbar {
-        // Height: subtract navigation header (64px), the 16px margin at top and 16 px spacing bottom
+        // Height: subtract navigation header (64px) and the 16px margins at top and bottom
         height: calc(100vh - 64px - 16px - 16px);
-        margin: 14px 14px 0 0;
+        margin-right: -14px;
         overflow-y: overlay;
         @include scrollbars($gray-100);
     }
     .filter-adjusted-height {
-        // Height: subtract navigation header (64px) and filterbox (48px) and 16px spacing bottom
-        height: calc(100vh - 64px - 48px - 16px);
+        // Height: subtract navigation header (64px), filterbox (40px), and the 16px margins at top and bottom
+        height: calc(100vh - 64px - 40px - 16px - 16px);
         margin-top: 0;
     }
 }
@@ -212,10 +222,10 @@ body {
 .filterbox {
     z-index: 1;
     top: 0;
-    height: 48px;
+    height: 40px;
     position: sticky;
     background-color: $body-bg;
-    align-items: center;
+    align-items: start;
 
     > * {
         margin-left: 0.75em;
@@ -261,8 +271,4 @@ body {
     .toggle-label {
         font-size: 1rem;
     }
-}
-
-.me_32px {
-    margin-right: 32px;
 }

--- a/src/launcher/features/apps/AppList.test.tsx
+++ b/src/launcher/features/apps/AppList.test.tsx
@@ -7,6 +7,7 @@
 import React from 'react';
 import { Provider } from 'react-redux';
 import { mount } from 'enzyme';
+import { LOCAL } from 'pc-nrfconnect-shared/ipc/sources';
 
 import {
     createDownloadableTestApp,
@@ -14,6 +15,7 @@ import {
     createUninstalledTestApp,
 } from '../../../test/testFixtures';
 import render, { preparedStore } from '../../../test/testrenderer';
+import { hideSource } from '../filter/filterSlice';
 import AppList from './AppList';
 import {
     checkEngineAndLaunch,
@@ -67,6 +69,15 @@ const mockThunk = (thunkToMock: jest.MockableFunction) => {
 describe('AppList', () => {
     it('should render without any apps', () => {
         expect(render(<AppList />).baseElement).toMatchSnapshot();
+    });
+
+    it('should render with all apps filtered out', () => {
+        expect(
+            render(<AppList />, [
+                setAllLocalApps([localApp]),
+                hideSource(LOCAL),
+            ]).baseElement
+        ).toMatchSnapshot();
     });
 
     it('should render local, not-installed, installed, and updatable apps', () => {

--- a/src/launcher/features/apps/AppList.test.tsx
+++ b/src/launcher/features/apps/AppList.test.tsx
@@ -5,6 +5,7 @@
  */
 
 import React from 'react';
+import { act } from 'react-dom/test-utils';
 import { Provider } from 'react-redux';
 import { mount } from 'enzyme';
 import { LOCAL } from 'pc-nrfconnect-shared/ipc/sources';
@@ -67,8 +68,23 @@ const mockThunk = (thunkToMock: jest.MockableFunction) => {
 };
 
 describe('AppList', () => {
-    it('should render without any apps', () => {
+    it('should render without any apps initially empty', () => {
         expect(render(<AppList />).baseElement).toMatchSnapshot();
+    });
+
+    it('should render a message without any apps after some time', () => {
+        jest.useFakeTimers();
+
+        const view = render(<AppList />);
+
+        act(() => {
+            jest.runAllTimers();
+        });
+
+        expect(view.baseElement).toMatchSnapshot();
+
+        jest.runOnlyPendingTimers();
+        jest.useRealTimers();
     });
 
     it('should render with all apps filtered out', () => {

--- a/src/launcher/features/apps/AppList.tsx
+++ b/src/launcher/features/apps/AppList.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { App as AppType, isInstalled } from '../../../ipc/apps';
 import { useLauncherSelector } from '../../util/hooks';
@@ -27,21 +27,31 @@ const sortByStateAndName = (appA: AppType, appB: AppType) => {
     return cmpInstalled || aName.localeCompare(bName);
 };
 
-const NoApps = ({ notYetLoaded }: { notYetLoaded: boolean }) => (
-    <div className="tw-grid tw-flex-1 tw-place-items-center">
-        <div className="tw-max-w-[75%] tw-bg-white tw-p-4">
-            {notYetLoaded ? (
-                <>
-                    The list of apps is not yet loaded from{' '}
-                    <Link href="https://developer.nordicsemi.com" />. Make sure
-                    you can reach that server.
-                </>
-            ) : (
-                'No apps shown because of the selected filters. Change those to display apps again.'
-            )}
+const NoApps = ({ notYetLoaded }: { notYetLoaded: boolean }) => {
+    const [justStarted, setJustStarted] = useState(true);
+
+    useEffect(() => {
+        setTimeout(() => setJustStarted(false), 2000);
+    }, []);
+
+    if (justStarted && notYetLoaded) return null;
+
+    return (
+        <div className="tw-grid tw-flex-1 tw-place-items-center">
+            <div className="tw-max-w-[75%] tw-bg-white tw-p-4">
+                {notYetLoaded ? (
+                    <>
+                        The list of apps is not yet loaded from{' '}
+                        <Link href="https://developer.nordicsemi.com" />. Make
+                        sure you can reach that server.
+                    </>
+                ) : (
+                    'No apps shown because of the selected filters. Change those to display apps again.'
+                )}
+            </div>
         </div>
-    </div>
-);
+    );
+};
 
 const Apps = ({ apps }: { apps: DisplayedApp[] }) => (
     <WithScrollbarContainer hasFilter>

--- a/src/launcher/features/apps/AppList.tsx
+++ b/src/launcher/features/apps/AppList.tsx
@@ -8,12 +8,13 @@ import React from 'react';
 
 import { App as AppType, isInstalled } from '../../../ipc/apps';
 import { useLauncherSelector } from '../../util/hooks';
+import Link from '../../util/Link';
 import WithScrollbarContainer from '../../util/WithScrollbarContainer';
 import AppFilterBar from '../filter/AppFilterBar';
 import { getAppsFilter } from '../filter/filterSlice';
 import ReleaseNotesDialog from '../releaseNotes/ReleaseNotesDialog';
 import App from './App/App';
-import { getAllApps } from './appsSlice';
+import { DisplayedApp, getAllApps } from './appsSlice';
 import ConfirmLaunchDialog from './ConfirmLaunchDialog';
 import InstallOtherVersionDialog from './InstallOtherVersionDialog';
 
@@ -26,6 +27,30 @@ const sortByStateAndName = (appA: AppType, appB: AppType) => {
     return cmpInstalled || aName.localeCompare(bName);
 };
 
+const NoApps = ({ notYetLoaded }: { notYetLoaded: boolean }) => (
+    <div className="tw-grid tw-flex-1 tw-place-items-center">
+        <div className="tw-max-w-[75%] tw-bg-white tw-p-4">
+            {notYetLoaded ? (
+                <>
+                    The list of apps is not yet loaded from{' '}
+                    <Link href="https://developer.nordicsemi.com" />. Make sure
+                    you can reach that server.
+                </>
+            ) : (
+                'No apps shown because of the selected filters. Change those to display apps again.'
+            )}
+        </div>
+    </div>
+);
+
+const Apps = ({ apps }: { apps: DisplayedApp[] }) => (
+    <WithScrollbarContainer hasFilter>
+        {apps.map(app => (
+            <App key={`${app.name}-${app.source}`} app={app} />
+        ))}
+    </WithScrollbarContainer>
+);
+
 export default () => {
     const allApps = useLauncherSelector(getAllApps);
     const appsFilter = useLauncherSelector(getAppsFilter);
@@ -35,12 +60,11 @@ export default () => {
     return (
         <>
             <AppFilterBar />
-            <WithScrollbarContainer hasFilter>
-                {apps.map(app => (
-                    <App key={`${app.name}-${app.source}`} app={app} />
-                ))}
-            </WithScrollbarContainer>
-
+            {apps.length === 0 ? (
+                <NoApps notYetLoaded={allApps.length === 0} />
+            ) : (
+                <Apps apps={apps} />
+            )}
             <ConfirmLaunchDialog />
             <InstallOtherVersionDialog />
             <ReleaseNotesDialog />

--- a/src/launcher/features/apps/__snapshots__/AppList.test.tsx.snap
+++ b/src/launcher/features/apps/__snapshots__/AppList.test.tsx.snap
@@ -305,6 +305,33 @@ exports[`AppList should disable buttons while removing an app 1`] = `
 </body>
 `;
 
+exports[`AppList should render a message without any apps after some time 1`] = `
+<body>
+  <div>
+    <div />
+    <div
+      class="tw-grid tw-flex-1 tw-place-items-center"
+    >
+      <div
+        class="tw-max-w-[75%] tw-bg-white tw-p-4"
+      >
+        The list of apps is not yet loaded from
+         
+        <a
+          href="https://developer.nordicsemi.com"
+          rel="noreferrer"
+          target="_blank"
+        >
+          https://developer.nordicsemi.com
+        </a>
+        . Make sure you can reach that server.
+      </div>
+    </div>
+    <div />
+  </div>
+</body>
+`;
+
 exports[`AppList should render local, not-installed, installed, and updatable apps 1`] = `
 <body>
   <div>
@@ -622,28 +649,10 @@ exports[`AppList should render with all apps filtered out 1`] = `
 </body>
 `;
 
-exports[`AppList should render without any apps 1`] = `
+exports[`AppList should render without any apps initially empty 1`] = `
 <body>
   <div>
     <div />
-    <div
-      class="tw-grid tw-flex-1 tw-place-items-center"
-    >
-      <div
-        class="tw-max-w-[75%] tw-bg-white tw-p-4"
-      >
-        The list of apps is not yet loaded from
-         
-        <a
-          href="https://developer.nordicsemi.com"
-          rel="noreferrer"
-          target="_blank"
-        >
-          https://developer.nordicsemi.com
-        </a>
-        . Make sure you can reach that server.
-      </div>
-    </div>
     <div />
   </div>
 </body>

--- a/src/launcher/features/apps/__snapshots__/AppList.test.tsx.snap
+++ b/src/launcher/features/apps/__snapshots__/AppList.test.tsx.snap
@@ -604,16 +604,45 @@ exports[`AppList should render local, not-installed, installed, and updatable ap
 </body>
 `;
 
+exports[`AppList should render with all apps filtered out 1`] = `
+<body>
+  <div>
+    <div />
+    <div
+      class="tw-grid tw-flex-1 tw-place-items-center"
+    >
+      <div
+        class="tw-max-w-[75%] tw-bg-white tw-p-4"
+      >
+        No apps shown because of the selected filters. Change those to display apps again.
+      </div>
+    </div>
+    <div />
+  </div>
+</body>
+`;
+
 exports[`AppList should render without any apps 1`] = `
 <body>
   <div>
     <div />
     <div
-      class="with-scrollbar filter-adjusted-height"
+      class="tw-grid tw-flex-1 tw-place-items-center"
     >
       <div
-        class="content-container"
-      />
+        class="tw-max-w-[75%] tw-bg-white tw-p-4"
+      >
+        The list of apps is not yet loaded from
+         
+        <a
+          href="https://developer.nordicsemi.com"
+          rel="noreferrer"
+          target="_blank"
+        >
+          https://developer.nordicsemi.com
+        </a>
+        . Make sure you can reach that server.
+      </div>
     </div>
     <div />
   </div>

--- a/src/launcher/features/filter/UpdateAllApps.tsx
+++ b/src/launcher/features/filter/UpdateAllApps.tsx
@@ -23,11 +23,7 @@ export default () => {
     if (updatableApps.length === 0) return null;
 
     return (
-        <Button
-            variant="outline-secondary"
-            onClick={updateAllApps}
-            className="me_32px"
-        >
+        <Button variant="outline-secondary" onClick={updateAllApps}>
             Update all apps
         </Button>
     );

--- a/src/launcher/features/localAppInstall/DropZoneForLocalApps.tsx
+++ b/src/launcher/features/localAppInstall/DropZoneForLocalApps.tsx
@@ -11,6 +11,8 @@ import { installLocalApp } from '../apps/appsEffects';
 import DropZoneInfo from './DropZoneInfo';
 import { hideDropZone, showDropZone } from './localAppInstallSlice';
 
+import styles from './dropZoneInfo.module.scss';
+
 const DropZoneForLocalApps: React.FC = ({ children }) => {
     const dispatch = useLauncherDispatch();
     const enterCounter = useRef(0);
@@ -52,6 +54,7 @@ const DropZoneForLocalApps: React.FC = ({ children }) => {
             onDragOver={showAddCursor}
             onDragEnter={maybeShowDropZone}
             onDragLeave={maybeHideDropZone}
+            className={styles.dropzone}
         >
             {children}
 

--- a/src/launcher/features/localAppInstall/dropZoneInfo.module.scss
+++ b/src/launcher/features/localAppInstall/dropZoneInfo.module.scss
@@ -43,3 +43,9 @@
     font-size: 2rem;
     text-align: center;
 }
+
+.dropzone {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+}

--- a/src/launcher/features/proxyLogin/ProxyErrorDialog.tsx
+++ b/src/launcher/features/proxyLogin/ProxyErrorDialog.tsx
@@ -8,6 +8,7 @@ import React from 'react';
 import { ErrorDialog } from 'pc-nrfconnect-shared';
 
 import { useLauncherDispatch, useLauncherSelector } from '../../util/hooks';
+import Link from '../../util/Link';
 import { getIsErrorVisible, loginErrorDialogClosed } from './proxyLoginSlice';
 
 export default () => {
@@ -31,13 +32,7 @@ export default () => {
                 disable &quot;Check for updates at startup&quot;. Then restart
                 nRF Connect for Desktop and install apps manually by following
                 the instructions at{' '}
-                <a
-                    target="_blank"
-                    href="https://github.com/NordicSemiconductor/pc-nrfconnect-launcher"
-                    rel="noreferrer"
-                >
-                    https://github.com/NordicSemiconductor/pc-nrfconnect-launcher
-                </a>
+                <Link href="https://github.com/NordicSemiconductor/pc-nrfconnect-launcher" />
                 .
             </p>
         </ErrorDialog>

--- a/src/launcher/util/Link.tsx
+++ b/src/launcher/util/Link.tsx
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import React from 'react';
+
+export default ({ href }: { href: string }) => (
+    <a target="_blank" href={href} rel="noreferrer">
+        {href}
+    </a>
+);

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+const baseConfig = require('pc-nrfconnect-shared/config/tailwind.config.js');
+
+module.exports = {
+    ...baseConfig,
+};


### PR DESCRIPTION
For https://nordicsemi.atlassian.net/browse/NCD-90:

It is confusing to users, if no apps at all are shown. This PR changes this and shows a short information about the reasons in two cases:

If the filters are set in such a way that all apps are filtered out, a message is shown that the users need to change the filter (This also happens if the users have selected only a single source to be shown in the filter and then remove that source completely in the settings pane):

![image](https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/assets/260705/f63cd5b9-ce51-445b-8e62-cfb1d85b88aa)

If no information about the apps was loaded from the server yet. This rarely happens but if it does it can be critical. This case usually only happens while users start nRF Connect for Desktop the very first time. But even then we do not want to shortly flash a misleading help text, for potentially the fraction of a second. So the text is only shown if the app is already running for at least two seconds:

![image](https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/assets/260705/d0609d38-c074-4e67-8ed3-d1de770c9c6e)