### PR TITLE
Fix: Strange source URLs could be handled wrong

### DIFF
--- a/Changelog.minor.md
+++ b/Changelog.minor.md
@@ -7,6 +7,12 @@ because it is so minor that the users will rarely care about them.
 It is still helpful that we collect them, e.g. so that we can check them when
 release the new version.
 
+## Unreleased
+
+### Fixed
+
+-   #989: Some strange source URLs could be handled wrong.
+
 ## 4.4.0
 
 ### Changed

--- a/src/launcher/features/settings/Settings.tsx
+++ b/src/launcher/features/settings/Settings.tsx
@@ -131,7 +131,7 @@ export default () => {
                                             onClick={() =>
                                                 clipboard.writeText(
                                                     source.url.replace(
-                                                        /source.json$/,
+                                                        /source\.json$/,
                                                         'apps.json'
                                                     )
                                                 )

--- a/src/main/apps/sourceChanges.ts
+++ b/src/main/apps/sourceChanges.ts
@@ -36,7 +36,7 @@ const downloadSource = async (
 
     const isLegacyUrl = url.endsWith('/apps.json') && sourceJson.apps == null;
     if (isLegacyUrl) {
-        return downloadSource(url.replace(/apps.json$/, 'source.json'));
+        return downloadSource(url.replace(/apps\.json$/, 'source.json'));
     }
 
     return { source, sourceJson };

--- a/src/main/apps/sources.ts
+++ b/src/main/apps/sources.ts
@@ -39,7 +39,7 @@ const convertToOldSourceJsonFormat = (allSources: Source[]) =>
     Object.fromEntries(
         allSources.map(source => [
             source.name,
-            source.url.replace(/source.json$/, 'apps.json'),
+            source.url.replace(/source\.json$/, 'apps.json'),
         ])
     );
 
@@ -48,7 +48,7 @@ const convertFromOldSourceJsonFormat = (
 ) =>
     Object.entries(sourceJsonParsed).map(([name, url]) => ({
         name,
-        url: url.replace(/apps.json$/, 'source.json'),
+        url: url.replace(/apps\.json$/, 'source.json'),
     }));
 
 const loadAllSources = () => {

--- a/src/main/apps/sources.ts
+++ b/src/main/apps/sources.ts
@@ -39,7 +39,7 @@ const convertToOldSourceJsonFormat = (allSources: Source[]) =>
     Object.fromEntries(
         allSources.map(source => [
             source.name,
-            source.url.replace('source.json', 'apps.json'),
+            source.url.replace(/source.json$/, 'apps.json'),
         ])
     );
 
@@ -48,7 +48,7 @@ const convertFromOldSourceJsonFormat = (
 ) =>
     Object.entries(sourceJsonParsed).map(([name, url]) => ({
         name,
-        url: url.replace('apps.json', 'source.json'),
+        url: url.replace(/apps.json$/, 'source.json'),
     }));
 
 const loadAllSources = () => {


### PR DESCRIPTION
Didn't happen in practice, but if a source URL contained the string `apps.json` or `source.json` somewhere in the middle, it would wrongly be replaced. E.g. https://source.json.example.org/source.json would not be handled correctly.