### PR TITLE
feat: remove mention of supported devices is quickstart dialog

### DIFF
--- a/src/launcher/features/quickstart/QuickstartDialog.tsx
+++ b/src/launcher/features/quickstart/QuickstartDialog.tsx
@@ -6,14 +6,9 @@
 
 import React from 'react';
 import {
-    deviceInfo,
     DialogButton,
     GenericDialog,
-    InstalledDownloadableApp,
 } from '@nordicsemiconductor/pc-nrfconnect-shared';
-import { parsePackageJsonApp } from '@nordicsemiconductor/pc-nrfconnect-shared/main';
-import fs from 'fs';
-import path from 'path';
 
 import { useLauncherDispatch, useLauncherSelector } from '../../util/hooks';
 import { getIsAppleSiliconDialogVisible } from '../appleSilicon/appleSiliconSlice';
@@ -24,35 +19,6 @@ import {
     quickStartInfoWasShown,
 } from '../settings/settingsSlice';
 import { getIsTelemetryDialogVisible } from '../telemetry/telemetrySlice';
-
-const DEFAULT_SUPPORTED_DEVICES = ['pca10090', 'pca10153'];
-
-const nameFor = (pcaNumber: string) =>
-    deviceInfo({
-        id: 0,
-        traits: {},
-        devkit: { boardVersion: pcaNumber },
-    }).name;
-
-const packageJson = (quickStartApp?: InstalledDownloadableApp) => {
-    if (quickStartApp?.installed.path == null) {
-        return;
-    }
-
-    const packageJSONPath = path.join(
-        quickStartApp?.installed.path,
-        'package.json'
-    );
-
-    if (!fs.existsSync(packageJSONPath)) {
-        return undefined;
-    }
-
-    const parsed = parsePackageJsonApp(
-        fs.readFileSync(packageJSONPath, 'utf8')
-    );
-    return parsed.success ? parsed.data : undefined;
-};
 
 export default () => {
     const isQuickStartInfoShownBefore = useLauncherSelector(
@@ -75,10 +41,6 @@ export default () => {
         !isTelemetryDialogVisible &&
         !isAppleSiliconDialogVisible &&
         quickStartApp != null;
-
-    const supportedDevices =
-        packageJson(quickStartApp)?.nrfConnectForDesktop?.supportedDevices ??
-        DEFAULT_SUPPORTED_DEVICES;
 
     return (
         <GenericDialog
@@ -115,7 +77,6 @@ export default () => {
                 Do you have a new development kit? Use the Quick Start app to
                 get up and running as fast as possible.
             </p>
-            <p>Supported kits: {supportedDevices.map(nameFor).join(', ')}.</p>
         </GenericDialog>
     );
 };


### PR DESCRIPTION
This was outdated anyway but is now fairly irrelevant due to quickstart supporting most devices