### PR TITLE
Fix: Missing file necessary for macOS auto update

### DIFF
--- a/pipelines/package/darwin.yml
+++ b/pipelines/package/darwin.yml
@@ -13,5 +13,5 @@ steps:
     APPLE_TEAMID: $(WAYLAND_APPLE_TEAMID)
   displayName: Package release
 - bash: |
-    cp release/*.dmg "$(Build.ArtifactStagingDirectory)"
+    cp release/*.dmg release/*.zip "$(Build.ArtifactStagingDirectory)"
   displayName: 'Copy artifacts'

--- a/pipelines/package/darwin_arm.yml
+++ b/pipelines/package/darwin_arm.yml
@@ -14,6 +14,5 @@ steps:
     APPLE_TEAMID: $(WAYLAND_APPLE_TEAMID)
   displayName: Package release
 - bash: |
-    cp release/*.dmg "$(Build.ArtifactStagingDirectory)"
+    cp release/*.dmg release/*.zip "$(Build.ArtifactStagingDirectory)"
   displayName: 'Copy artifacts'
-


### PR DESCRIPTION
[NCD-505](https://nordicsemi.atlassian.net/browse/NCD-505):

According to https://www.electron.build/auto-update#quick-setup-guide the zip file is required for auto update to work on macOS.