### PR TITLE
fix: update shared with updated packagejson types to remove error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
             },
             "devDependencies": {
                 "@electron/notarize": "^2.2.0",
-                "@nordicsemiconductor/pc-nrfconnect-shared": "^152.0.0",
+                "@nordicsemiconductor/pc-nrfconnect-shared": "^154.0.0",
                 "@playwright/test": "^1.16.3",
                 "@testing-library/user-event": "^14.4.3",
                 "@types/chmodr": "1.0.0",
@@ -3158,9 +3158,9 @@
             }
         },
         "node_modules/@nordicsemiconductor/pc-nrfconnect-shared": {
-            "version": "152.0.0",
-            "resolved": "https://registry.npmjs.org/@nordicsemiconductor/pc-nrfconnect-shared/-/pc-nrfconnect-shared-152.0.0.tgz",
-            "integrity": "sha512-H60TjXqUfVDRiKol2Ackw8A1xE2jfRihkhsnvAPYnElsSKxEs3SIBWnFz3csJLMfmCajO7mRsIAxI1gVACVwmQ==",
+            "version": "154.0.0",
+            "resolved": "https://registry.npmjs.org/@nordicsemiconductor/pc-nrfconnect-shared/-/pc-nrfconnect-shared-154.0.0.tgz",
+            "integrity": "sha512-bnEp5gfgVW0Uf6kkD0nQZPWt3EX6Q/dvkd/wOv3b0PYTub5ltuBn6d2CApazZZrjtuSCE4fn6kjE8EIFNYgrew==",
             "dev": true,
             "hasInstallScript": true,
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     },
     "devDependencies": {
         "@electron/notarize": "^2.2.0",
-        "@nordicsemiconductor/pc-nrfconnect-shared": "^152.0.0",
+        "@nordicsemiconductor/pc-nrfconnect-shared": "^154.0.0",
         "@playwright/test": "^1.16.3",
         "@testing-library/user-event": "^14.4.3",
         "@types/chmodr": "1.0.0",


### PR DESCRIPTION
It would previously fail to load new apps with updated shared and more supported devices