### PR TITLE
Add `ui not required` label on renovate PRs 

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,7 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": ["config:recommended", ":labels(doc not required)"],
+    "extends": ["config:recommended"],
+    "labels": ["doc not required"],
     "packageRules": [
         {
             "excludePackageNames": [

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": ["config:recommended"],
-    "labels": ["doc not required"],
+    "labels": ["doc not required", "ui not required"],
     "packageRules": [
         {
             "excludePackageNames": [


### PR DESCRIPTION
Because the label `ui not required`/`ui required` is also checked by a GitHub action now and we do not want a failure from that on every renovate PR.