### PR TITLE
Show actual devices supported by Quick Start app

### DIFF
--- a/Changelog.minor.md
+++ b/Changelog.minor.md
@@ -9,6 +9,12 @@ release the new version.
 
 ## Unreleased
 
+### Changed
+
+-   #914: Show the devices actually supported by the current Quick Start app.
+
+## 4.3.0
+
 ### Fixed
 
 -   #888: Styling of the usage statistics dialog.


### PR DESCRIPTION
So far, the devices were hard coded in the launcher. If the Quick Start app started to support more devices, the launcher also had to be changed. Now the supported devices are read from the Quick Start app's package.json file.

The properties were added to the Quick Start’s `package.json` in https://github.com/NordicPlayground/pc-nrfconnect-quickstart/pull/129.