### PR TITLE
Fix to also warn for nrfutil-device 2.7

### DIFF
--- a/src/launcher/util/appCompatibilityWarning.tsx
+++ b/src/launcher/util/appCompatibilityWarning.tsx
@@ -201,7 +201,8 @@ const checkJLinkRequirements: AppCompatibilityChecker = async (
         moduleVersion.dependencies
     );
 
-    if (!jlinkVersionDependency) {
+    const noJlinkInstalled = jlinkVersionDependency?.version == null;
+    if (noJlinkInstalled) {
         const requiredVersion = nrfutilDeviceToJLink(deviceVersion);
 
         return incompatible(


### PR DESCRIPTION
Since nrfutil-device 2.7 jlinkVersionDependency will also be defined when no J-Link is installed. But then jlinkVersionDependency.version will be undefined.

So this handles both cases correct if J-Link is not installed:
- For nrfutil-device < 2.7 jlinkVersionDependency will be undefined
- For nrfutil-device >= 2.7 jlinkVersionDependency.version will be undefined