### PR TITLE
Add versioning to sources.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
             },
             "devDependencies": {
                 "@electron/notarize": "^2.2.0",
-                "@nordicsemiconductor/pc-nrfconnect-shared": "^191.0.0",
+                "@nordicsemiconductor/pc-nrfconnect-shared": "^195.0.0",
                 "@playwright/test": "^1.16.3",
                 "@testing-library/user-event": "^14.4.3",
                 "@types/chmodr": "1.0.0",
@@ -1726,32 +1726,6 @@
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
-        "node_modules/@jest/console/node_modules/@jest/types": {
-            "version": "29.6.3",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-            "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-            "dev": true,
-            "dependencies": {
-                "@jest/schemas": "^29.6.3",
-                "@types/istanbul-lib-coverage": "^2.0.0",
-                "@types/istanbul-reports": "^3.0.0",
-                "@types/node": "*",
-                "@types/yargs": "^17.0.8",
-                "chalk": "^4.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@jest/console/node_modules/@types/yargs": {
-            "version": "17.0.28",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.28.tgz",
-            "integrity": "sha512-N3e3fkS86hNhtk6BEnc0rj3zcehaxx8QWhCROJkqpl5Zaoi7nAic3jH8q94jVD3zu5LGk+PUB6KAiDmimYOEQw==",
-            "dev": true,
-            "dependencies": {
-                "@types/yargs-parser": "*"
-            }
-        },
         "node_modules/@jest/console/node_modules/ansi-styles": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -1869,32 +1843,6 @@
                 }
             }
         },
-        "node_modules/@jest/core/node_modules/@jest/types": {
-            "version": "29.6.3",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-            "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-            "dev": true,
-            "dependencies": {
-                "@jest/schemas": "^29.6.3",
-                "@types/istanbul-lib-coverage": "^2.0.0",
-                "@types/istanbul-reports": "^3.0.0",
-                "@types/node": "*",
-                "@types/yargs": "^17.0.8",
-                "chalk": "^4.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@jest/core/node_modules/@types/yargs": {
-            "version": "17.0.28",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.28.tgz",
-            "integrity": "sha512-N3e3fkS86hNhtk6BEnc0rj3zcehaxx8QWhCROJkqpl5Zaoi7nAic3jH8q94jVD3zu5LGk+PUB6KAiDmimYOEQw==",
-            "dev": true,
-            "dependencies": {
-                "@types/yargs-parser": "*"
-            }
-        },
         "node_modules/@jest/core/node_modules/ansi-styles": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -1998,15 +1946,16 @@
             }
         },
         "node_modules/@jest/create-cache-key-function": {
-            "version": "27.5.1",
-            "resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-27.5.1.tgz",
-            "integrity": "sha512-dmH1yW+makpTSURTy8VzdUwFnfQh1G8R+DxO2Ho2FFmBbKFEVm+3jWdvFhE2VqB/LATCTokkP0dotjyQyw5/AQ==",
+            "version": "29.7.0",
+            "resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-29.7.0.tgz",
+            "integrity": "sha512-4QqS3LY5PBmTRHj9sAg1HLoPzqAI0uOX6wI/TRqHIcOxlFidy6YEmCQJk6FSZjNLGCeubDMfmkWL+qaLKhSGQA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@jest/types": "^27.5.1"
+                "@jest/types": "^29.6.3"
             },
             "engines": {
-                "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
         "node_modules/@jest/environment": {
@@ -2022,102 +1971,6 @@
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@jest/environment/node_modules/@jest/types": {
-            "version": "29.6.3",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-            "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-            "dev": true,
-            "dependencies": {
-                "@jest/schemas": "^29.6.3",
-                "@types/istanbul-lib-coverage": "^2.0.0",
-                "@types/istanbul-reports": "^3.0.0",
-                "@types/node": "*",
-                "@types/yargs": "^17.0.8",
-                "chalk": "^4.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@jest/environment/node_modules/@types/yargs": {
-            "version": "17.0.28",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.28.tgz",
-            "integrity": "sha512-N3e3fkS86hNhtk6BEnc0rj3zcehaxx8QWhCROJkqpl5Zaoi7nAic3jH8q94jVD3zu5LGk+PUB6KAiDmimYOEQw==",
-            "dev": true,
-            "dependencies": {
-                "@types/yargs-parser": "*"
-            }
-        },
-        "node_modules/@jest/environment/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/@jest/environment/node_modules/chalk": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "dev": true,
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "node_modules/@jest/environment/node_modules/color-convert": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
-            "dependencies": {
-                "color-name": "~1.1.4"
-            },
-            "engines": {
-                "node": ">=7.0.0"
-            }
-        },
-        "node_modules/@jest/environment/node_modules/color-name": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true
-        },
-        "node_modules/@jest/environment/node_modules/has-flag": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@jest/environment/node_modules/supports-color": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dev": true,
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/@jest/expect": {
@@ -2162,102 +2015,6 @@
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
-        "node_modules/@jest/fake-timers/node_modules/@jest/types": {
-            "version": "29.6.3",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-            "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-            "dev": true,
-            "dependencies": {
-                "@jest/schemas": "^29.6.3",
-                "@types/istanbul-lib-coverage": "^2.0.0",
-                "@types/istanbul-reports": "^3.0.0",
-                "@types/node": "*",
-                "@types/yargs": "^17.0.8",
-                "chalk": "^4.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@jest/fake-timers/node_modules/@types/yargs": {
-            "version": "17.0.28",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.28.tgz",
-            "integrity": "sha512-N3e3fkS86hNhtk6BEnc0rj3zcehaxx8QWhCROJkqpl5Zaoi7nAic3jH8q94jVD3zu5LGk+PUB6KAiDmimYOEQw==",
-            "dev": true,
-            "dependencies": {
-                "@types/yargs-parser": "*"
-            }
-        },
-        "node_modules/@jest/fake-timers/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/@jest/fake-timers/node_modules/chalk": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "dev": true,
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "node_modules/@jest/fake-timers/node_modules/color-convert": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
-            "dependencies": {
-                "color-name": "~1.1.4"
-            },
-            "engines": {
-                "node": ">=7.0.0"
-            }
-        },
-        "node_modules/@jest/fake-timers/node_modules/color-name": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true
-        },
-        "node_modules/@jest/fake-timers/node_modules/has-flag": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@jest/fake-timers/node_modules/supports-color": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dev": true,
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/@jest/globals": {
             "version": "29.7.0",
             "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
@@ -2271,102 +2028,6 @@
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@jest/globals/node_modules/@jest/types": {
-            "version": "29.6.3",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-            "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-            "dev": true,
-            "dependencies": {
-                "@jest/schemas": "^29.6.3",
-                "@types/istanbul-lib-coverage": "^2.0.0",
-                "@types/istanbul-reports": "^3.0.0",
-                "@types/node": "*",
-                "@types/yargs": "^17.0.8",
-                "chalk": "^4.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@jest/globals/node_modules/@types/yargs": {
-            "version": "17.0.28",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.28.tgz",
-            "integrity": "sha512-N3e3fkS86hNhtk6BEnc0rj3zcehaxx8QWhCROJkqpl5Zaoi7nAic3jH8q94jVD3zu5LGk+PUB6KAiDmimYOEQw==",
-            "dev": true,
-            "dependencies": {
-                "@types/yargs-parser": "*"
-            }
-        },
-        "node_modules/@jest/globals/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/@jest/globals/node_modules/chalk": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "dev": true,
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "node_modules/@jest/globals/node_modules/color-convert": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
-            "dependencies": {
-                "color-name": "~1.1.4"
-            },
-            "engines": {
-                "node": ">=7.0.0"
-            }
-        },
-        "node_modules/@jest/globals/node_modules/color-name": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true
-        },
-        "node_modules/@jest/globals/node_modules/has-flag": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@jest/globals/node_modules/supports-color": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dev": true,
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/@jest/reporters": {
@@ -2410,32 +2071,6 @@
                 "node-notifier": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/@jest/reporters/node_modules/@jest/types": {
