### PR TITLE
Fix: Check if app is truly installed befare reading package.json

### DIFF
--- a/Changelog.minor.md
+++ b/Changelog.minor.md
@@ -25,6 +25,10 @@ release the new version.
 -   #950, #952: Use the refactored telemetry code.
 -   #958 Update electron from 22.x to 28.x
 
+### Fixed
+
+-   #978 Do not convert legacy app if it has been uninstalled in the mean time
+
 ## 4.3.0
 
 ### Fixed

--- a/src/main/apps/legacyMetaFiles.ts
+++ b/src/main/apps/legacyMetaFiles.ts
@@ -166,18 +166,20 @@ const migrateLegacyMetaFiles = (source: Source) => {
             'package.json'
         );
 
-        const packageJsonResult = parsePackageJsonLegacyApp(
-            readFile(packageJsonFile)
-        );
+        if (fs.existsSync(packageJsonFile)) {
+            const packageJsonResult = parsePackageJsonLegacyApp(
+                readFile(packageJsonFile)
+            );
 
-        const packageJson = packageJsonResult.success
-            ? packageJsonResult.data
-            : null;
+            const packageJson = packageJsonResult.success
+                ? packageJsonResult.data
+                : null;
 
-        writeAppInfo(
-            createNewAppInfo(appName, appsJson, updatesJson, packageJson),
-            source
-        );
+            writeAppInfo(
+                createNewAppInfo(appName, appsJson, updatesJson, packageJson),
+                source
+            );
+        }
     });
 
     createWithDrawnAppFiles('pc-nrfconnect-gettingstarted', source);


### PR DESCRIPTION
This PR address an issue where an error is show when an app.json is being converted and one or more app that existed in apps.json is no longer installed.

Also @datenreisender should we consider deleting apps.jon after converting it?