### PR TITLE
Rework app argument logic

### DIFF
--- a/src/main/argv.test.ts
+++ b/src/main/argv.test.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import { mergeAppArguments } from './argv';
+
+describe('mergeAppArguments', () => {
+    it('leaves the args unchanged if no open app options are provided', () => {
+        const args = ['--deviceSerial', '001122', '--otherArg'];
+        expect(mergeAppArguments(args)).toEqual(args);
+    });
+
+    it('removes --deviceSerial if any device is specified', () => {
+        const args = ['--deviceSerial', '001122', '--otherArg'];
+
+        expect(
+            mergeAppArguments(args, { device: { serialNumber: '334455' } })
+        ).toEqual(['--otherArg', '--deviceSerial', '334455']);
+        expect(
+            mergeAppArguments(args, { device: { serialPortPath: 'COM0' } })
+        ).toEqual(['--otherArg', '--comPort', 'COM0']);
+    });
+
+    it('removes --comPort if any device is specified', () => {
+        const args = ['--comPort', 'COM2', '--otherArg'];
+
+        expect(
+            mergeAppArguments(args, { device: { serialNumber: '334455' } })
+        ).toEqual(['--otherArg', '--deviceSerial', '334455']);
+        expect(
+            mergeAppArguments(args, { device: { serialPortPath: 'COM0' } })
+        ).toEqual(['--otherArg', '--comPort', 'COM0']);
+    });
+
+    it('even though that should not happen it handles a trailing --deviceSerial correctly', () => {
+        const args = ['--comPort', 'COM2', '--deviceSerial'];
+
+        expect(
+            mergeAppArguments(args, { device: { serialNumber: '334455' } })
+        ).toEqual(['--deviceSerial', '334455']);
+        expect(
+            mergeAppArguments(args, { device: { serialPortPath: 'COM0' } })
+        ).toEqual(['--comPort', 'COM0']);
+    });
+});

--- a/src/main/argv.ts
+++ b/src/main/argv.ts
@@ -103,9 +103,7 @@ const hasDeviceSerialNumber = appArguments().some(a => a === '--deviceSerial');
 const hasDeviceSerialPort = appArguments().some(a => a === '--comPort');
 
 if (hasDeviceSerialNumber && hasDeviceSerialPort) {
-    console.log(
-        'Only --deviceSerial or --comPort can be passed when opening an app'
-    );
+    console.log('--deviceSerial and --comPort cannot be used at the same time');
     process.exit();
 }
 

--- a/src/main/browser.ts
+++ b/src/main/browser.ts
@@ -11,7 +11,7 @@ import {
     shell,
 } from 'electron';
 
-import { additionalArguments } from './argv';
+import { appArguments } from './argv';
 import { getBundledResourcesDir } from './config';
 
 type BrowserWindowOptions = BrowserWindowConstructorOptions & {
@@ -43,21 +43,9 @@ const createSplashScreen = (icon: BrowserWindowOptions['icon']) => {
     return splashScreen;
 };
 
-const mergeAdditionalArguments = (
-    nonCommandlineArguments: string[],
-    appArguments: string[]
-) => {
-    if (appArguments.length === 0 && nonCommandlineArguments.length === 0) {
-        return [];
-    }
-
-    return ['--', ...nonCommandlineArguments, ...appArguments];
-};
-
 export const createWindow = (
     options: BrowserWindowOptions,
-    nonCommandlineArguments: string[] = [],
-    args: string[] = additionalArguments
+    args = appArguments()
 ) => {
     const mergedOptions: BrowserWindowOptions = {
         minWidth: 308,
@@ -68,10 +56,7 @@ export const createWindow = (
             nodeIntegration: true,
             sandbox: false,
             contextIsolation: false,
-            additionalArguments: mergeAdditionalArguments(
-                nonCommandlineArguments,
-                args
-            ),
+            additionalArguments: args.length === 0 ? [] : ['--', ...args],
             backgroundThrottling: false,
         },
         ...options,

--- a/src/main/configureElectronApp.ts
+++ b/src/main/configureElectronApp.ts
@@ -20,7 +20,7 @@ import {
     ensureBundledSourceExists,
     initialiseAllSources,
 } from './apps/sources';
-import argv, { getStartupApp } from './argv';
+import argv, { appArguments, getStartupApp } from './argv';
 import {
     getAppsExternalDir,
     getAppsLocalDir,
@@ -66,9 +66,9 @@ export const openInitialWindow = (args = argv) => {
     }
 
     if (startupApp.local) {
-        openLocalAppWindow(startupApp.name, undefined, args['--']);
+        openLocalAppWindow(startupApp.name, appArguments(args));
     } else {
-        openDownloadableAppWindow(startupApp, undefined, args['--']);
+        openDownloadableAppWindow(startupApp, appArguments(args));
     }
 };
 


### PR DESCRIPTION
The functions `openAppWindow`, `openDownloadableAppWindow`, and `openLocalAppWindow` had two parameters `openAppOptions` and `args` which serve a similar purpose and can never be specified at the same time. Now they are (again) merged into only a single parameter `args` and if there are `openAppOptions` they are earlier merged into `args`.