### PR TITLE
fix: having spaces in electron path now doesn't make path unusable

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,8 @@
 
 -   Installation of the J-Link legacy driver on Windows.
 -   App crash on Linux (Ubuntu 22.04).
+-   Linux: Application shortcuts now also work for when the path to nRF Connect
+    for Desktop contains spaces.
 
 ## 5.0.0 - 2024-05-13
 

--- a/src/main/apps/createDesktopShortcut.ts
+++ b/src/main/apps/createDesktopShortcut.ts
@@ -113,7 +113,7 @@ const createShortcutForLinux = (app: LaunchableApp) => {
         'Encoding=UTF-8',
         `Version=${app.currentVersion}`,
         `Name=${fileName}`,
-        `Exec=${getElectronExePath()} ${args}`,
+        `Exec=${getElectronExePath().replace(/ /g, '\\ ')} ${args}`,
         'Terminal=false',
         `Icon=${icon}`,
         'Type=Application',


### PR DESCRIPTION
Surrounding ' or " didn't fix the issue for me