### PR TITLE
Style: Empty apps list

### DIFF
--- a/Changelog.minor.md
+++ b/Changelog.minor.md
@@ -12,6 +12,8 @@ release the new version.
 ### Fixed
 
 -   #888: Styling of the usage statistics dialog.
+-   #888: Add command line switch `--new-instance` to force opening a new
+    instance of the launcher.
 
 ## 4.2.1
 

--- a/Changelog.minor.md
+++ b/Changelog.minor.md
@@ -14,6 +14,7 @@ release the new version.
 -   #888: Styling of the usage statistics dialog.
 -   #888: Add command line switch `--new-instance` to force opening a new
     instance of the launcher.
+-   #891: Styling of the empty apps list state.
 
 ## 4.2.1
 

--- a/src/launcher/features/apps/AppListEmpty.tsx
+++ b/src/launcher/features/apps/AppListEmpty.tsx
@@ -18,8 +18,8 @@ import { getShouldCheckForUpdatesAtStartup } from '../settings/settingsSlice';
 import { getNoAppsExist } from './appsSlice';
 
 const Box = ({ children }: { children: ReactNode }) => (
-    <div className="tw-grid tw-flex-1 tw-place-items-center">
-        <div className="tw-max-w-[75%] tw-bg-white tw-p-4">{children}</div>
+    <div className="tw-preflight tw-grid tw-flex-1 tw-place-items-center">
+        <div className="tw-text-center">{children}</div>
     </div>
 );
 
@@ -31,7 +31,7 @@ const InlineButton = ({
     onClick: MouseEventHandler;
 }) => (
     <button
-        className="tw-inline tw-border-0 tw-bg-white tw-p-0 tw-text-primary"
+        className="tw-inline tw-border-0 tw-p-0 tw-text-primary"
         type="button"
         onClick={onClick}
     >
@@ -44,13 +44,20 @@ const CheckForUpdatesDisabled = () => {
 
     return (
         <Box>
-            No apps are loaded from the server yet and you have “Check for
-            updates at startup” disabled in the settings. You can enable it
-            there or just{' '}
-            <InlineButton onClick={() => dispatch(checkForUpdatesManually())}>
-                now check once for updates
-            </InlineButton>
-            .
+            <p>No apps are loaded from the server yet.</p>
+            <p>
+                You have “Check for updates at startup” disabled in the
+                settings.
+            </p>
+            <p>
+                You can enable it there or now just{' '}
+                <InlineButton
+                    onClick={() => dispatch(checkForUpdatesManually())}
+                >
+                    check once for updates
+                </InlineButton>
+                .
+            </p>
         </Box>
     );
 };
@@ -64,9 +71,11 @@ const NotLoadedYet = () => {
 
     return justStarted ? null : (
         <Box>
-            The list of apps is not yet loaded from{' '}
-            <Link href="https://developer.nordicsemi.com" />. Make sure you can
-            reach that server.
+            <p>
+                The list of apps is not yet loaded from{' '}
+                <Link href="https://developer.nordicsemi.com" />.
+            </p>
+            <p>Make sure you can reach that server.</p>
         </Box>
     );
 };
@@ -85,8 +94,8 @@ const NoApps = () => {
 
 const AllFilteredOut = () => (
     <Box>
-        No apps shown because of the selected filters. Change those to display
-        apps again.
+        <p>No apps shown because of the selected filters.</p>
+        <p>Change those to display apps again.</p>
     </Box>
 );
 

--- a/src/launcher/features/apps/__snapshots__/AppList.test.tsx.snap
+++ b/src/launcher/features/apps/__snapshots__/AppList.test.tsx.snap
@@ -310,21 +310,26 @@ exports[`AppList should render a message without any apps after some time 1`] = 
   <div>
     <div />
     <div
-      class="tw-grid tw-flex-1 tw-place-items-center"
+      class="tw-preflight tw-grid tw-flex-1 tw-place-items-center"
     >
       <div
-        class="tw-max-w-[75%] tw-bg-white tw-p-4"
+        class="tw-text-center"
       >
-        The list of apps is not yet loaded from
-         
-        <a
-          href="https://developer.nordicsemi.com"
-          rel="noreferrer"
-          target="_blank"
-        >
-          https://developer.nordicsemi.com
-        </a>
-        . Make sure you can reach that server.
+        <p>
+          The list of apps is not yet loaded from
+           
+          <a
+            href="https://developer.nordicsemi.com"
+            rel="noreferrer"
+            target="_blank"
+          >
+            https://developer.nordicsemi.com
+          </a>
+          .
+        </p>
+        <p>
+          Make sure you can reach that server.
+        </p>
       </div>
     </div>
     <div />
@@ -636,12 +641,17 @@ exports[`AppList should render with all apps filtered out 1`] = `
   <div>
     <div />
     <div
-      class="tw-grid tw-flex-1 tw-place-items-center"
+      class="tw-preflight tw-grid tw-flex-1 tw-place-items-center"
     >
       <div
-        class="tw-max-w-[75%] tw-bg-white tw-p-4"
+        class="tw-text-center"
       >
-        No apps shown because of the selected filters. Change those to display apps again.
+        <p>
+          No apps shown because of the selected filters.
+        </p>
+        <p>
+          Change those to display apps again.
+        </p>
       </div>
     </div>
     <div />
@@ -654,20 +664,28 @@ exports[`AppList should render without any apps and disabled update check 1`] = 
   <div>
     <div />
     <div
-      class="tw-grid tw-flex-1 tw-place-items-center"
+      class="tw-preflight tw-grid tw-flex-1 tw-place-items-center"
     >
       <div
-        class="tw-max-w-[75%] tw-bg-white tw-p-4"
+        class="tw-text-center"
       >
-        No apps are loaded from the server yet and you have “Check for updates at startup” disabled in the settings. You can enable it there or just
-         
-        <button
-          class="tw-inline tw-border-0 tw-bg-white tw-p-0 tw-text-primary"
-          type="button"
-        >
-          now check once for updates
-        </button>
-        .
+        <p>
+          No apps are loaded from the server yet.
+        </p>
+        <p>
+          You have “Check for updates at startup” disabled in the settings.
+        </p>
+        <p>
+          You can enable it there or now just
+           
+          <button
+            class="tw-inline tw-border-0 tw-p-0 tw-text-primary"
+            type="button"
+          >
+            check once for updates
+          </button>
+          .
+        </p>
       </div>
     </div>
     <div />


### PR DESCRIPTION
Fixes https://nordicsemi.atlassian.net/browse/NCD-324.

The empty list state should be styled differently in three regards:

- The background should not be white any longer but transparent.
- The text should be split up by sentences.
- The sentences should be horizontally centred.

This is how it looked before:
![image](https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/assets/260705/ee4907de-4ad9-4fcf-b25a-43952a93d59b)

This is how it looks now:
![image](https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/assets/260705/e22dabad-d0fe-4ee4-b45a-595dcdf94371)

This is how it looks if no apps could be loaded yet:
![image](https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/assets/260705/4ff66435-e390-4f19-8b66-835aff33ba1f)

And this is how the rare edge case looks if no apps could be loaded yet and the startup check is disabled:
![image](https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/assets/260705/d5d5ec52-3e5f-4db7-8d48-3f65056ad4d4)

Splitting up by sentence of course can mean that if the window gets too narrow, the sentence can get a line break in it. But this rarely happens and then still looks ok. E.g. this is the last window when resized to be just 400px wide: 
![image](https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/assets/260705/821c6c5b-579a-4bcb-8db7-19bc76a0c22e)

