### PR TITLE
Fix: Broken link to the proxy settings docs

### DIFF
--- a/Changelog.minor.md
+++ b/Changelog.minor.md
@@ -12,6 +12,7 @@ release the new version.
 ### Fixed
 
 -   #989: Some strange source URLs could be handled wrong.
+-   #997: Broken link to the proxy settings docs.
 
 ## 4.4.0
 

--- a/doc/docs/download_cfd.md
+++ b/doc/docs/download_cfd.md
@@ -29,6 +29,6 @@ repository. You need to set up these rules only once.
 ## Using behind proxy
 
 To use nRF Connect for Desktop and its applications behind a proxy, see the
-[proxy settings](https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/blob/main/doc/non-mkdocs/proxy-settings.md) page.
+[proxy settings](https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/blob/main/doc/non_mkdocs/proxy-settings.md) page.
 
 


### PR DESCRIPTION
The link in https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/download_cfd.html#using-behind-proxy is currently broken. This change should fix that.