### PR TITLE
Use runner provided by GitHub

### DIFF
--- a/.github/workflows/build_darwin_arm64.yml
+++ b/.github/workflows/build_darwin_arm64.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
     build:
-        runs-on: [self-hosted, macOS, ARM64]
+        runs-on: macos-latest
         steps:
             - uses: actions/checkout@v4
             - name: Build


### PR DESCRIPTION
Before GitHub didn't provide a macOS runner on arm64 so we had to host it ourselves (or pay for it). Now we can just use the one provided by GitHub.