### PR TITLE
Get J-Link from Artifactory

### DIFF
--- a/Changelog.minor.md
+++ b/Changelog.minor.md
@@ -12,6 +12,7 @@ release the new version.
 ### Changed
 
 -   #1057: Show J-Link warning also for local apps.
+-   #1063: Download J-Link from Artifactory.
 
 ## 5.1.0
 

--- a/build/getJlink.js
+++ b/build/getJlink.js
@@ -11,7 +11,7 @@ const bundledJlinkVersion = require('../src/main/bundledJlinkVersion.js');
 
 const minVersion = bundledJlinkVersion.replace('.', '');
 
-const FILE_URL = `https://developer.nordicsemi.com/.pc-tools/jlink/JLink_Windows_${minVersion}_x86_64.exe`;
+const FILE_URL = `https://files.nordicsemi.com/artifactory/swtools/external/ncd/jlink/JLink_Windows_${minVersion}_x86_64.exe`;
 const DESTINATION_FILE_PATH = path.join(
     'build',
     `JLink_Windows_${minVersion}.exe`

--- a/scripts/downloadFile.js
+++ b/scripts/downloadFile.js
@@ -11,11 +11,11 @@ const path = require('path');
 const crypto = require('crypto');
 
 const downloadChecksum = async fileUrl => {
-    console.log('Downloading', `${fileUrl}.md5`);
-    const { status, data } = await axios.get(`${fileUrl}.md5`);
+    console.log('Downloading', fileUrl);
+    const { status, data } = await axios.get(fileUrl);
     if (status !== 200) {
         throw new Error(
-            `Unable to download ${fileUrl}.md5. Got status code ${status}`
+            `Unable to download ${fileUrl}. Got status code ${status}`
         );
     }
     return data.split(' ').shift();
@@ -45,7 +45,9 @@ module.exports = async (fileUrl, destinationFile, useChecksum = false) => {
                 console.log('🏁 Saved to', destinationFile);
                 if (useChecksum) {
                     const calculatedChecksum = hash.digest('hex');
-                    const expectedChecksum = await downloadChecksum(fileUrl);
+                    const expectedChecksum = await downloadChecksum(
+                        `${fileUrl}.md5`
+                    );
 
                     if (calculatedChecksum !== expectedChecksum) {
                         fs.unlinkSync(destinationFile);

--- a/scripts/downloadFile.js
+++ b/scripts/downloadFile.js
@@ -18,11 +18,11 @@ const downloadChecksum = async fileUrl => {
             `Unable to download ${fileUrl}. Got status code ${status}`
         );
     }
-    return data.split(' ').shift();
+    return data;
 };
 
 module.exports = async (fileUrl, destinationFile, useChecksum = false) => {
-    const hash = crypto.createHash('md5');
+    const hash = crypto.createHash('sha256');
 
     console.log('Started Download', fileUrl);
     const { status, data: stream } = await axios.get(fileUrl, {
@@ -46,7 +46,7 @@ module.exports = async (fileUrl, destinationFile, useChecksum = false) => {
                 if (useChecksum) {
                     const calculatedChecksum = hash.digest('hex');
                     const expectedChecksum = await downloadChecksum(
-                        `${fileUrl}.md5`
+                        `${fileUrl}.sha256`
                     );
 
                     if (calculatedChecksum !== expectedChecksum) {

--- a/scripts/downloadFile.js
+++ b/scripts/downloadFile.js
@@ -12,13 +12,17 @@ const crypto = require('crypto');
 
 const downloadChecksum = async fileUrl => {
     console.log('Downloading', fileUrl);
-    const { status, data } = await axios.get(fileUrl);
-    if (status !== 200) {
-        throw new Error(
-            `Unable to download ${fileUrl}. Got status code ${status}`
-        );
+    try {
+        const { status, data } = await axios.get(fileUrl);
+        if (status !== 200) {
+            throw new Error(
+                `Unable to download ${fileUrl}. Got status code ${status}`
+            );
+        }
+        return data;
+    } catch (error) {
+        throw new Error(`Unable to download ${fileUrl}: ${error.message}`);
     }
-    return data;
 };
 
 module.exports = async (fileUrl, destinationFile, useChecksum = false) => {


### PR DESCRIPTION
Only executed while building the launcher. J-Link is already uploaded to https://files.nordicsemi.com/ui/native/swtools/external/ncd/jlink/. The checksum files are not visible, but they can be fetched from the same location (e.g. https://files.nordicsemi.com/artifactory/swtools/external/ncd/jlink/JLink_Windows_V794i_x86_64.exe.sha256).

Part of [NCD-1110](https://nordicsemi.atlassian.net/browse/NCD-1110).