### PR TITLE
Enhance message when installing downloadable apps fails

### DIFF
--- a/Changelog.minor.md
+++ b/Changelog.minor.md
@@ -12,6 +12,9 @@ release the new version.
 ### Changed
 
 -   #914: Show the devices actually supported by the current Quick Start app.
+-   #935: Updated and corrected dialog styles from
+    [shared v146](https://github.com/NordicSemiconductor/pc-nrfconnect-shared/releases/tag/v146).
+-   #935: Better message when installing downloadable apps fails.
 
 ## 4.3.0
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,7 +6,6 @@
 
 const sharedConfig =
     require('@nordicsemiconductor/pc-nrfconnect-shared/config/jest.config')([
-        'packageJson',
         'serialport',
     ]);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "nrfconnect",
-    "version": "4.3.0-pre2",
+    "version": "4.3.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "nrfconnect",
-            "version": "4.3.0-pre1",
+            "version": "4.3.0",
             "hasInstallScript": true,
             "license": "Proprietary",
             "dependencies": {
@@ -30,7 +30,7 @@
             },
             "devDependencies": {
                 "@electron/notarize": "^2.1.0",
-                "@nordicsemiconductor/pc-nrfconnect-shared": "^132.0.0",
+                "@nordicsemiconductor/pc-nrfconnect-shared": "^147.0.0",
                 "@playwright/test": "^1.16.3",
                 "@testing-library/user-event": "^14.4.3",
                 "@types/chmodr": "1.0.0",
@@ -3074,9 +3074,9 @@
             }
         },
         "node_modules/@nordicsemiconductor/pc-nrfconnect-shared": {
-            "version": "132.0.0",
-            "resolved": "https://registry.npmjs.org/@nordicsemiconductor/pc-nrfconnect-shared/-/pc-nrfconnect-shared-132.0.0.tgz",
-            "integrity": "sha512-qDeYfPQmYLzCVdi6uHq0DnY0CZFEn6ksmGqWoE5SLw1IYXZ6hq5Pw5WHqIlfiWLQq3D7ae0uxzgiPRDPNwNRFA==",
+            "version": "147.0.0",
+            "resolved": "https://registry.npmjs.org/@nordicsemiconductor/pc-nrfconnect-shared/-/pc-nrfconnect-shared-147.0.0.tgz",
+            "integrity": "sha512-j41i5bXBdfKzyQyNtp1nHKRfv+/+SPi1mGDQIrWGZl2MI1JG2PVcfz0M1ufrr06l5iihHpR7hVk6vtQSRUVI4A==",
             "dev": true,
             "hasInstallScript": true,
             "dependencies": {
@@ -3141,7 +3141,7 @@
                 "lodash.range": "3.2.0",
                 "mousetrap": "1.6.5",
                 "npm-run-all2": "6.0.5",
-                "nrf-intel-hex": "^1.3.0",
+                "nrf-intel-hex": "^1.4.0",
                 "postcss": "8.4.24",
                 "postcss-modules": "^6.0.0",
                 "prettier": "2.8.8",
@@ -17807,9 +17807,9 @@
             }
         },
         "node_modules/nrf-intel-hex": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/nrf-intel-hex/-/nrf-intel-hex-1.3.0.tgz",
-            "integrity": "sha512-oXwBJxX/0Jc4fe2Jxjv3Mw9/qw9JdToDLvJuozfVx+twpkc2oSUm8W/OODX6W4kmWOaYA11ORpGLfQ8BP7mndw==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/nrf-intel-hex/-/nrf-intel-hex-1.4.0.tgz",
+            "integrity": "sha512-q3+GGRIpe0VvCjUP1zaqW5rk6IpCZzhD0lu7Sguo1bgWwFcA9kZRjsaKUb0jBQMnefyOl5o0BBGAxvqMqYx8Sg==",
             "dev": true,
             "engines": {
                 "node": ">=6.0.0"

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     },
     "devDependencies": {
         "@electron/notarize": "^2.1.0",
-        "@nordicsemiconductor/pc-nrfconnect-shared": "^132.0.0",
+        "@nordicsemiconductor/pc-nrfconnect-shared": "^147.0.0",
         "@playwright/test": "^1.16.3",
         "@testing-library/user-event": "^14.4.3",
         "@types/chmodr": "1.0.0",

--- a/src/launcher/features/apps/appsEffects.ts
+++ b/src/launcher/features/apps/appsEffects.ts
@@ -21,6 +21,7 @@ import {
     isInstalled,
     LaunchableApp,
 } from '../../../ipc/apps';
+import { cleanIpcErrorMessage } from '../../../ipc/error';
 import type { AppThunk } from '../../store';
 import appCompatibilityWarning from '../../util/appCompatibilityWarning';
 import { handleSourcesWithErrors } from '../sources/sourcesEffects';
@@ -149,7 +150,9 @@ const install =
         } catch (error) {
             dispatch(
                 ErrorDialogActions.showDialog(
-                    `Unable to install: ${(error as Error).message}`
+                    `Unable to install downloadable app.`,
+                    undefined,
+                    cleanIpcErrorMessage(describeError(error))
                 )
             );
         }

