### PR TITLE
Minor changelog and Label checker

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -6,6 +6,7 @@ on:
             - opened
             - labeled
             - unlabeled
+            - synchronize
         branches:
             - main
 

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -12,23 +12,8 @@ on:
 
 jobs:
     check_labels:
-        runs-on: ubuntu-latest
-        steps:
-          - name: 'Required "doc required" or "doc not required" label'
-            if: >
-                contains(github.event.pull_request.labels.*.name, 'doc required') == false &&
-                contains(github.event.pull_request.labels.*.name, 'doc not required') == false
-            uses: actions/github-script@v7
-            with:
-              script: |
-                github.rest.issues.createComment({
-                  issue_number: context.issue.number,
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  body: 'Make sure to add the "doc required" or "doc not required" label. '
-                })
-                core.setFailed('Required "doc required" or "doc not required" label')
-
+        uses: NordicSemiconductor/pc-nrfconnect-shared/.github/workflows/labels.yml@main
+        secrets: inherit
 
 
 

--- a/Changelog.minor.md
+++ b/Changelog.minor.md
@@ -20,6 +20,9 @@ release the new version.
     [shared v150](https://github.com/NordicSemiconductor/pc-nrfconnect-shared/releases/tag/v150)).
 -   #937: No error message on shutdown when e.g. an ongoing download still wants
     to send IPC messages.
+-   #926, #931, #940, #946, #955: Switch from Azure to GitHub Actions.
+-   #928, #939, #945, #954: Update documentation.
+-   #950, #952: Use the refactored telemetry code.
 
 ## 4.3.0
 


### PR DESCRIPTION
- Amend minor changelog
- Use the label checker from shared
- Do not forget about a failed label check on subsequent pushes