### PR TITLE
Fix `nrfutil` always being overwritten

### DIFF
--- a/Changelog.minor.md
+++ b/Changelog.minor.md
@@ -13,6 +13,8 @@ release the new version.
 
 -   #1037: Aligned "Update all apps" button with the list of the apps
     vertically.
+-   #1051: `nrfutil` was always overwritten by the bundled version, even if the
+    latter was older.
 
 ## 4.4.1 - 5.0.2
 

--- a/src/main/configureElectronApp.ts
+++ b/src/main/configureElectronApp.ts
@@ -91,13 +91,13 @@ const initNrfutil = () => {
     const nrfutilInAppPath = path.join(getUserDataDir(), binName);
     const nrfutilBundledStats = fse.statSync(nrfutilBundled);
 
-    const noNrfutilInstalled = !fse.existsSync(nrfutilInAppPath);
+    const nrfutilInstalled = fse.existsSync(nrfutilInAppPath);
     const installedNrfutilOlderThenBundledNrfutil =
-        nrfutilInAppPath ||
+        nrfutilInstalled &&
         Math.round(nrfutilBundledStats.mtimeMs) >
             Math.round(fse.statSync(nrfutilInAppPath).mtimeMs);
 
-    if (noNrfutilInstalled || installedNrfutilOlderThenBundledNrfutil) {
+    if (!nrfutilInstalled || installedNrfutilOlderThenBundledNrfutil) {
         fse.copyFileSync(nrfutilBundled, nrfutilInAppPath);
         fse.utimes(
             nrfutilInAppPath,


### PR DESCRIPTION
Because `nrfutilInAppPath` is always a string containing something, `installedNrfutilOlderThenBundledNrfutil` was always truthy, causing nrfutil to be always overwritten by the bundled version.