### PR TITLE
Remove tar gz from the linux builds.

### DIFF
--- a/Changelog.minor.md
+++ b/Changelog.minor.md
@@ -53,6 +53,11 @@ release the new version.
     when starting application – Error: Tried to open app …, but it is not
     installed”. Now the app opens correctly.
 
+### Removed
+
+-   Building the linux version with .tar.gz, now it's only AppImage, the only
+    version released.
+
 ## 4.1.2
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -56,8 +56,7 @@
         },
         "linux": {
             "target": [
-                "AppImage",
-                "tar.gz"
+                "AppImage"
             ],
             "artifactName": "${name}-${version}-${arch}.${ext}",
             "category": "Development",


### PR DESCRIPTION
These builds were never distributed/released. They take a lot of time to build, and seemingly noone uses them.