### PR TITLE
fix: change electron version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8067,14 +8067,14 @@
             }
         },
         "node_modules/electron": {
-            "version": "26.3.0",
-            "resolved": "https://registry.npmjs.org/electron/-/electron-26.3.0.tgz",
-            "integrity": "sha512-7ZpvSHu+jmqialSvywTZnOQZZGLqlyj+yV5HGDrEzFnMiFaXBRpbByHgoUhaExJ/8t/0xKQjKlMRAY65w+zNZQ==",
+            "version": "22.3.27",
+            "resolved": "https://registry.npmjs.org/electron/-/electron-22.3.27.tgz",
+            "integrity": "sha512-7Rht21vHqj4ZFRnKuZdFqZFsvMBCmDqmjetiMqPtF+TmTBiGne1mnstVXOA/SRGhN2Qy5gY5bznJKpiqogjM8A==",
             "hasInstallScript": true,
             "peer": true,
             "dependencies": {
                 "@electron/get": "^2.0.0",
-                "@types/node": "^18.11.18",
+                "@types/node": "^16.11.26",
                 "extract-zip": "^2.0.1"
             },
             "bin": {
@@ -8491,6 +8491,12 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
             "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
+        },
+        "node_modules/electron/node_modules/@types/node": {
+            "version": "16.18.58",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.58.tgz",
+            "integrity": "sha512-YGncyA25/MaVtQkjWW9r0EFBukZ+JulsLcVZBlGUfIb96OBMjkoRWwQo5IEWJ8Fj06Go3GHw+bjYDitv6BaGsA==",
+            "peer": true
         },
         "node_modules/emittery": {
             "version": "0.13.1",


### PR DESCRIPTION
The newer version of electron was caused by a previous update to electron/remote. This caused a crash on ubuntu when the cursor entered the application window.

Currently this is just a fix for the crash but it does not stop this from happening again in the future. A more robust fix would be to have a version of electron required in the launcher. Given that shared is the one including electron, I have not done this yet to avoid confusion.