### PR TITLE
Migrate currently used sources to `files.nordicsemi.com`

### DIFF
--- a/Changelog.minor.md
+++ b/Changelog.minor.md
@@ -19,6 +19,14 @@ release the new version.
 -   #1063: Download J-Link from Artifactory.
 -   #1071: Use `ExternalLink` from shared.
 -   #1071: Simplified option passing in low-level net functions.
+-   #1079: Switch from developer.nordicsemi.com to files.nordicsemi.com for all
+    app downloads. Usage of sources from developer.nordicsemi.com is
+    automatically migrated to files.nordicsemi.com on the first run.
+
+    When running this version and then going back to an older version of the
+    launcher, the older version will show apps installed from
+    developer.nordicsemi.com as being withdrawn. But going forward to this
+    version again, the app will look fine again.
 
 ### Fixed
 

--- a/build/bundleApps.js
+++ b/build/bundleApps.js
@@ -10,7 +10,7 @@ const { execSync } = require('child_process');
 const downloadFile = require('../scripts/downloadFile');
 
 const SOURCE_URL =
-    'https://developer.nordicsemi.com/.pc-tools/nrfconnect-apps/source.json';
+    'https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=external/ncd/apps/official/source.json';
 
 const BUNDLE_APPS = ['pc-nrfconnect-quickstart'];
 

--- a/src/launcher/features/apps/AppListEmpty.tsx
+++ b/src/launcher/features/apps/AppListEmpty.tsx
@@ -73,7 +73,7 @@ const NotLoadedYet = () => {
         <Box>
             <p>
                 The list of apps is not yet loaded from{' '}
-                <ExternalLink href="https://developer.nordicsemi.com" />.
+                <ExternalLink href="https://files.nordicsemi.com" />.
             </p>
             <p>Make sure you can reach that server.</p>
         </Box>

--- a/src/launcher/features/apps/__snapshots__/AppList.test.tsx.snap
+++ b/src/launcher/features/apps/__snapshots__/AppList.test.tsx.snap
@@ -320,11 +320,11 @@ exports[`AppList should render a message without any apps after some time 1`] = 
            
           <a
             class="tw-preflight tw-text-nordicBlue hover:tw-underline"
-            href="https://developer.nordicsemi.com"
+            href="https://files.nordicsemi.com"
             rel="noreferrer noopener"
             target="_blank"
           >
-            https://developer.nordicsemi.com
+            https://files.nordicsemi.com
           </a>
           .
         </p>

--- a/src/main/apps/dataMigration/migrateSourcesJson.ts
+++ b/src/main/apps/dataMigration/migrateSourcesJson.ts
@@ -10,7 +10,8 @@ import { z } from 'zod';
 
 import { getAppsExternalDir } from '../../config';
 import { readSchemedJsonFile } from '../../fileUtil';
-import { sourcesVersionedJsonPath, writeSourcesFile } from '../sources';
+import { sourcesVersionedJsonPath } from '../sources';
+import { writeV1SourcesFile } from './sourcesVersionedJsonV1';
 
 export const oldSourcesJsonPath = () =>
     path.join(getAppsExternalDir(), 'sources.json');
@@ -36,5 +37,5 @@ export const migrateSourcesJson = () => {
         })
     );
 
-    writeSourcesFile(migratedSources);
+    writeV1SourcesFile(migratedSources);
 };

--- a/src/main/apps/dataMigration/migrateSourcesVersionedJson.test.ts
+++ b/src/main/apps/dataMigration/migrateSourcesVersionedJson.test.ts
@@ -5,10 +5,12 @@
  */
 
 import {
+    getAllSources,
     type SourcesVersionedJson,
     writeSourcesVersionedJson,
 } from '../sources';
 import {
+    migrateAllURLsInJSON,
     migrateSourcesVersionedJson,
     migrateURL,
 } from './migrateSourcesVersionedJson';
@@ -67,11 +69,45 @@ describe('converting URLs from developer.nordicsemi.com to files.nordicsemi.com'
     });
 });
 