-            "version": "29.6.3",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-            "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-            "dev": true,
-            "dependencies": {
-                "@jest/schemas": "^29.6.3",
-                "@types/istanbul-lib-coverage": "^2.0.0",
-                "@types/istanbul-reports": "^3.0.0",
-                "@types/node": "*",
-                "@types/yargs": "^17.0.8",
-                "chalk": "^4.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@jest/reporters/node_modules/@types/yargs": {
-            "version": "17.0.28",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.28.tgz",
-            "integrity": "sha512-N3e3fkS86hNhtk6BEnc0rj3zcehaxx8QWhCROJkqpl5Zaoi7nAic3jH8q94jVD3zu5LGk+PUB6KAiDmimYOEQw==",
-            "dev": true,
-            "dependencies": {
-                "@types/yargs-parser": "*"
             }
         },
         "node_modules/@jest/reporters/node_modules/ansi-styles": {
@@ -2549,102 +2184,6 @@
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
-        "node_modules/@jest/test-result/node_modules/@jest/types": {
-            "version": "29.6.3",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-            "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-            "dev": true,
-            "dependencies": {
-                "@jest/schemas": "^29.6.3",
-                "@types/istanbul-lib-coverage": "^2.0.0",
-                "@types/istanbul-reports": "^3.0.0",
-                "@types/node": "*",
-                "@types/yargs": "^17.0.8",
-                "chalk": "^4.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@jest/test-result/node_modules/@types/yargs": {
-            "version": "17.0.28",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.28.tgz",
-            "integrity": "sha512-N3e3fkS86hNhtk6BEnc0rj3zcehaxx8QWhCROJkqpl5Zaoi7nAic3jH8q94jVD3zu5LGk+PUB6KAiDmimYOEQw==",
-            "dev": true,
-            "dependencies": {
-                "@types/yargs-parser": "*"
-            }
-        },
-        "node_modules/@jest/test-result/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/@jest/test-result/node_modules/chalk": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "dev": true,
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "node_modules/@jest/test-result/node_modules/color-convert": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
-            "dependencies": {
-                "color-name": "~1.1.4"
-            },
-            "engines": {
-                "node": ">=7.0.0"
-            }
-        },
-        "node_modules/@jest/test-result/node_modules/color-name": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true
-        },
-        "node_modules/@jest/test-result/node_modules/has-flag": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@jest/test-result/node_modules/supports-color": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dev": true,
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/@jest/test-sequencer": {
             "version": "29.7.0",
             "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
@@ -2684,32 +2223,6 @@
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@jest/transform/node_modules/@jest/types": {
-            "version": "29.6.3",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-            "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-            "dev": true,
-            "dependencies": {
-                "@jest/schemas": "^29.6.3",
-                "@types/istanbul-lib-coverage": "^2.0.0",
-                "@types/istanbul-reports": "^3.0.0",
-                "@types/node": "*",
-                "@types/yargs": "^17.0.8",
-                "chalk": "^4.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@jest/transform/node_modules/@types/yargs": {
-            "version": "17.0.28",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.28.tgz",
-            "integrity": "sha512-N3e3fkS86hNhtk6BEnc0rj3zcehaxx8QWhCROJkqpl5Zaoi7nAic3jH8q94jVD3zu5LGk+PUB6KAiDmimYOEQw==",
-            "dev": true,
-            "dependencies": {
-                "@types/yargs-parser": "*"
             }
         },
         "node_modules/@jest/transform/node_modules/ansi-styles": {
@@ -2783,19 +2296,21 @@
             }
         },
         "node_modules/@jest/types": {
-            "version": "27.5.1",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-27.5.1.tgz",
-            "integrity": "sha512-Cx46iJ9QpwQTjIdq5VJu2QTMMs3QlEjI0x1QbBP5W1+nMzyc2XmimiRR/CbX9TO0cPTeUlxWMOu8mslYsJ8DEw==",
+            "version": "29.6.3",
+            "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
+            "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
+                "@jest/schemas": "^29.6.3",
                 "@types/istanbul-lib-coverage": "^2.0.0",
                 "@types/istanbul-reports": "^3.0.0",
                 "@types/node": "*",
-                "@types/yargs": "^16.0.0",
+                "@types/yargs": "^17.0.8",
                 "chalk": "^4.0.0"
             },
             "engines": {
-                "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
         "node_modules/@jest/types/node_modules/ansi-styles": {
@@ -2803,6 +2318,7 @@
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
             "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "color-convert": "^2.0.1"
             },
@@ -2818,6 +2334,7 @@
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
             "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -2834,6 +2351,7 @@
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
             "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "color-name": "~1.1.4"
             },
@@ -2845,13 +2363,15 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@jest/types/node_modules/has-flag": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
             "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
@@ -2861,6 +2381,7 @@
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
             "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "has-flag": "^4.0.0"
             },
@@ -3197,9 +2718,9 @@
             }
         },
         "node_modules/@nordicsemiconductor/pc-nrfconnect-shared": {
-            "version": "191.0.0",
-            "resolved": "https://registry.npmjs.org/@nordicsemiconductor/pc-nrfconnect-shared/-/pc-nrfconnect-shared-191.0.0.tgz",
-            "integrity": "sha512-2jwPvVnUy00pStDM/lpbX47w8bSQYky3pEjVIwu3Tx8ejohIMOCBJqx/XMqtgOhpx8ATyyRTGsNXvLfUTxa9wg==",
+            "version": "195.0.0",
+            "resolved": "https://registry.npmjs.org/@nordicsemiconductor/pc-nrfconnect-shared/-/pc-nrfconnect-shared-195.0.0.tgz",
+            "integrity": "sha512-uuXs+hsIWrIlPEGl6xxuC1zKClA6meV07Vh0EgiOwDwkYTAEi522rQ+JDwgwmu8lZSLcTo1SYwOii3KtcoEFcQ==",
             "dev": true,
             "hasInstallScript": true,
             "license": "ISC",
@@ -3212,8 +2733,8 @@
                 "@reduxjs/toolkit": "1.9.3",
                 "@svgr/core": "^7.0.0",
                 "@svgr/plugin-jsx": "7.0.0",
-                "@swc/core": "1.3.56",
-                "@swc/jest": "0.2.24",
+                "@swc/core": "1.10.0",
+                "@swc/jest": "0.2.37",
                 "@testing-library/jest-dom": "5.16.5",
                 "@testing-library/react": "^14.0.0",
                 "@types/adm-zip": "^0.5.0",
@@ -4314,11 +3835,16 @@
             }
         },
         "node_modules/@swc/core": {
-            "version": "1.3.56",
-            "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.56.tgz",
-            "integrity": "sha512-yz/EeXT+PMZucUNrYceRUaTfuNS4IIu5EDZSOlvCEvm4jAmZi7CYH1B/kvzEzoAOzr7zkQiDPNJftcQXLkjbjA==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.10.0.tgz",
+            "integrity": "sha512-+CuuTCmQFfzaNGg1JmcZvdUVITQXJk9sMnl1C2TiDLzOSVOJRwVD4dNo5dljX/qxpMAN+2BIYlwjlSkoGi6grg==",
             "dev": true,
             "hasInstallScript": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@swc/counter": "^0.1.3",
+                "@swc/types": "^0.1.17"
+            },
             "engines": {
                 "node": ">=10"
             },
