### PR TITLE
Fix: Some errors in native dialogs

### DIFF
--- a/Changelog.minor.md
+++ b/Changelog.minor.md
@@ -18,6 +18,8 @@ release the new version.
 -   #937: No quirky error message when invoking `nrfutil` fails in strange ways
     (from from
     [shared v150](https://github.com/NordicSemiconductor/pc-nrfconnect-shared/releases/tag/v150)).
+-   #937: No error message on shutdown when e.g. an ongoing download still wants
+    to send IPC messages.
 
 ## 4.3.0
 

--- a/Changelog.minor.md
+++ b/Changelog.minor.md
@@ -15,6 +15,9 @@ release the new version.
 -   #935: Updated and corrected dialog styles from
     [shared v146](https://github.com/NordicSemiconductor/pc-nrfconnect-shared/releases/tag/v146).
 -   #935: Better message when installing downloadable apps fails.
+-   #937: No quirky error message when invoking `nrfutil` fails in strange ways
+    (from from
+    [shared v150](https://github.com/NordicSemiconductor/pc-nrfconnect-shared/releases/tag/v150)).
 
 ## 4.3.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
             },
             "devDependencies": {
                 "@electron/notarize": "^2.1.0",
-                "@nordicsemiconductor/pc-nrfconnect-shared": "^147.0.0",
+                "@nordicsemiconductor/pc-nrfconnect-shared": "^150.0.0",
                 "@playwright/test": "^1.16.3",
                 "@testing-library/user-event": "^14.4.3",
                 "@types/chmodr": "1.0.0",
@@ -3074,9 +3074,9 @@
             }
         },
         "node_modules/@nordicsemiconductor/pc-nrfconnect-shared": {
-            "version": "147.0.0",
-            "resolved": "https://registry.npmjs.org/@nordicsemiconductor/pc-nrfconnect-shared/-/pc-nrfconnect-shared-147.0.0.tgz",
-            "integrity": "sha512-j41i5bXBdfKzyQyNtp1nHKRfv+/+SPi1mGDQIrWGZl2MI1JG2PVcfz0M1ufrr06l5iihHpR7hVk6vtQSRUVI4A==",
+            "version": "150.0.0",
+            "resolved": "https://registry.npmjs.org/@nordicsemiconductor/pc-nrfconnect-shared/-/pc-nrfconnect-shared-150.0.0.tgz",
+            "integrity": "sha512-330bk39lJRunJV8wcrzZlJpvKbVH/SUjlLraiZ2il7mZ6W9zpfu0Zai1qZvQX9N5XF5oXKW33BKjb0V1w3fKOg==",
             "dev": true,
             "hasInstallScript": true,
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     },
     "devDependencies": {
         "@electron/notarize": "^2.1.0",
-        "@nordicsemiconductor/pc-nrfconnect-shared": "^147.0.0",
+        "@nordicsemiconductor/pc-nrfconnect-shared": "^150.0.0",
         "@playwright/test": "^1.16.3",
         "@testing-library/user-event": "^14.4.3",
         "@types/chmodr": "1.0.0",

--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -7,6 +7,7 @@
 import {
     OpenAppOptions,
     registerLauncherWindowFromMain,
+    removeLauncherWindowFromMain,
 } from '@nordicsemiconductor/pc-nrfconnect-shared/main';
 import {
     app as electronApp,
@@ -64,6 +65,8 @@ const createLauncherWindow = () => {
         if (appWindows.length > 0) {
             event.preventDefault();
             window.hide();
+        } else {
+            removeLauncherWindowFromMain();
         }
     });
 


### PR DESCRIPTION
Fixes two problems:

## Uncaught exception when invoking `nrfutil` 
When spawning the nrfutil process fails in certain ways, an uncaught exception in the main process got thrown.

The “certain ways” make this a bit hard to reproduce: On macOS this happened, when the nrfutil executable did not have the executable file mode. Usually this should not happen, because we set that mode ourselves correctly.

This resulted in an ugly dialog, outside of the launcher getting displayed by electron:

![image](https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/assets/260705/dae11391-5c16-4919-abbe-3e8e73c14c0d)

## Rare error message on shutdown 
When during shutdown some process still tries to send IPC messages to the launcher window, an exception was thrown, which was presented to users as an ugly dialog.

To reproduce this, start to install a particular large app (nPM is the best for this). While the download is still ongoing, quit the launcher. A dialog like this was shown:
![image](https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/assets/260705/61caccb1-1b79-47cd-ac09-e8a0aac0ebc4)

