### PR TITLE
Fix: J-Link update to 7.94i

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,8 +1,8 @@
 ## 5.0.3 - Unrelesed
 
-### Updated
+### Changed
 
--   Bundeled J-Link Version to 7.94i for windows.
+-   Updated bundled SEGGER J-Link to v7.94i for Windows.
 
 ## 5.0.2 - 2024-07-24
 

--- a/doc/docs/download_cfd.md
+++ b/doc/docs/download_cfd.md
@@ -18,7 +18,7 @@ All nRF Connect for Desktop applications require the launcher v4.1.0 or later.
 
 Running nRF Connect for Desktop has the following additional requirements:
 
-- [**SEGGER J-Link** v7.94e](https://www.segger.com/downloads/jlink/#J-LinkSoftwareAndDocumentationPack) - required for all platforms.
+- [**SEGGER J-Link** v7.94i](https://www.segger.com/downloads/jlink/#J-LinkSoftwareAndDocumentationPack) - required for all platforms.
 
     - On Windows, the driver comes bundled with nRF Connect for Desktop.
     - On macOS and Linux, you must install the driver manually. Download the installer for your platform from [SEGGER J-Link Software](https://www.segger.com/downloads/jlink/#J-LinkSoftwareAndDocumentationPack).


### PR DESCRIPTION
#1040 was labeled as “doc not required” but the J-Link version is actually mentioned in the docs, so it needs to be updated.

Also, the wording in the changelog was a bit off, so also updated that.