### PR TITLE
Skip build workflow for doc changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,9 +6,13 @@ on:
     pull_request:
         branches:
             - main
+        paths-ignore:
+            - 'doc/**'
     push:
         branches:
             - main
+        paths-ignore:
+            - 'doc/**'
 
 jobs:
     build_on_windows:


### PR DESCRIPTION
If all changes are contained to doc/ directory, then the build workflow does not need to run.