@@ -4327,19 +3853,19 @@
                 "url": "https://opencollective.com/swc"
             },
             "optionalDependencies": {
-                "@swc/core-darwin-arm64": "1.3.56",
-                "@swc/core-darwin-x64": "1.3.56",
-                "@swc/core-linux-arm-gnueabihf": "1.3.56",
-                "@swc/core-linux-arm64-gnu": "1.3.56",
-                "@swc/core-linux-arm64-musl": "1.3.56",
-                "@swc/core-linux-x64-gnu": "1.3.56",
-                "@swc/core-linux-x64-musl": "1.3.56",
-                "@swc/core-win32-arm64-msvc": "1.3.56",
-                "@swc/core-win32-ia32-msvc": "1.3.56",
-                "@swc/core-win32-x64-msvc": "1.3.56"
+                "@swc/core-darwin-arm64": "1.10.0",
+                "@swc/core-darwin-x64": "1.10.0",
+                "@swc/core-linux-arm-gnueabihf": "1.10.0",
+                "@swc/core-linux-arm64-gnu": "1.10.0",
+                "@swc/core-linux-arm64-musl": "1.10.0",
+                "@swc/core-linux-x64-gnu": "1.10.0",
+                "@swc/core-linux-x64-musl": "1.10.0",
+                "@swc/core-win32-arm64-msvc": "1.10.0",
+                "@swc/core-win32-ia32-msvc": "1.10.0",
+                "@swc/core-win32-x64-msvc": "1.10.0"
             },
             "peerDependencies": {
-                "@swc/helpers": "^0.5.0"
+                "@swc/helpers": "*"
             },
             "peerDependenciesMeta": {
                 "@swc/helpers": {
@@ -4348,13 +3874,14 @@
             }
         },
         "node_modules/@swc/core-darwin-arm64": {
-            "version": "1.3.56",
-            "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.3.56.tgz",
-            "integrity": "sha512-DZcu7BzDaLEdWHabz9DRTP0yEBLqkrWmskFcD5BX0lGAvoIvE4duMnAqi5F2B3X7630QioHRCYFoRw2WkeE3Cw==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.10.0.tgz",
+            "integrity": "sha512-wCeUpanqZyzvgqWRtXIyhcFK3CqukAlYyP+fJpY2gWc/+ekdrenNIfZMwY7tyTFDkXDYEKzvn3BN/zDYNJFowQ==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "darwin"
@@ -4364,13 +3891,14 @@
             }
         },
         "node_modules/@swc/core-darwin-x64": {
-            "version": "1.3.56",
-            "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.3.56.tgz",
-            "integrity": "sha512-VH5saqYFasdRXJy6RAT+MXm0+IjkMZvOkohJwUei+oA65cKJofQwrJ1jZro8yOJFYvUSI3jgNRGsdBkmo/4hMw==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.10.0.tgz",
+            "integrity": "sha512-0CZPzqTynUBO+SHEl/qKsFSahp2Jv/P2ZRjFG0gwZY5qIcr1+B/v+o74/GyNMBGz9rft+F2WpU31gz2sJwyF4A==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "darwin"
@@ -4380,13 +3908,14 @@
             }
         },
         "node_modules/@swc/core-linux-arm-gnueabihf": {
-            "version": "1.3.56",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.3.56.tgz",
-            "integrity": "sha512-LWwPo6NnJkH01+ukqvkoNIOpMdw+Zundm4vBeicwyVrkP+mC3kwVfi03TUFpQUz3kRKdw/QEnxGTj+MouCPbtw==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.10.0.tgz",
+            "integrity": "sha512-oq+DdMu5uJOFPtRkeiITc4kxmd+QSmK+v+OBzlhdGkSgoH3yRWZP+H2ao0cBXo93ZgCr2LfjiER0CqSKhjGuNA==",
             "cpu": [
                 "arm"
             ],
             "dev": true,
+            "license": "Apache-2.0",
             "optional": true,
             "os": [
                 "linux"
@@ -4396,13 +3925,14 @@
             }
         },
         "node_modules/@swc/core-linux-arm64-gnu": {
-            "version": "1.3.56",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.3.56.tgz",
-            "integrity": "sha512-GzsUy/4egJ4cMlxbM+Ub7AMi5CKAc+pxBxrh8MUPQbyStW8jGgnQsJouTnGy0LHawtdEnsCOl6PcO6OgvktXuQ==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.10.0.tgz",
+            "integrity": "sha512-Y6+PC8knchEViRxiCUj3j8wsGXaIhuvU+WqrFqV834eiItEMEI9+Vh3FovqJMBE3L7d4E4ZQtgImHCXjrHfxbw==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -4412,13 +3942,14 @@
             }
         },
         "node_modules/@swc/core-linux-arm64-musl": {
-            "version": "1.3.56",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.3.56.tgz",
-            "integrity": "sha512-9gxL09BIiAv8zY0DjfnFf19bo8+P4T9tdhzPwcm+1yPJcY5yr1+YFWLNFzz01agtOj6VlZ2/wUJTaOfdjjtc+A==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.10.0.tgz",
+            "integrity": "sha512-EbrX9A5U4cECCQQfky7945AW9GYnTXtCUXElWTkTYmmyQK87yCyFfY8hmZ9qMFIwxPOH6I3I2JwMhzdi8Qoz7g==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -4428,13 +3959,14 @@
             }
         },
         "node_modules/@swc/core-linux-x64-gnu": {
-            "version": "1.3.56",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.3.56.tgz",
-            "integrity": "sha512-n0ORNknl50vMRkll3BDO1E4WOqY6iISlPV1ZQCRLWQ6YQ2q8/WAryBxc2OAybcGHBUFkxyACpJukeU1QZ/9tNw==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.10.0.tgz",
+            "integrity": "sha512-TaxpO6snTjjfLXFYh5EjZ78se69j2gDcqEM8yB9gguPYwkCHi2Ylfmh7iVaNADnDJFtjoAQp0L41bTV/Pfq9Cg==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -4444,13 +3976,14 @@
             }
         },
         "node_modules/@swc/core-linux-x64-musl": {
-            "version": "1.3.56",
-            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.3.56.tgz",
-            "integrity": "sha512-r+D34WLAOAlJtfw1gaVWpHRwCncU9nzW9i7w9kSw4HpWYnHJOz54jLGSEmNsrhdTCz1VK2ar+V2ktFUsrlGlDA==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.10.0.tgz",
+            "integrity": "sha512-IEGvDd6aEEKEyZFZ8oCKuik05G5BS7qwG5hO5PEMzdGeh8JyFZXxsfFXbfeAqjue4UaUUrhnoX+Ze3M2jBVMHw==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "linux"
@@ -4460,13 +3993,14 @@
             }
         },
         "node_modules/@swc/core-win32-arm64-msvc": {
-            "version": "1.3.56",
-            "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.3.56.tgz",
-            "integrity": "sha512-29Yt75Is6X24z3x8h/xZC1HnDPkPpyLH9mDQiM6Cuc0I9mVr1XSriPEUB2N/awf5IE4SA8c+3IVq1DtKWbkJIw==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.10.0.tgz",
+            "integrity": "sha512-UkQ952GSpY+Z6XONj9GSW8xGSkF53jrCsuLj0nrcuw7Dvr1a816U/9WYZmmcYS8tnG2vHylhpm6csQkyS8lpCw==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "win32"
@@ -4476,13 +4010,14 @@
             }
         },
         "node_modules/@swc/core-win32-ia32-msvc": {
-            "version": "1.3.56",
-            "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.3.56.tgz",
-            "integrity": "sha512-mplp0zbYDrcHtfvkniXlXdB04e2qIjz2Gq/XHKr4Rnc6xVORJjjXF91IemXKpavx2oZYJws+LNJL7UFQ8jyCdQ==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.10.0.tgz",
+            "integrity": "sha512-a2QpIZmTiT885u/mUInpeN2W9ClCnqrV2LnMqJR1/Fgx1Afw/hAtiDZPtQ0SqS8yDJ2VR5gfNZo3gpxWMrqdVA==",
             "cpu": [
                 "ia32"
             ],
             "dev": true,
+            "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "win32"
@@ -4492,13 +4027,14 @@
             }
         },
         "node_modules/@swc/core-win32-x64-msvc": {
-            "version": "1.3.56",
-            "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.3.56.tgz",
-            "integrity": "sha512-zp8MBnrw/bjdLenO/ifYzHrImSjKunqL0C2IF4LXYNRfcbYFh2NwobsVQMZ20IT0474lKRdlP8Oxdt+bHuXrzA==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.10.0.tgz",
+            "integrity": "sha512-tZcCmMwf483nwsEBfUk5w9e046kMa1iSik4bP9Kwi2FGtOfHuDfIcwW4jek3hdcgF5SaBW1ktnK/lgQLDi5AtA==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "license": "Apache-2.0 AND MIT",
             "optional": true,
             "os": [
                 "win32"
@@ -4507,13 +4043,22 @@
                 "node": ">=10"
             }
         },
