### PR TITLE
Add a single instance lock

### DIFF
--- a/src/main/argv.ts
+++ b/src/main/argv.ts
@@ -84,8 +84,8 @@ type StartupApp =
           source: string;
       };
 
-export const getStartupApp = (): StartupApp | undefined => {
-    const localApp = argv['open-local-app'];
+export const getStartupApp = (arg: typeof argv): StartupApp | undefined => {
+    const localApp = arg['open-local-app'];
     if (localApp != null) {
         return {
             local: true,
@@ -93,9 +93,9 @@ export const getStartupApp = (): StartupApp | undefined => {
         };
     }
 
-    const source = argv.source ?? OFFICIAL;
+    const source = arg.source ?? OFFICIAL;
 
-    const downloadableApp = argv['open-downloadable-app'];
+    const downloadableApp = arg['open-downloadable-app'];
     if (downloadableApp != null) {
         return {
             local: false,
@@ -104,7 +104,7 @@ export const getStartupApp = (): StartupApp | undefined => {
         };
     }
 
-    const officialApp = argv['open-official-app'];
+    const officialApp = arg['open-official-app'];
     if (officialApp != null) {
         console.warn(
             'Using the command line switch --open-official-app is deprecated,\n' +

--- a/src/main/configureElectronApp.ts
+++ b/src/main/configureElectronApp.ts
@@ -10,7 +10,7 @@ import path from 'path';
 
 import { installAllLocalAppArchives } from './apps/appChanges';
 import { initialiseAllSources } from './apps/sources';
-import { getStartupApp } from './argv';
+import argv, { getStartupApp } from './argv';
 import {
     getAppsExternalDir,
     getAppsLocalDir,
@@ -39,8 +39,8 @@ const initAppsDirectory = async () => {
     await installAllLocalAppArchives();
 };
 
-const openInitialWindow = () => {
-    const startupApp = getStartupApp();
+export const openInitialWindow = (args = argv) => {
+    const startupApp = getStartupApp(args);
 
     if (startupApp == null) {
         openLauncherWindow();

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -11,8 +11,10 @@ import { initialize as initializeElectronRemote } from '@electron/remote/main';
 
 import configureElectronApp from './configureElectronApp';
 import registerIpcHandler from './registerIpcHandler';
+import singeInstanceLock from './singeInstanceLock';
 import storeExecutablePath from './storeExecutablePath';
 
+singeInstanceLock();
 initializeElectronRemote();
 registerIpcHandler();
 configureElectronApp();

--- a/src/main/singeInstanceLock.ts
+++ b/src/main/singeInstanceLock.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import { app } from 'electron/main';
+
+import argv from './argv';
+import { openInitialWindow } from './configureElectronApp';
+
+export default () => {
+    const isFirstInstance = app.requestSingleInstanceLock({ argv });
+
+    if (isFirstInstance) {
+        app.on('second-instance', (_event, _args, _wd, message = {}) => {
+            const args = (message as { argv?: typeof argv }).argv;
+            openInitialWindow(args);
+        });
+    } else {
+        app.quit();
+    }
+};


### PR DESCRIPTION
If a second launcher opens, it sends a message to the first launcher with it's parsed cli arguments and then quits. The first launcher then determines whether to open an app, or the launcher window itself.