--- a/src/launcher/features/launcherUpdate/__snapshots__/UpdateAvailableDialog.test.tsx.snap
+++ b/src/launcher/features/launcherUpdate/__snapshots__/UpdateAvailableDialog.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`UpdateAvailableDialog shows the new version if one becomes available  1
           </div>
         </div>
         <div
-          class="modal-body"
+          class="tw-select-text modal-body"
         >
           <p>
             A new version (

--- a/src/launcher/features/launcherUpdate/__snapshots__/UpdateProgressDialog.test.tsx.snap
+++ b/src/launcher/features/launcherUpdate/__snapshots__/UpdateProgressDialog.test.tsx.snap
@@ -44,7 +44,7 @@ exports[`UpdateProgressDialog can be without progress, and not cancellable 1`] =
           </div>
         </div>
         <div
-          class="modal-body"
+          class="tw-select-text modal-body"
         >
           <p>
             Downloading nRF Connect for Desktop 
@@ -101,7 +101,7 @@ exports[`UpdateProgressDialog can have a version, percent downloaded, and be can
           </div>
         </div>
         <div
-          class="modal-body"
+          class="tw-select-text modal-body"
         >
           <p>
             Downloading nRF Connect for Desktop 
@@ -179,7 +179,7 @@ exports[`UpdateProgressDialog has cancelling disabled after being cancelled 1`] 
           </div>
         </div>
         <div
-          class="modal-body"
+          class="tw-select-text modal-body"
         >
           <p>
             Downloading nRF Connect for Desktop 
@@ -258,7 +258,7 @@ exports[`UpdateProgressDialog has cancelling disabled when 100 percent complete 
           </div>
         </div>
         <div
-          class="modal-body"
+          class="tw-select-text modal-body"
         >
           <p>
             Downloading nRF Connect for Desktop 

--- a/src/launcher/features/proxyLogin/__snapshots__/ProxyErrorDialog.test.tsx.snap
+++ b/src/launcher/features/proxyLogin/__snapshots__/ProxyErrorDialog.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`ProxyErrorDialog is displayed after users canceled the login 1`] = `
           />
         </div>
         <div
-          class="modal-body"
+          class="tw-select-text modal-body"
         >
           <p>
             It appears that you are having problems authenticating with a proxy server. This will prevent you from using certain features of nRF Connect for Desktop, such as installing downloadable apps or checking for updates.

--- a/src/launcher/features/proxyLogin/__snapshots__/ProxyLoginDialog.test.tsx.snap
+++ b/src/launcher/features/proxyLogin/__snapshots__/ProxyLoginDialog.test.tsx.snap
@@ -36,7 +36,7 @@ exports[`ProxyLoginDialog is displayed after a login is requested 1`] = `
           </div>
         </div>
         <div
-          class="modal-body"
+          class="tw-select-text modal-body"
         >
           <p>
             The proxy server 
@@ -166,7 +166,7 @@ exports[`ProxyLoginDialog is updated if users enter a username 1`] = `
           </div>
         </div>
         <div
-          class="modal-body"
+          class="tw-select-text modal-body"
         >
           <p>
             The proxy server 

--- a/src/launcher/features/settings/__snapshots__/Settings.test.tsx.snap
+++ b/src/launcher/features/settings/__snapshots__/Settings.test.tsx.snap
@@ -209,7 +209,7 @@ exports[`SettingsView should render check for updates completed, with everything
           </div>
         </div>
         <div
-          class="modal-body"
+          class="tw-select-text modal-body"
         >
           All apps are up to date.
         </div>
@@ -438,7 +438,7 @@ exports[`SettingsView should render check for updates completed, with updates av
           </div>
         </div>
         <div
-          class="modal-body"
+          class="tw-select-text modal-body"
         >
           One or more updates are available. Go to the apps screen to update.
         </div>

--- a/src/launcher/features/sources/__snapshots__/ConfirmRemoveSourceDialog.test.tsx.snap
+++ b/src/launcher/features/sources/__snapshots__/ConfirmRemoveSourceDialog.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`ConfirmRemoveSourceDialog shows the new version if one becomes availabl
           </div>
         </div>
         <div
-          class="modal-body"
+          class="tw-select-text modal-body"
         >
           Are you sure to remove 
           the source to remove


### PR DESCRIPTION
[NCD-602](https://nordicsemi.atlassian.net/browse/NCD-602): When installing downloadable apps fails, the users got to see the name of the IPC channel invoked, which looks rather cryptic. This happens often enough that I want to make this more user friendly. Now:

- There is first just the easier to understand message “Unable to install downloadable app.”
- An additional “Show technical details” section which, when clicked on, shows the error messages that causes the failure, but without the redundant IPC channel name.

More visually, this was the error dialog before:
![image](https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/assets/260705/a7b03001-5e04-4c8c-abb2-41b561f30607)

This is how it looks now:
![image](https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/assets/260705/0ba2b834-bad1-496d-87b7-e5ba721e3d66)

And with expanded details:
![image](https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/assets/260705/cfb8d01c-dcb0-4f35-87d1-e0e559cd33b4)

Because this also updates shared, the updated and corrected dialog styles from [v146](https://github.com/NordicSemiconductor/pc-nrfconnect-shared/releases/tag/v146) are also included in this PR.