### PR TITLE
Add the standard “Window” menu

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Added
+
+-   Menu “Window”.
+
 ## 4.2.1 - 2023-09-28
 
 ### Added

--- a/src/main/menu.ts
+++ b/src/main/menu.ts
@@ -6,6 +6,8 @@
 
 import { app, BrowserWindow, Menu, MenuItem } from 'electron';
 
+const isMac = process.platform === 'darwin';
+
 export default () =>
     Menu.buildFromTemplate([
         {
@@ -62,10 +64,7 @@ export default () =>
                 },
                 {
                     label: 'Toggle &Full Screen',
-                    accelerator:
-                        process.platform === 'darwin'
-                            ? 'Ctrl+Command+F'
-                            : 'F11',
+                    accelerator: isMac ? 'Ctrl+Command+F' : 'F11',
                     click: (_item: MenuItem, focusedWindow?: BrowserWindow) => {
                         if (focusedWindow) {
                             focusedWindow.setFullScreen(
@@ -76,10 +75,7 @@ export default () =>
                 },
                 {
                     label: 'Toggle &Developer Tools',
-                    accelerator:
-                        process.platform === 'darwin'
-                            ? 'Alt+Command+I'
-                            : 'Ctrl+Shift+I',
+                    accelerator: isMac ? 'Alt+Command+I' : 'Ctrl+Shift+I',
                     visible: true,
                     click: (_item: MenuItem, focusedWindow?: BrowserWindow) => {
                         if (focusedWindow) {
@@ -88,5 +84,8 @@ export default () =>
                     },
                 },
             ],
+        },
+        {
+            role: 'windowMenu',
         },
     ]);


### PR DESCRIPTION
This is especially important on macOS, where this adds the standard list of all open windows for an app.

On macOS this can looks like this (before that whole menu was not there): 
![Screenshot 2023-10-05 at 13 17 43](https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/assets/260705/a56c8351-0275-4c79-8228-1f963f9ac92e)

On Windows and Linux those menus are usually not visible at all and only appear after pressing “alt”. Then it looks like this on Windows:
![image](https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/assets/260705/4a0bc08c-ad47-4305-b6bf-3f2a3cdc521f)

And similar on Linux:
![image](https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/assets/260705/6509a401-fa4f-41ba-992c-16d7b4be0c88)
