### PR TITLE
Remove CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,0 @@
-# Require Review from the Wayland team
-* @NordicSemiconductor/wayland


### PR DESCRIPTION
Misunderstood the use case of CODEOWNERS. Thought it could require PRs to have at least one review from someone in CODEOWNERS in order to merge. But it seems to have a side effect.

It automatically sets the whole team to Reviewers when creating a PR, which is not desired.