### PR TITLE
Show dialog informing about the Quickstart app

### DIFF
--- a/src/ipc/apps.ts
+++ b/src/ipc/apps.ts
@@ -44,6 +44,10 @@ export {
     type WithdrawnApp,
 };
 
+const quickstartAppName = 'pc-nrfconnect-quickstart';
+
+export const isQuickstartApp = (app: App) => app.name === quickstartAppName;
+
 const channel = {
     downloadLatestAppInfos: 'apps:download-latest-app-infos',
     getLocalApps: 'apps:get-local-apps',

--- a/src/ipc/persistedStore.ts
+++ b/src/ipc/persistedStore.ts
@@ -22,6 +22,7 @@ export type ShownStates = {
 };
 
 interface Schema {
+    isQuickstartInfoShownBefore: boolean;
     lastWindowState: WindowState;
     updateCheck: {
         doOnStartup: boolean;
@@ -77,3 +78,8 @@ export const getShownStates = () =>
     store.get('appFilter')?.shownStates ?? defaultShownStates;
 export const setShownStates = (shownStates: ShownStates) =>
     store.set('appFilter.shownStates', shownStates);
+
+export const getIsQuickstartInfoShownBefore = () =>
+    store.get('isQuickstartInfoShownBefore', false);
+export const setQuickstartInfoWasShown = () =>
+    store.set('isQuickstartInfoShownBefore', true);

--- a/src/launcher/Root.tsx
+++ b/src/launcher/Root.tsx
@@ -19,6 +19,7 @@ import UpdateProgressDialog from './features/launcherUpdate/UpdateProgressDialog
 import DropZoneForLocalApps from './features/localAppInstall/DropZoneForLocalApps';
 import ProxyErrorDialog from './features/proxyLogin/ProxyErrorDialog';
 import ProxyLoginDialog from './features/proxyLogin/ProxyLoginDialog';
+import QuickstartDialog from './features/quickstart/QuickstartDialog';
 import Settings from './features/settings/Settings';
 import UsageDataDialog from './features/usageData/UsageDataDialog';
 import ErrorBoundaryLauncher from './util/ErrorBoundaryLauncher';
@@ -88,6 +89,7 @@ export default () => {
             <UsageDataDialog />
             <ProxyLoginDialog />
             <ProxyErrorDialog />
+            <QuickstartDialog />
         </ErrorBoundaryLauncher>
     );
 };

--- a/src/launcher/features/apps/appsSlice.ts
+++ b/src/launcher/features/apps/appsSlice.ts
@@ -14,6 +14,8 @@ import {
     DownloadableApp,
     InstalledDownloadableApp,
     isDownloadable,
+    isInstalled,
+    isQuickstartApp,
     isUpdatable,
     isWithdrawn,
     LocalApp,
@@ -23,7 +25,11 @@ import {
     getLastUpdateCheckDate,
     setLastUpdateCheckDate,
 } from '../../../ipc/persistedStore';
-import { allStandardSourceNames, SourceName } from '../../../ipc/sources';
+import {
+    allStandardSourceNames,
+    OFFICIAL,
+    SourceName,
+} from '../../../ipc/sources';
 import type { RootState } from '../../store';
 import { getAppsFilter } from '../filter/filterSlice';
 
@@ -324,3 +330,9 @@ export const totalProgress = (app: DownloadableAppWithProgress) => {
     const fractions = Object.values(app.progress.fractions);
     return fractions.length === 0 ? 0 : mean(fractions);
 };
+
+export const getOfficialQuickstartApp = (state: RootState) =>
+    state.apps.downloadableApps
+        .filter(app => app.source === OFFICIAL)
+        .filter(isQuickstartApp)
+        .filter(isInstalled)[0] as InstalledDownloadableApp | undefined;

--- a/src/launcher/features/quickstart/QuickstartDialog.tsx
+++ b/src/launcher/features/quickstart/QuickstartDialog.tsx
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2015 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import React from 'react';
+import {
+    DialogButton,
+    GenericDialog,
+} from '@nordicsemiconductor/pc-nrfconnect-shared';
+
+import { useLauncherDispatch, useLauncherSelector } from '../../util/hooks';
+import { checkEngineAndLaunch } from '../apps/appsEffects';
+import { getOfficialQuickstartApp } from '../apps/appsSlice';
+import {
+    getIsQuickstartInfoShownBefore,
+    quickstartInfoWasShown,
+} from '../settings/settingsSlice';
+import { getIsUsageDataDialogVisible } from '../usageData/usageDataSlice';
+
+export default () => {
+    const isQuickstartInfoShownBefore = useLauncherSelector(
+        getIsQuickstartInfoShownBefore
+    );
+    const isUsageDataDialogVisible = useLauncherSelector(
+        getIsUsageDataDialogVisible
+    );
+    const quickstartApp = useLauncherSelector(getOfficialQuickstartApp);
+
+    const dispatch = useLauncherDispatch();
+
+    const isVisible =
+        !isQuickstartInfoShownBefore &&
+        !isUsageDataDialogVisible &&
+        quickstartApp != null;
+
+    return (
+        <GenericDialog
+            isVisible={isVisible}
+            closeOnEsc
+            closeOnUnfocus
+            title="Quickstart"
+            footer={
+                <>
+                    <DialogButton
+                        variant="primary"
+                        onClick={() => {
+                            if (quickstartApp == null) {
+                                throw new Error(
+                                    'Dialog must not be visible if quickstart app is not available.'
+                                );
+                            }
+
+                            dispatch(quickstartInfoWasShown());
+                            dispatch(checkEngineAndLaunch(quickstartApp));
+                        }}
+                    >
+                        Open Quickstart app
+                    </DialogButton>
+                    <DialogButton
+                        onClick={() => dispatch(quickstartInfoWasShown())}
+                    >
+                        Close
+                    </DialogButton>
+                </>
+            }
+        >
+            <p>
+                Do you have a new development kit? Use the Quickstart app to get
+                up and running as fast as possible.
+            </p>
+            <p>Supported kits: nRF9160 DK, nRF9161 DK.</p>
+        </GenericDialog>
+    );
+};

--- a/src/launcher/features/settings/settingsSlice.ts
+++ b/src/launcher/features/settings/settingsSlice.ts
@@ -9,18 +9,22 @@ import { createSlice } from '@reduxjs/toolkit';
 
 import {
     getCheckForUpdatesAtStartup as getPersistedCheckForUpdatesAtStartup,
+    getIsQuickstartInfoShownBefore as getPersistedIsQuickstartInfoShownBefore,
     setCheckForUpdatesAtStartup as setPersistedCheckForUpdatesAtStartup,
+    setQuickstartInfoWasShown as setPersistedQuickstartInfoWasShown,
 } from '../../../ipc/persistedStore';
 import type { RootState } from '../../store';
 
 export type State = {
     shouldCheckForUpdatesAtStartup: boolean;
     isUpdateCheckCompleteVisible: boolean;
+    isQuickstartInfoShownBefore: boolean;
 };
 
 const initialState: State = {
     shouldCheckForUpdatesAtStartup: getPersistedCheckForUpdatesAtStartup(),
     isUpdateCheckCompleteVisible: false,
+    isQuickstartInfoShownBefore: getPersistedIsQuickstartInfoShownBefore(),
 };
 
 const slice = createSlice({
@@ -40,18 +44,25 @@ const slice = createSlice({
         hideUpdateCheckComplete(state) {
             state.isUpdateCheckCompleteVisible = false;
         },
+        quickstartInfoWasShown(state) {
+            state.isQuickstartInfoShownBefore = true;
+            setPersistedQuickstartInfoWasShown();
+        },
     },
 });
 
 export default slice.reducer;
 
 export const {
+    hideUpdateCheckComplete,
+    quickstartInfoWasShown,
     setCheckForUpdatesAtStartup,
     showUpdateCheckComplete,
-    hideUpdateCheckComplete,
 } = slice.actions;
 
 export const getShouldCheckForUpdatesAtStartup = (state: RootState) =>
     state.settings.shouldCheckForUpdatesAtStartup;
 export const getIsUpdateCheckCompleteVisible = (state: RootState) =>
     state.settings.isUpdateCheckCompleteVisible;
+export const getIsQuickstartInfoShownBefore = (state: RootState) =>
+    state.settings.isQuickstartInfoShownBefore;

--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -18,7 +18,12 @@ import {
 import { join } from 'path';
 
 import packageJson from '../../package.json';
-import { AppSpec, isInstalled, LaunchableApp } from '../ipc/apps';
+import {
+    AppSpec,
+    isInstalled,
+    isQuickstartApp,
+    LaunchableApp,
+} from '../ipc/apps';
 import { getLastWindowState, setLastWindowState } from '../ipc/persistedStore';
 import { LOCAL } from '../ipc/sources';
 import { getDownloadableApps, getLocalApps } from './apps/apps';
@@ -27,8 +32,6 @@ import { createWindow } from './browser';
 import bundledJlinkVersion from './bundledJlinkVersion';
 import { getBundledResourcesDir } from './config';
 import { getAppIcon, getNrfConnectForDesktopIcon } from './icons';
-
-const quickstartAppName = 'pc-nrfconnect-quickstart';
 
 let launcherWindow: BrowserWindow | undefined;
 const appWindows: {
@@ -75,7 +78,7 @@ export const hideLauncherWindow = () => {
 };
 
 const getSizeOptions = (app: LaunchableApp) => {
-    if (app.name === quickstartAppName) {
+    if (isQuickstartApp(app)) {
         return {
             width: 800,
             height: 550,
@@ -154,7 +157,7 @@ export const openAppWindow = (
         app,
     });
 
-    if (app.name !== quickstartAppName) {
+    if (!isQuickstartApp(app)) {
         appWindow.webContents.on('did-finish-load', () => {
             if (getLastWindowState().maximized) {
                 appWindow.maximize();


### PR DESCRIPTION
When the users close the dialog, it is now shown again.

![image](https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/assets/260705/9f066e64-59bb-4453-8f95-78fb144ee54d)