### PR TITLE
Feat: show depreciation warning

### DIFF
--- a/src/ipc/persistedStore.ts
+++ b/src/ipc/persistedStore.ts
@@ -91,3 +91,9 @@ export const getBundledAppInstalled = () =>
 
 export const setBundledAppInstalled = () =>
     store.set('lastBundledAppInstalledVersion', packageJson.version);
+
+export const setDoNotShowAppleSiliconWarning = () =>
+    store.set('doNotShowAppleSiliconWarning', true);
+
+export const getDoNotShowAppleSiliconWarning = () =>
+    store.get('doNotShowAppleSiliconWarning', false);

--- a/src/launcher/Root.tsx
+++ b/src/launcher/Root.tsx
@@ -13,6 +13,8 @@ import {
 } from '@nordicsemiconductor/pc-nrfconnect-shared';
 
 import About from './features/about/About';
+import AppleSiliconAlert from './features/appleSilicon/AppleSiliconAlert';
+import AppleSiliconDialog from './features/appleSilicon/AppleSiliconDialog';
 import AppList from './features/apps/AppList';
 import UpdateAvailableDialog from './features/launcherUpdate/UpdateAvailableDialog';
 import UpdateProgressDialog from './features/launcherUpdate/UpdateProgressDialog';
@@ -71,12 +73,15 @@ export default () => {
                     </Nav>
                     <Tab.Content>
                         <Tab.Pane eventKey="apps">
+                            <AppleSiliconAlert />
                             <AppList />
                         </Tab.Pane>
                         <Tab.Pane eventKey="settings">
+                            <AppleSiliconAlert />
                             <Settings />
                         </Tab.Pane>
                         <Tab.Pane eventKey="about">
+                            <AppleSiliconAlert />
                             <About />
                         </Tab.Pane>
                     </Tab.Content>
@@ -89,6 +94,7 @@ export default () => {
             <TelemetryDialog />
             <ProxyLoginDialog />
             <ProxyErrorDialog />
+            <AppleSiliconDialog />
             <QuickStartDialog />
         </ErrorBoundaryLauncher>
     );

--- a/src/launcher/features/appleSilicon/AppleSiliconAlert.tsx
+++ b/src/launcher/features/appleSilicon/AppleSiliconAlert.tsx
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2015 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import React from 'react';
+import { Alert } from '@nordicsemiconductor/pc-nrfconnect-shared';
+
+import { isIntelElectronOnAppleSilicon } from './appleSiliconSlice';
+
+export default () =>
+    isIntelElectronOnAppleSilicon ? (
+        <Alert variant="warning">
+            <div className="tw-text-sm tw-text-white">
+                <strong>Warning: </strong>A nativeApple Silicon build is
+                available for download{' '}
+                <a
+                    target="_blank"
+                    rel="noreferrer noopener"
+                    href="https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/releases/latest"
+                    className="tw-preflight tw-text-white tw-underline"
+                >
+                    here
+                </a>
+                . Using an Intel build of nRF Connect for Desktop may result in
+                unexpected behavior and is not supported.
+            </div>
+        </Alert>
+    ) : null;

--- a/src/launcher/features/appleSilicon/AppleSiliconAlert.tsx
+++ b/src/launcher/features/appleSilicon/AppleSiliconAlert.tsx
@@ -13,15 +13,14 @@ export default () =>
     isIntelElectronOnAppleSilicon ? (
         <Alert variant="warning">
             <div className="tw-text-sm tw-text-white">
-                <strong>Warning: </strong>A nativeApple Silicon build is
-                available for download{' '}
+                <strong>Warning: </strong>A native Apple Silicon build is{' '}
                 <a
                     target="_blank"
                     rel="noreferrer noopener"
                     href="https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/releases/latest"
                     className="tw-preflight tw-text-white tw-underline"
                 >
-                    here
+                    available for download
                 </a>
                 . Using an Intel build of nRF Connect for Desktop may result in
                 unexpected behavior and is not supported.

--- a/src/launcher/features/appleSilicon/AppleSiliconDialog.tsx
+++ b/src/launcher/features/appleSilicon/AppleSiliconDialog.tsx
@@ -9,11 +9,12 @@ import {
     DialogButton,
     ExternalLink,
     GenericDialog,
+    openUrl,
 } from '@nordicsemiconductor/pc-nrfconnect-shared';
 
 import { useLauncherDispatch, useLauncherSelector } from '../../util/hooks';
 import { getIsTelemetryDialogVisible } from '../telemetry/telemetrySlice';
-import { confirm, doNotShowAgain } from './appleSiliconEffects';
+import { doNotShowAgain, download, ignore } from './appleSiliconEffects';
 import { getIsAppleSiliconDialogVisible } from './appleSiliconSlice';
 
 export default () => {
@@ -34,32 +35,40 @@ export default () => {
             headerIcon="alert"
             className="tw-preflight"
             isVisible={isVisible}
-            onHide={() => dispatch(confirm())}
+            onHide={() => dispatch(ignore())}
             title="Unsupported - Intel Build on Apple Silicon"
             footer={
                 <>
                     <DialogButton
                         variant="primary"
-                        onClick={() => dispatch(confirm())}
+                        onClick={() => {
+                            openUrl(
+                                'https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/releases/latest'
+                            );
+                            dispatch(download());
+                        }}
                     >
-                        OK
+                        Download
+                    </DialogButton>
+                    <DialogButton onClick={() => dispatch(ignore())}>
+                        Ignore
                     </DialogButton>
                     <DialogButton onClick={() => dispatch(doNotShowAgain())}>
-                        {`Don't show this again`}
+                        {`Don't show again`}
                     </DialogButton>
                 </>
             }
         >
-            <div className="">
+            <div>
                 <p>
                     nRF Connect for Desktop is now available natively for Apple
-                    Silicon. Click on this{' '}
+                    Silicon.{' '}
                     <ExternalLink
-                        label="link"
+                        label="Download the latest version of the launcher"
                         href="https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/releases/latest"
-                    />{' '}
-                    to download the latest version. This is the only support way
-                    to use nRF Connect for Desktop on Apple Silicon machines.
+                    />
+                    . This is the only supported way to use nRF Connect for
+                    Desktop on Apple Silicon machines.
                 </p>
             </div>
         </GenericDialog>

--- a/src/launcher/features/appleSilicon/AppleSiliconDialog.tsx
+++ b/src/launcher/features/appleSilicon/AppleSiliconDialog.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2015 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import React from 'react';
+import {
+    DialogButton,
+    ExternalLink,
+    GenericDialog,
+} from '@nordicsemiconductor/pc-nrfconnect-shared';
+
+import { useLauncherDispatch, useLauncherSelector } from '../../util/hooks';
+import { getIsTelemetryDialogVisible } from '../telemetry/telemetrySlice';
+import { confirm, doNotShowAgain } from './appleSiliconEffects';
+import { getIsAppleSiliconDialogVisible } from './appleSiliconSlice';
+
+export default () => {
+    const dispatch = useLauncherDispatch();
+    const isAppleSiliconDialogVisible = useLauncherSelector(
+        getIsAppleSiliconDialogVisible
+    );
+
+    const isTelemetryDialogVisible = useLauncherSelector(
+        getIsTelemetryDialogVisible
+    );
+
+    const isVisible = !isTelemetryDialogVisible && isAppleSiliconDialogVisible;
+
+    return (
+        <GenericDialog
+            closeOnEsc
+            headerIcon="alert"
+            className="tw-preflight"
+            isVisible={isVisible}
+            onHide={() => dispatch(confirm())}
+            title="Unsupported - Intel Build on Apple Silicon"
+            footer={
+                <>
+                    <DialogButton
+                        variant="primary"
+                        onClick={() => dispatch(confirm())}
+                    >
+                        OK
+                    </DialogButton>
+                    <DialogButton onClick={() => dispatch(doNotShowAgain())}>
+                        {`Don't show this again`}
+                    </DialogButton>
+                </>
+            }
+        >
+            <div className="">
+                <p>
+                    nRF Connect for Desktop is now available natively for Apple
+                    Silicon. Click on this{' '}
+                    <ExternalLink
+                        label="link"
+                        href="https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/releases/latest"
+                    />{' '}
+                    to download the latest version. This is the only support way
+                    to use nRF Connect for Desktop on Apple Silicon machines.
+                </p>
+            </div>
+        </GenericDialog>
+    );
+};

--- a/src/launcher/features/appleSilicon/appleSiliconEffects.ts
+++ b/src/launcher/features/appleSilicon/appleSiliconEffects.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2015 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import { telemetry } from '@nordicsemiconductor/pc-nrfconnect-shared';
+
+import { setDoNotShowAppleSiliconWarning } from '../../../ipc/persistedStore';
+import type { AppThunk } from '../../store';
+import { hideAppleSiliconDialog } from './appleSiliconSlice';
+
+export const confirm = (): AppThunk => dispatch => {
+    telemetry.sendEvent('IgnoreAppleSiliconWarning', {
+        permanent: false,
+    });
+    dispatch(hideAppleSiliconDialog());
+};
+
+export const doNotShowAgain = (): AppThunk => dispatch => {
+    telemetry.sendEvent('IgnoreAppleSiliconWarning', {
+        permanent: false,
+    });
+    dispatch(hideAppleSiliconDialog());
+    setDoNotShowAppleSiliconWarning();
+};

--- a/src/launcher/features/appleSilicon/appleSiliconEffects.ts
+++ b/src/launcher/features/appleSilicon/appleSiliconEffects.ts
@@ -10,16 +10,25 @@ import { setDoNotShowAppleSiliconWarning } from '../../../ipc/persistedStore';
 import type { AppThunk } from '../../store';
 import { hideAppleSiliconDialog } from './appleSiliconSlice';
 
-export const confirm = (): AppThunk => dispatch => {
-    telemetry.sendEvent('IgnoreAppleSiliconWarning', {
+export const download = (): AppThunk => dispatch => {
+    telemetry.sendEvent('Apple Silicon Warning', {
+        ignored: false,
+    });
+    dispatch(hideAppleSiliconDialog());
+};
+
+export const ignore = (): AppThunk => dispatch => {
+    telemetry.sendEvent('Apple Silicon Warning', {
+        ignored: true,
         permanent: false,
     });
     dispatch(hideAppleSiliconDialog());
 };
 
 export const doNotShowAgain = (): AppThunk => dispatch => {
-    telemetry.sendEvent('IgnoreAppleSiliconWarning', {
-        permanent: false,
+    telemetry.sendEvent('Apple Silicon Warning', {
+        ignored: true,
+        permanent: true,
     });
     dispatch(hideAppleSiliconDialog());
     setDoNotShowAppleSiliconWarning();

--- a/src/launcher/features/appleSilicon/appleSiliconSlice.ts
+++ b/src/launcher/features/appleSilicon/appleSiliconSlice.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import { createSlice } from '@reduxjs/toolkit';
+import os from 'os';
+
+import { getDoNotShowAppleSiliconWarning } from '../../../ipc/persistedStore';
+import type { RootState } from '../../store';
+
+export type State = {
+    isAppleSiliconDialogVisible: boolean;
+};
+
+const isAppleSilicon = os.cpus()[0].model.includes('Apple');
+
+export const isIntelElectronOnAppleSilicon =
+    isAppleSilicon && process.arch !== 'arm64';
+
+const initialState: State = {
+    isAppleSiliconDialogVisible:
+        process.platform === 'darwin' &&
+        isIntelElectronOnAppleSilicon &&
+        !getDoNotShowAppleSiliconWarning(),
+};
+
+const slice = createSlice({
+    name: 'settings',
+    initialState,
+    reducers: {
+        showAppleSiliconDialog(state) {
+            state.isAppleSiliconDialogVisible = true;
+        },
+        hideAppleSiliconDialog(state) {
+            state.isAppleSiliconDialogVisible = false;
+        },
+    },
+});
+
+export default slice.reducer;
+
+export const { showAppleSiliconDialog, hideAppleSiliconDialog } = slice.actions;
+
+export const getIsAppleSiliconDialogVisible = (state: RootState) =>
+    state.appleSilicon.isAppleSiliconDialogVisible;

--- a/src/launcher/features/quickstart/QuickstartDialog.tsx
+++ b/src/launcher/features/quickstart/QuickstartDialog.tsx
@@ -16,6 +16,7 @@ import fs from 'fs';
 import path from 'path';
 
 import { useLauncherDispatch, useLauncherSelector } from '../../util/hooks';
+import { getIsAppleSiliconDialogVisible } from '../appleSilicon/appleSiliconSlice';
 import { checkEngineAndLaunch } from '../apps/appsEffects';
 import { getOfficialQuickStartApp } from '../apps/appsSlice';
 import {
@@ -60,6 +61,11 @@ export default () => {
     const isTelemetryDialogVisible = useLauncherSelector(
         getIsTelemetryDialogVisible
     );
+
+    const isAppleSiliconDialogVisible = useLauncherSelector(
+        getIsAppleSiliconDialogVisible
+    );
+
     const quickStartApp = useLauncherSelector(getOfficialQuickStartApp);
 
     const dispatch = useLauncherDispatch();
@@ -67,6 +73,7 @@ export default () => {
     const isVisible =
         !isQuickStartInfoShownBefore &&
         !isTelemetryDialogVisible &&
+        !isAppleSiliconDialogVisible &&
         quickStartApp != null;
 
     const supportedDevices =

--- a/src/launcher/store.ts
+++ b/src/launcher/store.ts
@@ -10,6 +10,7 @@ import { enableMapSet } from 'immer';
 import { AnyAction } from 'redux';
 import { ThunkAction } from 'redux-thunk';
 
+import appleSilicon from './features/appleSilicon/appleSiliconSlice';
 import appDialogs from './features/apps/appDialogsSlice';
 import apps from './features/apps/appsSlice';
 import filter from './features/filter/filterSlice';
@@ -24,6 +25,7 @@ import telemetry from './features/telemetry/telemetrySlice';
 enableMapSet();
 
 export const reducer = {
+    appleSilicon,
     apps,
     appDialogs,
     errorDialog,


### PR DESCRIPTION
Show warning on Apple silicon machines using Intel build that this is not supported

![image](https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/assets/10996496/2884ca55-d757-4ddd-bb42-1ccc452264df)

![image](https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/assets/10996496/2453377d-8ec0-4a76-a0ec-d03ee6087430)

![image](https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/assets/10996496/4d7a5d29-1f47-4d11-ba7d-0926a48d52cd)
