### PR TITLE
Fix changelog entry

### DIFF
--- a/Changelog.minor.md
+++ b/Changelog.minor.md
@@ -13,6 +13,7 @@ release the new version.
 
 -   #844: Text is select when search field is focused, making it easier to
     replace the current text.
+-   #864: Bump device-lib-js to 0.7.0.
 
 ### Fixed
 
@@ -31,7 +32,6 @@ release the new version.
             official source.
     -   Name filter for apps: Trim leading and trailing whitespace.
 -   #856: Fix shortcuts when different directories were specified.
--   #864: Bump device-lib-js to 0.7.0
 
     To reproduce:
 


### PR DESCRIPTION
The bump entry was wrongly placed (not in “Changed” and right in the middle of an entry describing a bug and how to reproduce it.)