+test('migrateAllURLsInJSON', () => {
+    expect(
+        migrateAllURLsInJSON(`{
+  "homepage": "https://github.com/NordicPlayground/pc-nrfconnect-boilerplate",
+  "iconUrl": "https://developer.nordicsemi.com/.pc-tools/nrfconnect-apps/pc-nrfconnect-boilerplate.svg",
+  "releaseNotesUrl": "https://developer.nordicsemi.com/.pc-tools/nrfconnect-apps/3.7-apps/pc-nrfconnect-boilerplate-Changelog.md",
+  "versions": {
+    "1.0.0": {
+      "tarballUrl": "https://developer.nordicsemi.com/.pc-tools/nrfconnect-apps/directionfinding/pc-nrfconnect-npm-1.0.0.tgz"
+    },
+    "2.0.0": {
+      "tarballUrl": "https://developer.nordicsemi.com/.pc-tools/nrfconnect-apps/secret/pc-nrfconnect-npm-2.0.0.tgz"
+    }
+  }
+}`)
+    ).toBe(
+        `{
+  "homepage": "https://github.com/NordicPlayground/pc-nrfconnect-boilerplate",
+  "iconUrl": "https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=external/ncd/apps/official/pc-nrfconnect-boilerplate.svg",
+  "releaseNotesUrl": "https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=external/ncd/apps/3.7-apps/pc-nrfconnect-boilerplate-Changelog.md",
+  "versions": {
+    "1.0.0": {
+      "tarballUrl": "https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=external-confidential/ncd/apps/directionfinding/pc-nrfconnect-npm-1.0.0.tgz"
+    },
+    "2.0.0": {
+      "tarballUrl": "https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=internal/ncd/apps/secret/pc-nrfconnect-npm-2.0.0.tgz"
+    }
+  }
+}`
+    );
+});
+
 describe('migrating sources-versioned.json from V1 to V2', () => {
     const mockedReadV1SourcesFile = jest.mocked(readV1SourcesFile);
 
     beforeEach(() => {
         jest.resetAllMocks();
+
+        jest.mocked(getAllSources).mockReturnValue([]);
     });
 
     it('updates sources to use files.nordicsemi.com', () => {
@@ -144,6 +180,7 @@ describe('migrating sources-versioned.json from V1 to V2', () => {
         migrateSourcesVersionedJson();
 
         expect(writeSourcesVersionedJson).not.toBeCalled();
+        expect(getAllSources).not.toBeCalled();
     });
 
     it('does nothing if there already is a v2', () => {
@@ -152,5 +189,6 @@ describe('migrating sources-versioned.json from V1 to V2', () => {
         migrateSourcesVersionedJson();
 
         expect(writeSourcesVersionedJson).not.toBeCalled();
+        expect(getAllSources).not.toBeCalled();
     });
 });

--- a/src/main/apps/dataMigration/migrateSourcesVersionedJson.test.ts
+++ b/src/main/apps/dataMigration/migrateSourcesVersionedJson.test.ts
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import {
+    type SourcesVersionedJson,
+    writeSourcesVersionedJson,
+} from '../sources';
+import {
+    migrateSourcesVersionedJson,
+    migrateURL,
+} from './migrateSourcesVersionedJson';
+import { readV1SourcesFile } from './sourcesVersionedJsonV1';
+
+jest.mock('./sourcesVersionedJsonV1');
+jest.mock('../sources');
+
+describe('converting URLs from developer.nordicsemi.com to files.nordicsemi.com', () => {
+    test('official is in external', () => {
+        expect(
+            migrateURL(
+                'https://developer.nordicsemi.com/.pc-tools/nrfconnect-apps/source.json'
+            )
+        ).toBe(
+            'https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=external/ncd/apps/official/source.json'
+        );
+    });
+
+    test('3.*-apps are in external', () => {
+        expect(
+            migrateURL(
+                'https://developer.nordicsemi.com/.pc-tools/nrfconnect-apps/3.7-apps/pc-nrfconnect-rssi.json'
+            )
+        ).toBe(
+            'https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=external/ncd/apps/3.7-apps/pc-nrfconnect-rssi.json'
+        );
+
+        expect(
+            migrateURL(
+                'https://developer.nordicsemi.com/.pc-tools/nrfconnect-apps/3.11-apps/pc-nrfconnect-ble.json'
+            )
+        ).toBe(
+            'https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=external/ncd/apps/3.11-apps/pc-nrfconnect-ble.json'
+        );
+    });
+
+    test('direction-finding is external-confidential', () => {
+        expect(
+            migrateURL(
+                'https://developer.nordicsemi.com/.pc-tools/nrfconnect-apps/directionfinding/source.json'
+            )
+        ).toBe(
+            'https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=external-confidential/ncd/apps/directionfinding/source.json'
+        );
+    });
+
+    test('everything else is internal', () => {
+        expect(
+            migrateURL(
+                'https://developer.nordicsemi.com/.pc-tools/nrfconnect-apps/secret/pc-nrfconnect-secret.json'
+            )
+        ).toBe(
+            'https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=internal/ncd/apps/secret/pc-nrfconnect-secret.json'
+        );
+    });
+});
+
+describe('migrating sources-versioned.json from V1 to V2', () => {
+    const mockedReadV1SourcesFile = jest.mocked(readV1SourcesFile);
+
+    beforeEach(() => {
+        jest.resetAllMocks();
+    });
+
+    it('updates sources to use files.nordicsemi.com', () => {
+        mockedReadV1SourcesFile.mockReturnValue({
+            v1: [
+                {
+                    name: 'official',
+                    url: 'https://developer.nordicsemi.com/.pc-tools/nrfconnect-apps/source.json',
+                },
+                {
+                    name: '3.7 compatible apps',
+                    url: 'https://developer.nordicsemi.com/.pc-tools/nrfconnect-apps/3.7-apps/source.json',
+                },
+                {
+                    name: 'Latest',
+                    url: 'https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=internal/ncd/apps/latest/source.json',
+                },
+                {
+                    name: '3rd Party',
+                    url: 'https://example.org/source.json',
+                },
+            ],
+        } as SourcesVersionedJson);
+
+        migrateSourcesVersionedJson();
+
+        expect(writeSourcesVersionedJson).toBeCalledWith({
+            v1: [
+                {
+                    name: 'official',
+                    url: 'https://developer.nordicsemi.com/.pc-tools/nrfconnect-apps/source.json',
+                },
+                {
+                    name: '3.7 compatible apps',
+                    url: 'https://developer.nordicsemi.com/.pc-tools/nrfconnect-apps/3.7-apps/source.json',
+                },
+                {
+                    name: 'Latest',
+                    url: 'https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=internal/ncd/apps/latest/source.json',
+                },
+                {
+                    name: '3rd Party',
+                    url: 'https://example.org/source.json',
+                },
+            ],
+            v2: [
+                {
+                    name: 'official',
+                    url: 'https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=external/ncd/apps/official/source.json',
+                },
+                {
+                    name: '3.7 compatible apps',
+                    url: 'https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=external/ncd/apps/3.7-apps/source.json',
+                },
+                {
+                    name: 'Latest',
+                    url: 'https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=internal/ncd/apps/latest/source.json',
+                },
+                {
+                    name: '3rd Party',
+                    url: 'https://example.org/source.json',
+                },
+            ],
+        });
+    });
+
+    it('does nothing if there is no v1', () => {
+        mockedReadV1SourcesFile.mockReturnValue({ v2: [] });
+
+        migrateSourcesVersionedJson();
+
+        expect(writeSourcesVersionedJson).not.toBeCalled();
+    });
+
+    it('does nothing if there already is a v2', () => {
+        mockedReadV1SourcesFile.mockReturnValue({ v1: [], v2: [] });
+
+        migrateSourcesVersionedJson();
+
+        expect(writeSourcesVersionedJson).not.toBeCalled();
+    });
+});

--- a/src/main/apps/dataMigration/migrateSourcesVersionedJson.ts
+++ b/src/main/apps/dataMigration/migrateSourcesVersionedJson.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import { writeSourcesVersionedJson } from '../sources';
+import { readV1SourcesFile } from './sourcesVersionedJsonV1';
+
+export const migrateURL = (url: string) =>
+    url
+        .replace(
+            /https:\/\/developer\.nordicsemi\.com\/\.pc-tools\/nrfconnect-apps\/(3\.\d+-apps)\/(.+)/,
+            'https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=external/ncd/apps/$1/$2'
+        )
+        .replace(
+            /https:\/\/developer\.nordicsemi\.com\/\.pc-tools\/nrfconnect-apps\/directionfinding\/(.+)/,
+            'https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=external-confidential/ncd/apps/directionfinding/$1'
+        )
+        .replace(
+            /https:\/\/developer\.nordicsemi\.com\/\.pc-tools\/nrfconnect-apps\/([^/]+)\/(.+)/,
+            'https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=internal/ncd/apps/$1/$2'
+        )
+        .replace(
+            /https:\/\/developer.nordicsemi.com\/\.pc-tools\/nrfconnect-apps\/(.+)/,
+            'https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=external/ncd/apps/official/$1'
+        );
+
+export const migrateSourcesVersionedJson = () => {
+    const sourcesVersionedJson = readV1SourcesFile();
+    if (sourcesVersionedJson.v1 == null || sourcesVersionedJson.v2 != null) {
+        return;
+    }
+
+    const v2 = sourcesVersionedJson.v1.map(({ name, url }) => ({
+        name,
+        url: migrateURL(url),
+    }));
+
+    writeSourcesVersionedJson({ ...sourcesVersionedJson, v2 });
+};

--- a/src/main/apps/dataMigration/sourcesVersionedJsonV1.ts
+++ b/src/main/apps/dataMigration/sourcesVersionedJsonV1.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import type { Source } from '@nordicsemiconductor/pc-nrfconnect-shared/ipc/sources';
+import fs from 'fs-extra';
+
+import { readSchemedJsonFile, writeSchemedJsonFile } from '../../fileUtil';
+import {
+    sourcesVersionedJsonPath,
+    sourcesVersionedJsonSchema,
+} from '../sources';
+
+const sourcesVersionedJsonV1Schema = sourcesVersionedJsonSchema.partial();
+
+export const writeV1SourcesFile = (allSources: Source[]) => {
+    writeSchemedJsonFile(
+        sourcesVersionedJsonPath(),
+        sourcesVersionedJsonV1Schema,
+        {
+            v1: allSources,
+        }
+    );
+};
+
+export const readV1SourcesFile = () => {
+    if (!fs.existsSync(sourcesVersionedJsonPath())) {
+        return { v2: [] };
+    }
+
+    return readSchemedJsonFile(
+        sourcesVersionedJsonPath(),
+        sourcesVersionedJsonV1Schema
+    );
+};

--- a/src/main/apps/sources.ts
+++ b/src/main/apps/sources.ts
@@ -33,7 +33,7 @@ let sources: Source[] = [];
 
 const officialSource = {
     name: OFFICIAL,
-    url: 'https://developer.nordicsemi.com/.pc-tools/nrfconnect-apps/source.json',
+    url: 'https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=external/ncd/apps/official/source.json',
 };
 
 export const sourcesVersionedJsonPath = () =>

--- a/src/main/apps/sources.ts
+++ b/src/main/apps/sources.ts
@@ -141,7 +141,10 @@ const ensureSourcesAreLoaded = () => {
     }
 };
 
-export const getAllSources = () => [...sources];
+export const getAllSources = () => {
+    ensureSourcesAreLoaded();
+    return [...sources];
+};
 
 export const initialise = (source: Source) =>
     ensureDirExists(getNodeModulesDir(source.name));

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -11,6 +11,7 @@ import { initialize as initializeElectronRemote } from '@electron/remote/main';
 import telemetry from '@nordicsemiconductor/pc-nrfconnect-shared/src/telemetry/telemetry';
 
 import { migrateSourcesJson } from './apps/dataMigration/migrateSourcesJson';
+import { migrateSourcesVersionedJson } from './apps/dataMigration/migrateSourcesVersionedJson';
 import configureElectronApp from './configureElectronApp';
 import initNrfUtilProxyEnv from './initNrfUtilProxyEnv';
 import registerIpcHandler from './registerIpcHandler';
@@ -23,6 +24,7 @@ initNrfUtilProxyEnv();
 singeInstanceLock();
 initializeElectronRemote();
 migrateSourcesJson();
+migrateSourcesVersionedJson();
 registerIpcHandler();
 configureElectronApp();
 storeExecutablePath();


### PR DESCRIPTION
Part of [NCD-791](https://nordicsemi.atlassian.net/browse/NCD-791):

- Instead of `developer.nordicsemi.com` use `files.nordicsemi.com` for the official source.
- On the first run migrate all sources which previously used `developer.nordicsemi.com` to now use `files.nordicsemi.com`.
- When running this version and then going back to an older version of the launcher, the older version will show apps installed from `developer.nordicsemi.com` as being withdrawn. But going forward to this version again, the app will look fine again.