-        "node_modules/@swc/jest": {
-            "version": "0.2.24",
-            "resolved": "https://registry.npmjs.org/@swc/jest/-/jest-0.2.24.tgz",
-            "integrity": "sha512-fwgxQbM1wXzyKzl1+IW0aGrRvAA8k0Y3NxFhKigbPjOJ4mCKnWEcNX9HQS3gshflcxq8YKhadabGUVfdwjCr6Q==",
+        "node_modules/@swc/counter": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+            "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
             "dev": true,
+            "license": "Apache-2.0"
+        },
+        "node_modules/@swc/jest": {
+            "version": "0.2.37",
+            "resolved": "https://registry.npmjs.org/@swc/jest/-/jest-0.2.37.tgz",
+            "integrity": "sha512-CR2BHhmXKGxTiFr21DYPRHQunLkX3mNIFGFkxBGji6r9uyIR5zftTOVYj1e0sFNMV2H7mf/+vpaglqaryBtqfQ==",
+            "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@jest/create-cache-key-function": "^27.4.2",
+                "@jest/create-cache-key-function": "^29.7.0",
+                "@swc/counter": "^0.1.3",
                 "jsonc-parser": "^3.2.0"
             },
             "engines": {
@@ -4521,6 +4066,16 @@
             },
             "peerDependencies": {
                 "@swc/core": "*"
+            }
+        },
+        "node_modules/@swc/types": {
+            "version": "0.1.17",
+            "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.17.tgz",
+            "integrity": "sha512-V5gRru+aD8YVyCOMAjMpWR1Ui577DD5KSJsHP8RAxopAH22jFz6GZd/qxqjO6MJHQhcsjvjOFXyDhyLQUnMveQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@swc/counter": "^0.1.3"
             }
         },
         "node_modules/@szmarczak/http-timer": {
@@ -5306,19 +4861,21 @@
             "dev": true
         },
         "node_modules/@types/yargs": {
-            "version": "16.0.6",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-16.0.6.tgz",
-            "integrity": "sha512-oTP7/Q13GSPrgcwEwdlnkoZSQ1Hg9THe644qq8PG6hhJzjZ3qj1JjEFPIwWV/IXVs5XGIVqtkNOS9kh63WIJ+A==",
+            "version": "17.0.33",
+            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.33.tgz",
+            "integrity": "sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@types/yargs-parser": "*"
             }
         },
         "node_modules/@types/yargs-parser": {
-            "version": "21.0.1",
-            "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.1.tgz",
-            "integrity": "sha512-axdPBuLuEJt0c4yI5OZssC19K2Mq1uKdrfZBzuxLvaztgqUtFYZUNw7lETExPYJR9jdEoIg4mb7RQKRQzOkeGQ==",
-            "dev": true
+            "version": "21.0.3",
+            "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
+            "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/yauzl": {
             "version": "2.10.1",
@@ -7536,32 +7093,6 @@
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/create-jest/node_modules/@jest/types": {
-            "version": "29.6.3",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-            "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-            "dev": true,
-            "dependencies": {
-                "@jest/schemas": "^29.6.3",
-                "@types/istanbul-lib-coverage": "^2.0.0",
-                "@types/istanbul-reports": "^3.0.0",
-                "@types/node": "*",
-                "@types/yargs": "^17.0.8",
-                "chalk": "^4.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/create-jest/node_modules/@types/yargs": {
-            "version": "17.0.28",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.28.tgz",
-            "integrity": "sha512-N3e3fkS86hNhtk6BEnc0rj3zcehaxx8QWhCROJkqpl5Zaoi7nAic3jH8q94jVD3zu5LGk+PUB6KAiDmimYOEQw==",
-            "dev": true,
-            "dependencies": {
-                "@types/yargs-parser": "*"
             }
         },
         "node_modules/create-jest/node_modules/ansi-styles": {
@@ -12158,32 +11689,6 @@
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
-        "node_modules/jest-circus/node_modules/@jest/types": {
-            "version": "29.6.3",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-            "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-            "dev": true,
-            "dependencies": {
-                "@jest/schemas": "^29.6.3",
-                "@types/istanbul-lib-coverage": "^2.0.0",
-                "@types/istanbul-reports": "^3.0.0",
-                "@types/node": "*",
-                "@types/yargs": "^17.0.8",
-                "chalk": "^4.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-circus/node_modules/@types/yargs": {
-            "version": "17.0.28",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.28.tgz",
-            "integrity": "sha512-N3e3fkS86hNhtk6BEnc0rj3zcehaxx8QWhCROJkqpl5Zaoi7nAic3jH8q94jVD3zu5LGk+PUB6KAiDmimYOEQw==",
-            "dev": true,
-            "dependencies": {
-                "@types/yargs-parser": "*"
-            }
-        },
         "node_modules/jest-circus/node_modules/ansi-styles": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -12317,32 +11822,6 @@
                 "node-notifier": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/jest-cli/node_modules/@jest/types": {
-            "version": "29.6.3",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-            "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-            "dev": true,
-            "dependencies": {
-                "@jest/schemas": "^29.6.3",
-                "@types/istanbul-lib-coverage": "^2.0.0",
-                "@types/istanbul-reports": "^3.0.0",
-                "@types/node": "*",
-                "@types/yargs": "^17.0.8",
-                "chalk": "^4.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-cli/node_modules/@types/yargs": {
-            "version": "17.0.28",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.28.tgz",
-            "integrity": "sha512-N3e3fkS86hNhtk6BEnc0rj3zcehaxx8QWhCROJkqpl5Zaoi7nAic3jH8q94jVD3zu5LGk+PUB6KAiDmimYOEQw==",
-            "dev": true,
-            "dependencies": {
-                "@types/yargs-parser": "*"
             }
         },
         "node_modules/jest-cli/node_modules/ansi-styles": {
@@ -12499,32 +11978,6 @@
                 "ts-node": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/jest-config/node_modules/@jest/types": {
-            "version": "29.6.3",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-            "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-            "dev": true,
-            "dependencies": {
-                "@jest/schemas": "^29.6.3",
-                "@types/istanbul-lib-coverage": "^2.0.0",
-                "@types/istanbul-reports": "^3.0.0",
-                "@types/node": "*",
-                "@types/yargs": "^17.0.8",
-                "chalk": "^4.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-config/node_modules/@types/yargs": {
-            "version": "17.0.28",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.28.tgz",
-            "integrity": "sha512-N3e3fkS86hNhtk6BEnc0rj3zcehaxx8QWhCROJkqpl5Zaoi7nAic3jH8q94jVD3zu5LGk+PUB6KAiDmimYOEQw==",
-            "dev": true,
-            "dependencies": {
-                "@types/yargs-parser": "*"
             }
         },
         "node_modules/jest-config/node_modules/ansi-styles": {
@@ -12774,32 +12227,6 @@
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
-        "node_modules/jest-each/node_modules/@jest/types": {
-            "version": "29.6.3",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-            "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-            "dev": true,
-            "dependencies": {
-                "@jest/schemas": "^29.6.3",
-                "@types/istanbul-lib-coverage": "^2.0.0",
-                "@types/istanbul-reports": "^3.0.0",
-                "@types/node": "*",
-                "@types/yargs": "^17.0.8",
-                "chalk": "^4.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-each/node_modules/@types/yargs": {
-            "version": "17.0.28",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.28.tgz",
-            "integrity": "sha512-N3e3fkS86hNhtk6BEnc0rj3zcehaxx8QWhCROJkqpl5Zaoi7nAic3jH8q94jVD3zu5LGk+PUB6KAiDmimYOEQw==",
-            "dev": true,
-            "dependencies": {
-                "@types/yargs-parser": "*"
-            }
-        },
         "node_modules/jest-each/node_modules/ansi-styles": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -12929,102 +12356,6 @@
                 }
             }
         },
-        "node_modules/jest-environment-jsdom/node_modules/@jest/types": {
-            "version": "29.6.3",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-            "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-            "dev": true,
-            "dependencies": {
-                "@jest/schemas": "^29.6.3",
-                "@types/istanbul-lib-coverage": "^2.0.0",
-                "@types/istanbul-reports": "^3.0.0",
-                "@types/node": "*",
-                "@types/yargs": "^17.0.8",
-                "chalk": "^4.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-environment-jsdom/node_modules/@types/yargs": {
-            "version": "17.0.28",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.28.tgz",
-            "integrity": "sha512-N3e3fkS86hNhtk6BEnc0rj3zcehaxx8QWhCROJkqpl5Zaoi7nAic3jH8q94jVD3zu5LGk+PUB6KAiDmimYOEQw==",
-            "dev": true,
-            "dependencies": {
-                "@types/yargs-parser": "*"
-            }
-        },
-        "node_modules/jest-environment-jsdom/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/jest-environment-jsdom/node_modules/chalk": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "dev": true,
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "node_modules/jest-environment-jsdom/node_modules/color-convert": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
-            "dependencies": {
-                "color-name": "~1.1.4"
-            },
-            "engines": {
-                "node": ">=7.0.0"
-            }
-        },
-        "node_modules/jest-environment-jsdom/node_modules/color-name": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true
-        },
-        "node_modules/jest-environment-jsdom/node_modules/has-flag": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/jest-environment-jsdom/node_modules/supports-color": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dev": true,
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/jest-environment-node": {
             "version": "29.7.0",
             "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
@@ -13040,102 +12371,6 @@
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-environment-node/node_modules/@jest/types": {
-            "version": "29.6.3",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-            "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-            "dev": true,
-            "dependencies": {
-                "@jest/schemas": "^29.6.3",
-                "@types/istanbul-lib-coverage": "^2.0.0",
-                "@types/istanbul-reports": "^3.0.0",
-                "@types/node": "*",
-                "@types/yargs": "^17.0.8",
-                "chalk": "^4.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-environment-node/node_modules/@types/yargs": {
-            "version": "17.0.28",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.28.tgz",
-            "integrity": "sha512-N3e3fkS86hNhtk6BEnc0rj3zcehaxx8QWhCROJkqpl5Zaoi7nAic3jH8q94jVD3zu5LGk+PUB6KAiDmimYOEQw==",
-            "dev": true,
-            "dependencies": {
-                "@types/yargs-parser": "*"
-            }
-        },
-        "node_modules/jest-environment-node/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/jest-environment-node/node_modules/chalk": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "dev": true,
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "node_modules/jest-environment-node/node_modules/color-convert": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
-            "dependencies": {
-                "color-name": "~1.1.4"
-            },
-            "engines": {
-                "node": ">=7.0.0"
-            }
-        },
-        "node_modules/jest-environment-node/node_modules/color-name": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true
-        },
-        "node_modules/jest-environment-node/node_modules/has-flag": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/jest-environment-node/node_modules/supports-color": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dev": true,
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/jest-get-type": {
@@ -13170,102 +12405,6 @@
             },
             "optionalDependencies": {
                 "fsevents": "^2.3.2"
-            }
-        },
-        "node_modules/jest-haste-map/node_modules/@jest/types": {
-            "version": "29.6.3",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-            "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-            "dev": true,
-            "dependencies": {
-                "@jest/schemas": "^29.6.3",
-                "@types/istanbul-lib-coverage": "^2.0.0",
-                "@types/istanbul-reports": "^3.0.0",
-                "@types/node": "*",
-                "@types/yargs": "^17.0.8",
-                "chalk": "^4.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-haste-map/node_modules/@types/yargs": {
-            "version": "17.0.28",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.28.tgz",
-            "integrity": "sha512-N3e3fkS86hNhtk6BEnc0rj3zcehaxx8QWhCROJkqpl5Zaoi7nAic3jH8q94jVD3zu5LGk+PUB6KAiDmimYOEQw==",
-            "dev": true,
-            "dependencies": {
-                "@types/yargs-parser": "*"
-            }
-        },
-        "node_modules/jest-haste-map/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/jest-haste-map/node_modules/chalk": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "dev": true,
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "node_modules/jest-haste-map/node_modules/color-convert": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
-            "dependencies": {
-                "color-name": "~1.1.4"
-            },
-            "engines": {
-                "node": ">=7.0.0"
-            }
-        },
-        "node_modules/jest-haste-map/node_modules/color-name": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true
-        },
-        "node_modules/jest-haste-map/node_modules/has-flag": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/jest-haste-map/node_modules/supports-color": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dev": true,
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/jest-leak-detector": {
@@ -13450,32 +12589,6 @@
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
-        "node_modules/jest-message-util/node_modules/@jest/types": {
-            "version": "29.6.3",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-            "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-            "dev": true,
-            "dependencies": {
-                "@jest/schemas": "^29.6.3",
-                "@types/istanbul-lib-coverage": "^2.0.0",
-                "@types/istanbul-reports": "^3.0.0",
-                "@types/node": "*",
-                "@types/yargs": "^17.0.8",
-                "chalk": "^4.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-message-util/node_modules/@types/yargs": {
-            "version": "17.0.28",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.28.tgz",
-            "integrity": "sha512-N3e3fkS86hNhtk6BEnc0rj3zcehaxx8QWhCROJkqpl5Zaoi7nAic3jH8q94jVD3zu5LGk+PUB6KAiDmimYOEQw==",
-            "dev": true,
-            "dependencies": {
-                "@types/yargs-parser": "*"
-            }
-        },
         "node_modules/jest-message-util/node_modules/ansi-styles": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -13590,102 +12703,6 @@
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-mock/node_modules/@jest/types": {
-            "version": "29.6.3",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-            "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-            "dev": true,
-            "dependencies": {
-                "@jest/schemas": "^29.6.3",
-                "@types/istanbul-lib-coverage": "^2.0.0",
-                "@types/istanbul-reports": "^3.0.0",
-                "@types/node": "*",
-                "@types/yargs": "^17.0.8",
-                "chalk": "^4.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-mock/node_modules/@types/yargs": {
-            "version": "17.0.28",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.28.tgz",
-            "integrity": "sha512-N3e3fkS86hNhtk6BEnc0rj3zcehaxx8QWhCROJkqpl5Zaoi7nAic3jH8q94jVD3zu5LGk+PUB6KAiDmimYOEQw==",
-            "dev": true,
-            "dependencies": {
-                "@types/yargs-parser": "*"
-            }
-        },
-        "node_modules/jest-mock/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/jest-mock/node_modules/chalk": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "dev": true,
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "node_modules/jest-mock/node_modules/color-convert": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
-            "dependencies": {
-                "color-name": "~1.1.4"
-            },
-            "engines": {
-                "node": ">=7.0.0"
-            }
-        },
-        "node_modules/jest-mock/node_modules/color-name": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true
-        },
-        "node_modules/jest-mock/node_modules/has-flag": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/jest-mock/node_modules/supports-color": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dev": true,
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/jest-pnp-resolver": {
@@ -13849,32 +12866,6 @@
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
-        "node_modules/jest-runner/node_modules/@jest/types": {
-            "version": "29.6.3",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-            "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-            "dev": true,
-            "dependencies": {
-                "@jest/schemas": "^29.6.3",
-                "@types/istanbul-lib-coverage": "^2.0.0",
-                "@types/istanbul-reports": "^3.0.0",
-                "@types/node": "*",
-                "@types/yargs": "^17.0.8",
-                "chalk": "^4.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-runner/node_modules/@types/yargs": {
-            "version": "17.0.28",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.28.tgz",
-            "integrity": "sha512-N3e3fkS86hNhtk6BEnc0rj3zcehaxx8QWhCROJkqpl5Zaoi7nAic3jH8q94jVD3zu5LGk+PUB6KAiDmimYOEQw==",
-            "dev": true,
-            "dependencies": {
-                "@types/yargs-parser": "*"
-            }
-        },
         "node_modules/jest-runner/node_modules/ansi-styles": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -13994,32 +12985,6 @@
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
-        "node_modules/jest-runtime/node_modules/@jest/types": {
-            "version": "29.6.3",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-            "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-            "dev": true,
-            "dependencies": {
-                "@jest/schemas": "^29.6.3",
-                "@types/istanbul-lib-coverage": "^2.0.0",
-                "@types/istanbul-reports": "^3.0.0",
-                "@types/node": "*",
-                "@types/yargs": "^17.0.8",
-                "chalk": "^4.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-runtime/node_modules/@types/yargs": {
-            "version": "17.0.28",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.28.tgz",
-            "integrity": "sha512-N3e3fkS86hNhtk6BEnc0rj3zcehaxx8QWhCROJkqpl5Zaoi7nAic3jH8q94jVD3zu5LGk+PUB6KAiDmimYOEQw==",
-            "dev": true,
-            "dependencies": {
-                "@types/yargs-parser": "*"
-            }
-        },
         "node_modules/jest-runtime/node_modules/ansi-styles": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -14119,32 +13084,6 @@
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-snapshot/node_modules/@jest/types": {
-            "version": "29.6.3",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-            "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-            "dev": true,
-            "dependencies": {
-                "@jest/schemas": "^29.6.3",
-                "@types/istanbul-lib-coverage": "^2.0.0",
-                "@types/istanbul-reports": "^3.0.0",
-                "@types/node": "*",
-                "@types/yargs": "^17.0.8",
-                "chalk": "^4.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-snapshot/node_modules/@types/yargs": {
-            "version": "17.0.28",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.28.tgz",
-            "integrity": "sha512-N3e3fkS86hNhtk6BEnc0rj3zcehaxx8QWhCROJkqpl5Zaoi7nAic3jH8q94jVD3zu5LGk+PUB6KAiDmimYOEQw==",
-            "dev": true,
-            "dependencies": {
-                "@types/yargs-parser": "*"
             }
         },
         "node_modules/jest-snapshot/node_modules/ansi-styles": {
@@ -14299,32 +13238,6 @@
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
-        "node_modules/jest-util/node_modules/@jest/types": {
-            "version": "29.6.3",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-            "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-            "dev": true,
-            "dependencies": {
-                "@jest/schemas": "^29.6.3",
-                "@types/istanbul-lib-coverage": "^2.0.0",
-                "@types/istanbul-reports": "^3.0.0",
-                "@types/node": "*",
-                "@types/yargs": "^17.0.8",
-                "chalk": "^4.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-util/node_modules/@types/yargs": {
-            "version": "17.0.28",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.28.tgz",
-            "integrity": "sha512-N3e3fkS86hNhtk6BEnc0rj3zcehaxx8QWhCROJkqpl5Zaoi7nAic3jH8q94jVD3zu5LGk+PUB6KAiDmimYOEQw==",
-            "dev": true,
-            "dependencies": {
-                "@types/yargs-parser": "*"
-            }
-        },
         "node_modules/jest-util/node_modules/ansi-styles": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -14410,32 +13323,6 @@
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-validate/node_modules/@jest/types": {
-            "version": "29.6.3",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-            "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-            "dev": true,
-            "dependencies": {
-                "@jest/schemas": "^29.6.3",
-                "@types/istanbul-lib-coverage": "^2.0.0",
-                "@types/istanbul-reports": "^3.0.0",
-                "@types/node": "*",
-                "@types/yargs": "^17.0.8",
-                "chalk": "^4.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-validate/node_modules/@types/yargs": {
-            "version": "17.0.28",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.28.tgz",
-            "integrity": "sha512-N3e3fkS86hNhtk6BEnc0rj3zcehaxx8QWhCROJkqpl5Zaoi7nAic3jH8q94jVD3zu5LGk+PUB6KAiDmimYOEQw==",
-            "dev": true,
-            "dependencies": {
-                "@types/yargs-parser": "*"
             }
         },
         "node_modules/jest-validate/node_modules/ansi-styles": {
@@ -14559,32 +13446,6 @@
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
-        "node_modules/jest-watcher/node_modules/@jest/types": {
-            "version": "29.6.3",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-            "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-            "dev": true,
-            "dependencies": {
-                "@jest/schemas": "^29.6.3",
-                "@types/istanbul-lib-coverage": "^2.0.0",
-                "@types/istanbul-reports": "^3.0.0",
-                "@types/node": "*",
-                "@types/yargs": "^17.0.8",
-                "chalk": "^4.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-watcher/node_modules/@types/yargs": {
-            "version": "17.0.28",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.28.tgz",
-            "integrity": "sha512-N3e3fkS86hNhtk6BEnc0rj3zcehaxx8QWhCROJkqpl5Zaoi7nAic3jH8q94jVD3zu5LGk+PUB6KAiDmimYOEQw==",
-            "dev": true,
-            "dependencies": {
-                "@types/yargs-parser": "*"
-            }
-        },
         "node_modules/jest-watcher/node_modules/ansi-styles": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -14692,102 +13553,6 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/supports-color?sponsor=1"
-            }
-        },
-        "node_modules/jest/node_modules/@jest/types": {
-            "version": "29.6.3",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-            "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
-            "dev": true,
-            "dependencies": {
-                "@jest/schemas": "^29.6.3",
-                "@types/istanbul-lib-coverage": "^2.0.0",
-                "@types/istanbul-reports": "^3.0.0",
-                "@types/node": "*",
-                "@types/yargs": "^17.0.8",
-                "chalk": "^4.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest/node_modules/@types/yargs": {
-            "version": "17.0.28",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.28.tgz",
-            "integrity": "sha512-N3e3fkS86hNhtk6BEnc0rj3zcehaxx8QWhCROJkqpl5Zaoi7nAic3jH8q94jVD3zu5LGk+PUB6KAiDmimYOEQw==",
-            "dev": true,
-            "dependencies": {
-                "@types/yargs-parser": "*"
-            }
-        },
-        "node_modules/jest/node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-            "dev": true,
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/jest/node_modules/chalk": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "dev": true,
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "node_modules/jest/node_modules/color-convert": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-            "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-            "dev": true,
-            "dependencies": {
-                "color-name": "~1.1.4"
-            },
-            "engines": {
-                "node": ">=7.0.0"
-            }
-        },
-        "node_modules/jest/node_modules/color-name": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-            "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true
-        },
-        "node_modules/jest/node_modules/has-flag": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-            "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/jest/node_modules/supports-color": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-            "dev": true,
-            "dependencies": {
-                "has-flag": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/jiti": {
@@ -14946,10 +13711,11 @@
             }
         },
         "node_modules/jsonc-parser": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
-            "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
-            "dev": true
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+            "integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/jsonfile": {
             "version": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     },
     "devDependencies": {
         "@electron/notarize": "^2.2.0",
-        "@nordicsemiconductor/pc-nrfconnect-shared": "^191.0.0",
+        "@nordicsemiconductor/pc-nrfconnect-shared": "^195.0.0",
         "@playwright/test": "^1.16.3",
         "@testing-library/user-event": "^14.4.3",
         "@types/chmodr": "1.0.0",

--- a/src/launcher/features/settings/Settings.tsx
+++ b/src/launcher/features/settings/Settings.tsx
@@ -143,12 +143,7 @@ const Sources = () => {
                                     variant="outline-secondary"
                                     size="sm"
                                     onClick={() =>
-                                        clipboard.writeText(
-                                            source.url.replace(
-                                                /source\.json$/,
-                                                'apps.json'
-                                            )
-                                        )
+                                        clipboard.writeText(source.url)
                                     }
                                     title="Copy URL to clipboard"
                                 >

--- a/src/main/apps/apps.ts
+++ b/src/main/apps/apps.ts
@@ -33,7 +33,7 @@ import {
     writeAppInfo,
 } from './app';
 import { downloadAppResources } from './appResource';
-import { maybeMigrateLegacyMetaFiles } from './legacyMetaFiles';
+import { maybeMigrateLegacyMetaFiles } from './dataMigration/legacyMetaFiles';
 import {
     downloadAllSources,
     getAllAppUrls,

--- a/src/main/apps/dataMigration/legacyMetaFiles.test.ts
+++ b/src/main/apps/dataMigration/legacyMetaFiles.test.ts
@@ -12,7 +12,7 @@ import {
     createNewAppInfo,
 } from './legacyMetaFiles';
 
-jest.mock('../config', () => {
+jest.mock('../../config', () => {
     const { join } = jest.requireActual('path');
     const { homedir } = jest.requireActual('os');
     return {

--- a/src/main/apps/dataMigration/legacyMetaFiles.ts
+++ b/src/main/apps/dataMigration/legacyMetaFiles.ts
@@ -11,15 +11,15 @@ import {
 import fs from 'fs-extra';
 import path from 'path';
 
-import { Source } from '../../ipc/sources';
-import { getAppsRootDir, getNodeModulesDir } from '../config';
-import { readFile, readJsonFile } from '../fileUtil';
-import { installedAppPath, writeAppInfo } from './app';
+import { Source } from '../../../ipc/sources';
+import { getAppsRootDir, getNodeModulesDir } from '../../config';
+import { readFile, readJsonFile } from '../../fileUtil';
+import { installedAppPath, writeAppInfo } from '../app';
 import {
     sourceJsonExistsLocally,
     writeSourceJson,
     writeWithdrawnJson,
-} from './sources';
+} from '../sources';
 
 type AppName = `pc-nrfconnect-${string}`;
 
@@ -96,7 +96,7 @@ export const createNewAppInfo = (
     };
 };
 
-export const createNewAppInfoForWithdrawnApp = (
+const createNewAppInfoForWithdrawnApp = (
     source: Source,
     appName: AppName,
     packageJson: PackageJsonLegacyApp,

--- a/src/main/apps/dataMigration/migrateSourcesJson.test.ts
+++ b/src/main/apps/dataMigration/migrateSourcesJson.test.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2023 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import { existsSync } from 'fs';
+
+import { readSchemedJsonFile, writeSchemedJsonFile } from '../../fileUtil';
+import { migrateSourcesJson, oldSourcesJsonPath } from './migrateSourcesJson';
+
+jest.mock('fs');
+jest.mock('../../fileUtil');
+
+describe('migrating sources.json', () => {
+    const mockedExistsSync = jest.mocked(existsSync);
+    const mockedReadSchemedJsonFile = jest.mocked(readSchemedJsonFile);
+    const mockedWriteSchemedJsonFile = jest.mocked(writeSchemedJsonFile);
+
+    beforeEach(() => {
+        jest.resetAllMocks();
+    });
+
+    it('should migrate sources.json to sources-versioned.json', () => {
+        const oldSourceJsonContent = {
+            source1: 'http://source1.com/apps.json',
+            source2: 'http://source2.com/source.json',
+        };
+        const newSourceVersionedJsonContent = {
+            v1: [
+                { name: 'source1', url: 'http://source1.com/source.json' },
+                { name: 'source2', url: 'http://source2.com/source.json' },
+            ],
+        };
+
+        // Arrange
+        mockedExistsSync.mockImplementation(
+            path => path === oldSourcesJsonPath()
+        );
+        mockedReadSchemedJsonFile.mockReturnValue(oldSourceJsonContent);
+
+        // Act
+        migrateSourcesJson();
+
+        // Assert
+        expect(mockedWriteSchemedJsonFile).toBeCalledWith(
+            expect.anything(),
+            expect.anything(),
+            newSourceVersionedJsonContent
+        );
+    });
+
+    it('should do nothing if sources.json does not exist', () => {
+        mockedExistsSync.mockReturnValue(false);
+
+        migrateSourcesJson();
+
+        expect(mockedReadSchemedJsonFile).not.toBeCalled();
+    });
+
+    it('should do nothing if sources-versioned.json already exists', () => {
+        mockedExistsSync.mockReturnValue(true);
+
+        migrateSourcesJson();
+
+        expect(mockedReadSchemedJsonFile).not.toBeCalled();
+    });
+});

--- a/src/main/apps/dataMigration/migrateSourcesJson.ts
+++ b/src/main/apps/dataMigration/migrateSourcesJson.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2015 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import fs from 'fs-extra';
+import path from 'path';
+import { z } from 'zod';
+
+import { getAppsExternalDir } from '../../config';
+import { readSchemedJsonFile } from '../../fileUtil';
+import { sourcesVersionedJsonPath, writeSourcesFile } from '../sources';
+
+export const oldSourcesJsonPath = () =>
+    path.join(getAppsExternalDir(), 'sources.json');
+
+const oldSourcesJsonSchema = z.record(z.string(), z.string().url());
+
+export const migrateSourcesJson = () => {
+    if (
+        !fs.existsSync(oldSourcesJsonPath()) ||
+        fs.existsSync(sourcesVersionedJsonPath())
+    ) {
+        return;
+    }
+
+    const oldSourcesJson = readSchemedJsonFile(
+        oldSourcesJsonPath(),
+        oldSourcesJsonSchema
+    );
+    const migratedSources = Object.entries(oldSourcesJson).map(
+        ([name, url]) => ({
+            name,
+            url: url.replace(/apps\.json$/, 'source.json'),
+        })
+    );
+
+    writeSourcesFile(migratedSources);
+};

--- a/src/main/apps/sourceChanges.ts
+++ b/src/main/apps/sourceChanges.ts
@@ -34,11 +34,6 @@ const downloadSource = async (
     const sourceJson = await downloadSourceJson(url);
     const source: Source = { name: sourceJson.name, url };
 
-    const isLegacyUrl = url.endsWith('/apps.json') && sourceJson.apps == null;
-    if (isLegacyUrl) {
-        return downloadSource(url.replace(/apps\.json$/, 'source.json'));
-    }
-
     return { source, sourceJson };
 };
 

--- a/src/main/apps/sources.test.ts
+++ b/src/main/apps/sources.test.ts
@@ -4,14 +4,7 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-import { existsSync } from 'fs';
-
-import { readSchemedJsonFile, writeSchemedJsonFile } from '../fileUtil';
-import {
-    migrateSourcesJson,
-    newWithdrawnJson,
-    oldSourcesJsonPath,
-} from './sources';
+import { newWithdrawnJson } from './sources';
 
 jest.mock('fs');
 jest.mock('../fileUtil');
@@ -44,59 +37,4 @@ test('computing the new list of withdrawn apps', () => {
         'http://example.org/oldWithdrawnApp.json',
         'http://example.org/newlyWithdrawnApp.json',
     ]);
-});
-
-describe('migrating sources.json', () => {
-    const mockedExistsSync = jest.mocked(existsSync);
-    const mockedReadSchemedJsonFile = jest.mocked(readSchemedJsonFile);
-    const mockedWriteSchemedJsonFile = jest.mocked(writeSchemedJsonFile);
-
-    beforeEach(() => {
-        jest.resetAllMocks();
-    });
-
-    it('should migrate sources.json to sources-versioned.json', () => {
-        const oldSourceJsonContent = {
-            source1: 'http://source1.com/apps.json',
-            source2: 'http://source2.com/source.json',
-        };
-        const newSourceVersionedJsonContent = {
-            v1: [
-                { name: 'source1', url: 'http://source1.com/source.json' },
-                { name: 'source2', url: 'http://source2.com/source.json' },
-            ],
-        };
-
-        // Arrange
-        mockedExistsSync.mockImplementation(
-            path => path === oldSourcesJsonPath()
-        );
-        mockedReadSchemedJsonFile.mockReturnValue(oldSourceJsonContent);
-
-        // Act
-        migrateSourcesJson();
-
-        // Assert
-        expect(mockedWriteSchemedJsonFile).toBeCalledWith(
-            expect.anything(),
-            expect.anything(),
-            newSourceVersionedJsonContent
-        );
-    });
-
-    it('should do nothing if sources.json does not exist', () => {
-        mockedExistsSync.mockReturnValue(false);
-
-        migrateSourcesJson();
-
-        expect(mockedReadSchemedJsonFile).not.toBeCalled();
-    });
-
-    it('should do nothing if sources-versioned.json already exists', () => {
-        mockedExistsSync.mockReturnValue(true);
-
-        migrateSourcesJson();
-
-        expect(mockedReadSchemedJsonFile).not.toBeCalled();
-    });
 });

--- a/src/main/apps/sources.test.ts
+++ b/src/main/apps/sources.test.ts
@@ -4,7 +4,17 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-import { newWithdrawnJson } from './sources';
+import { existsSync } from 'fs';
+
+import { readJsonFile, writeJsonFile } from '../fileUtil';
+import {
+    migrateSourcesJson,
+    newWithdrawnJson,
+    oldSourcesJsonPath,
+} from './sources';
+
+jest.mock('fs');
+jest.mock('../fileUtil');
 
 test('computing the new list of withdrawn apps', () => {
     const oldWithdrawnJson = [
@@ -34,4 +44,58 @@ test('computing the new list of withdrawn apps', () => {
         'http://example.org/oldWithdrawnApp.json',
         'http://example.org/newlyWithdrawnApp.json',
     ]);
+});
+
+describe('migrating sources.json', () => {
+    const mockedExistsSync = jest.mocked(existsSync);
+    const mockedReadJsonFile = jest.mocked(readJsonFile);
+    const mockedWriteJsonFile = jest.mocked(writeJsonFile);
+
+    beforeEach(() => {
+        jest.resetAllMocks();
+    });
+
+    it('should migrate sources.json to sources-versioned.json', () => {
+        const oldSourceJsonContent = {
+            source1: 'http://source1.com/apps.json',
+            source2: 'http://source2.com/source.json',
+        };
+        const newSourceVersionedJsonContent = {
+            v1: [
+                { name: 'source1', url: 'http://source1.com/source.json' },
+                { name: 'source2', url: 'http://source2.com/source.json' },
+            ],
+        };
+
+        // Arrange
+        mockedExistsSync.mockImplementation(
+            path => path === oldSourcesJsonPath()
+        );
+        mockedReadJsonFile.mockReturnValue(oldSourceJsonContent);
+
+        // Act
+        migrateSourcesJson();
+
+        // Assert
+        expect(mockedWriteJsonFile).toBeCalledWith(
+            expect.anything(),
+            newSourceVersionedJsonContent
+        );
+    });
+
+    it('should do nothing if sources.json does not exist', () => {
+        mockedExistsSync.mockReturnValue(false);
+
+        migrateSourcesJson();
+
+        expect(mockedReadJsonFile).not.toBeCalled();
+    });
+
+    it('should do nothing if sources-versioned.json already exists', () => {
+        mockedExistsSync.mockReturnValue(true);
+
+        migrateSourcesJson();
+
+        expect(mockedReadJsonFile).not.toBeCalled();
+    });
 });

--- a/src/main/apps/sources.test.ts
+++ b/src/main/apps/sources.test.ts
@@ -6,7 +6,7 @@
 
 import { existsSync } from 'fs';
 
-import { readJsonFile, writeJsonFile } from '../fileUtil';
+import { readSchemedJsonFile, writeSchemedJsonFile } from '../fileUtil';
 import {
     migrateSourcesJson,
     newWithdrawnJson,
@@ -48,8 +48,8 @@ test('computing the new list of withdrawn apps', () => {
 
 describe('migrating sources.json', () => {
     const mockedExistsSync = jest.mocked(existsSync);
-    const mockedReadJsonFile = jest.mocked(readJsonFile);
-    const mockedWriteJsonFile = jest.mocked(writeJsonFile);
+    const mockedReadSchemedJsonFile = jest.mocked(readSchemedJsonFile);
+    const mockedWriteSchemedJsonFile = jest.mocked(writeSchemedJsonFile);
 
     beforeEach(() => {
         jest.resetAllMocks();
@@ -71,13 +71,14 @@ describe('migrating sources.json', () => {
         mockedExistsSync.mockImplementation(
             path => path === oldSourcesJsonPath()
         );
-        mockedReadJsonFile.mockReturnValue(oldSourceJsonContent);
+        mockedReadSchemedJsonFile.mockReturnValue(oldSourceJsonContent);
 
         // Act
         migrateSourcesJson();
 
         // Assert
-        expect(mockedWriteJsonFile).toBeCalledWith(
+        expect(mockedWriteSchemedJsonFile).toBeCalledWith(
+            expect.anything(),
             expect.anything(),
             newSourceVersionedJsonContent
         );
@@ -88,7 +89,7 @@ describe('migrating sources.json', () => {
 
         migrateSourcesJson();
 
-        expect(mockedReadJsonFile).not.toBeCalled();
+        expect(mockedReadSchemedJsonFile).not.toBeCalled();
     });
 
     it('should do nothing if sources-versioned.json already exists', () => {
@@ -96,6 +97,6 @@ describe('migrating sources.json', () => {
 
         migrateSourcesJson();
 
-        expect(mockedReadJsonFile).not.toBeCalled();
+        expect(mockedReadSchemedJsonFile).not.toBeCalled();
     });
 });

--- a/src/main/apps/sources.ts
+++ b/src/main/apps/sources.ts
@@ -36,7 +36,7 @@ const officialSource = {
     url: 'https://developer.nordicsemi.com/.pc-tools/nrfconnect-apps/source.json',
 };
 
-const sourcesVersionedJsonPath = () =>
+export const sourcesVersionedJsonPath = () =>
     path.join(getAppsExternalDir(), 'sources-versioned.json');
 
 const sourcesVersionedSchema = z.object({
@@ -68,7 +68,7 @@ const loadAllSources = () => {
     }
 };
 
-const writeSourcesFile = (allSources: Source[]) => {
+export const writeSourcesFile = (allSources: Source[]) => {
     writeSchemedJsonFile(sourcesVersionedJsonPath(), sourcesVersionedSchema, {
         v1: allSources,
     });
@@ -274,33 +274,4 @@ export const ensureBundledSourceExists = () => {
             fs.copyFileSync(from, to);
         }
     });
-};
-
-// migration
-
-export const oldSourcesJsonPath = () =>
-    path.join(getAppsExternalDir(), 'sources.json');
-
-const oldSourcesJsonSchema = z.record(z.string(), z.string().url());
-
-export const migrateSourcesJson = () => {
-    if (
-        !fs.existsSync(oldSourcesJsonPath()) ||
-        fs.existsSync(sourcesVersionedJsonPath())
-    ) {
-        return;
-    }
-
-    const oldSourcesJson = readSchemedJsonFile(
-        oldSourcesJsonPath(),
-        oldSourcesJsonSchema
-    );
-    const migratedSources = Object.entries(oldSourcesJson).map(
-        ([name, url]) => ({
-            name,
-            url: url.replace(/apps\.json$/, 'source.json'),
-        })
-    );
-
-    writeSourcesFile(migratedSources);
 };

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -10,6 +10,7 @@ import './setUserDataDir';
 import { initialize as initializeElectronRemote } from '@electron/remote/main';
 import telemetry from '@nordicsemiconductor/pc-nrfconnect-shared/src/telemetry/telemetry';
 
+import { migrateSourcesJson } from './apps/sources';
 import configureElectronApp from './configureElectronApp';
 import initNrfUtilProxyEnv from './initNrfUtilProxyEnv';
 import registerIpcHandler from './registerIpcHandler';
@@ -21,6 +22,7 @@ telemetry.enableTelemetry();
 initNrfUtilProxyEnv();
 singeInstanceLock();
 initializeElectronRemote();
+migrateSourcesJson();
 registerIpcHandler();
 configureElectronApp();
 storeExecutablePath();

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -10,7 +10,7 @@ import './setUserDataDir';
 import { initialize as initializeElectronRemote } from '@electron/remote/main';
 import telemetry from '@nordicsemiconductor/pc-nrfconnect-shared/src/telemetry/telemetry';
 
-import { migrateSourcesJson } from './apps/sources';
+import { migrateSourcesJson } from './apps/dataMigration/migrateSourcesJson';
 import configureElectronApp from './configureElectronApp';
 import initNrfUtilProxyEnv from './initNrfUtilProxyEnv';
 import registerIpcHandler from './registerIpcHandler';


### PR DESCRIPTION
For [NCD-1128](https://nordicsemi.atlassian.net/browse/NCD-1128):

# Effect of this change

Before we had an used a file `sources.json` which looked like this:

```json
{
  "official": "https://developer.nordicsemi.com/.pc-tools/nrfconnect-apps/apps.json"
  "Test": "https://developer.nordicsemi.com/.pc-tools/nrfconnect-apps/test/apps.json"
}
```

This change introduces that instead a `sources-versioned.json` is used instead, which will look like this:
```json
{
  "v1": [
    {
      "name": "official",
      "url": "https://developer.nordicsemi.com/.pc-tools/nrfconnect-apps/source.json"
    },
    {
      "name": "Test",
      "url": "https://developer.nordicsemi.com/.pc-tools/nrfconnect-apps/test/source.json"
    }
  ]
}
```

If an existing `sources.json` is found it is left untouched but the content is migrated to a new `sources-versioned.json`. If an `sources-versioned.json` is found, no migration is done. If neither a `sources.json` nor a `sources-versioned.json` is found, a new `sources-versioned.json` is created.

After the migration, only the contents of `sources-versioned.json` are used, any existing `sources.json` is ignored.

# Motivation

With the move to Artifactory, I want to extend `sources-versioned.json` so that it can look like this:
```json
{
  "v1": [
    {
      "name": "official",
      "url": "https://developer.nordicsemi.com/.pc-tools/nrfconnect-apps/source.json"
    },
    {
      "name": "Test",
      "url": "https://developer.nordicsemi.com/.pc-tools/nrfconnect-apps/test/source.json"
    }
  ]
  "v2": [
    {
      "name": "official",
      "url": "https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=external/ncd/apps/official/source.json"
    },
    {
      "name": "Test",
      "url": "https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=internal/ncd/apps/test/source.json"
    }
  ]
}
```

The idea is, that new versions of the launcher can use the new version `v2` in this file, while old versions of the launcher can continue to use the old information. 

It already would have been helpful and simplified the code if we had done a change like this when switching to using the new app meta data in #804. But now it is helpful too and if it already was helpful twice it might prove to be helpful again in the future.

# Schema validation

Besides the migration to `sources-versioned.json` this change also adds schema validation to `source.json`. So the contents of all JSON files that are read of written there are also validated with `zod`.