### PR TITLE
Show warnings on missing token for restricted sources

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 ## 5.1.1 - unreleased
 
+### Added
+
+-   Possibility to authenticate, when accessing sources on
+    `files.nordicsemi.com` with a restricted access.
+
 ### Changed
 
 -   Layout of the changelog modal.

--- a/Changelog.minor.md
+++ b/Changelog.minor.md
@@ -34,6 +34,9 @@ release the new version.
     them locally.
 -   #1082: Warn when adding sources from `developer.nordicsemi.com` and offer to
     instead add the corresponding source from `files.nordicsemi.com`.
+-   #1083: Added dialogs about a required token for sources with a restricted
+    access level, either when they come in through a migration from
+    `developer.nordicsemi.com` or when they are added later.
 
 ### Fixed
 

--- a/src/common/persistedStore.ts
+++ b/src/common/persistedStore.ts
@@ -40,6 +40,7 @@ interface Schema {
     encryptedArtifactoryToken?: string;
     artifactoryTokenInformation?: TokenInformation;
     doNotRemindDeprecatedSources?: boolean;
+    wasWarnedOnMissingTokenAndMigratedSources?: boolean;
 }
 
 const store = new Store<Schema>();
@@ -122,3 +123,8 @@ export const getDoNotRemindDeprecatedSources = () =>
     store.get('doNotRemindDeprecatedSources', false);
 export const setDoNotRemindDeprecatedSources = () =>
     store.set('doNotRemindDeprecatedSources', true);
+
+export const wasWarnedOnMissingTokenAndMigratedSources = () =>
+    store.get('wasWarnedOnMissingTokenAndMigratedSources', false);
+export const setWarnedOnMissingTokenAndMigratedSources = () =>
+    store.set('wasWarnedOnMissingTokenAndMigratedSources', true);

--- a/src/launcher/Root.tsx
+++ b/src/launcher/Root.tsx
@@ -25,6 +25,7 @@ import QuickStartDialog from './features/quickstart/QuickstartDialog';
 import Settings from './features/settings/Settings';
 import AddLegacySourceWarning from './features/sources/AddLegacySourceWarning';
 import DeprecatedSourcesDialog from './features/sources/DeprecatedSourcesDialog';
+import MissingTokenWarning from './features/sources/MissingTokenWarning';
 import TelemetryDialog from './features/telemetry/TelemetryDialog';
 import ErrorBoundaryLauncher from './util/ErrorBoundaryLauncher';
 
@@ -100,6 +101,7 @@ export default () => {
             <QuickStartDialog />
             <DeprecatedSourcesDialog />
             <AddLegacySourceWarning />
+            <MissingTokenWarning />
         </ErrorBoundaryLauncher>
     );
 };

--- a/src/launcher/features/settings/AddArtifactoryTokenDialog.tsx
+++ b/src/launcher/features/settings/AddArtifactoryTokenDialog.tsx
@@ -8,20 +8,16 @@ import React, { useState } from 'react';
 import Form from 'react-bootstrap/Form';
 import {
     ConfirmationDialog,
-    ErrorDialogActions,
     ExternalLink,
     useFocusedOnVisible,
 } from '@nordicsemiconductor/pc-nrfconnect-shared';
-import describeError from '@nordicsemiconductor/pc-nrfconnect-shared/src/logging/describeError';
 
-import cleanIpcErrorMessage from '../../../common/cleanIpcErrorMessage';
-import { inMain as artifactoryToken } from '../../../ipc/artifactoryToken';
 import { useLauncherDispatch, useLauncherSelector } from '../../util/hooks';
+import { setArtifactoryToken } from './settingsEffects';
 import {
     getArtifactoryTokenInformation,
     getIsAddArtifactoryTokenVisible,
     hideAddArtifactoryToken,
-    setArtifactoryTokenInformation,
 } from './settingsSlice';
 
 export default () => {
@@ -34,25 +30,13 @@ export default () => {
     const hideDialog = () => dispatch(hideAddArtifactoryToken());
 
     const storeToken = async () => {
+        setEnteredToken('');
+        hideDialog();
+
         try {
-            const tokenInformation = await artifactoryToken.setToken(
-                enteredToken
-            );
-
-            setEnteredToken('');
-            dispatch(setArtifactoryTokenInformation(tokenInformation));
-            hideDialog();
+            await dispatch(setArtifactoryToken(enteredToken));
         } catch (error) {
-            setEnteredToken('');
-            hideDialog();
-
-            dispatch(
-                ErrorDialogActions.showDialog(
-                    `Token got rejected. Check if you entered a wrong or expired token.`,
-                    undefined,
-                    cleanIpcErrorMessage(describeError(error))
-                )
-            );
+            /* No further error handling than already is done in setArtifactoryToken */
         }
     };
 

--- a/src/launcher/features/settings/settingsEffects.ts
+++ b/src/launcher/features/settings/settingsEffects.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import {
+    describeError,
+    ErrorDialogActions,
+} from '@nordicsemiconductor/pc-nrfconnect-shared';
+
+import cleanIpcErrorMessage from '../../../common/cleanIpcErrorMessage';
+import { inMain as artifactoryToken } from '../../../ipc/artifactoryToken';
+import type { AppThunk } from '../../store';
+import { setArtifactoryTokenInformation } from './settingsSlice';
+
+export const setArtifactoryToken =
+    (token: string): AppThunk =>
+    async dispatch => {
+        let tokenInformation;
+        try {
+            tokenInformation = await artifactoryToken.setToken(token);
+        } catch (error) {
+            dispatch(
+                ErrorDialogActions.showDialog(
+                    `Token got rejected. Check if you entered a wrong or expired token.`,
+                    undefined,
+                    cleanIpcErrorMessage(describeError(error))
+                )
+            );
+            throw error;
+        }
+        dispatch(setArtifactoryTokenInformation(tokenInformation));
+    };

--- a/src/launcher/features/sources/AddLegacySourceWarning.tsx
+++ b/src/launcher/features/sources/AddLegacySourceWarning.tsx
@@ -24,8 +24,8 @@ export default () => {
             isVisible={isVisible}
             title="Adding a legacy source"
             onConfirm={() => {
-                dispatch(addSource(correctedUrl));
                 dispatch(clearSourceToAdd());
+                dispatch(addSource(correctedUrl));
             }}
             onCancel={() => {
                 dispatch(clearSourceToAdd());

--- a/src/launcher/features/sources/AddSourceDialog.tsx
+++ b/src/launcher/features/sources/AddSourceDialog.tsx
@@ -11,14 +11,9 @@ import {
     useFocusedOnVisible,
 } from '@nordicsemiconductor/pc-nrfconnect-shared';
 
-import { isLegacyUrl } from '../../../common/legacySource';
 import { useLauncherDispatch, useLauncherSelector } from '../../util/hooks';
 import { addSource } from './sourcesEffects';
-import {
-    getIsAddSourceVisible,
-    hideAddSource,
-    warnAddLegacySource,
-} from './sourcesSlice';
+import { getIsAddSourceVisible, hideAddSource } from './sourcesSlice';
 
 export default () => {
     const dispatch = useLauncherDispatch();
@@ -30,16 +25,10 @@ export default () => {
     const cancel = () => dispatch(hideAddSource());
 
     const maybeAddSource = () => {
-        const effectiveUrl = url.trim();
-
-        if (isLegacyUrl(effectiveUrl)) {
-            dispatch(warnAddLegacySource(effectiveUrl));
+        if (url.trim().length > 0) {
+            dispatch(addSource(url.trim()));
             dispatch(hideAddSource());
             setUrl('');
-        } else if (effectiveUrl.length > 0) {
-            dispatch(hideAddSource());
-            setUrl('');
-            dispatch(addSource(effectiveUrl));
         }
     };
 

--- a/src/launcher/features/sources/AddSourceDialog.tsx
+++ b/src/launcher/features/sources/AddSourceDialog.tsx
@@ -37,9 +37,9 @@ export default () => {
             dispatch(hideAddSource());
             setUrl('');
         } else if (effectiveUrl.length > 0) {
-            dispatch(addSource(effectiveUrl));
             dispatch(hideAddSource());
             setUrl('');
+            dispatch(addSource(effectiveUrl));
         }
     };
 

--- a/src/launcher/features/sources/DeprecatedSourcesDialog.tsx
+++ b/src/launcher/features/sources/DeprecatedSourcesDialog.tsx
@@ -25,8 +25,6 @@ export default () => {
         <ConfirmationDialog
             isVisible={isVisible}
             title="Remove deprecated sources"
-            cancelLabel="Ignore"
-            optionalLabel="Do not remind me again"
             confirmLabel="Yes, remove"
             onConfirm={async () => {
                 dispatch(hideDeprecatedSources());
@@ -38,12 +36,14 @@ export default () => {
                 );
                 dispatch(initialiseLauncherState());
             }}
+            optionalLabel="Do not remind me again"
             onOptional={() => {
                 dispatch(hideDeprecatedSources());
                 dispatch(initialiseLauncherState());
 
                 dispatch(doNotRemindDeprecatedSources());
             }}
+            cancelLabel="Ignore"
             onCancel={() => {
                 dispatch(hideDeprecatedSources());
                 dispatch(initialiseLauncherState());

--- a/src/launcher/features/sources/DeprecatedSourcesDialog.tsx
+++ b/src/launcher/features/sources/DeprecatedSourcesDialog.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 import { ConfirmationDialog } from '@nordicsemiconductor/pc-nrfconnect-shared';
 
 import { useLauncherDispatch, useLauncherSelector } from '../../util/hooks';
-import { initialiseLauncherStateStage2 } from '../initialisation/initialiseLauncherState';
+import initialiseLauncherState from '../initialisation/initialiseLauncherState';
 import { removeSource } from './sourcesEffects';
 import {
     doNotRemindDeprecatedSources,
@@ -36,17 +36,17 @@ export default () => {
                         dispatch(removeSource(source.name))
                     )
                 );
-                dispatch(initialiseLauncherStateStage2());
+                dispatch(initialiseLauncherState());
             }}
             onOptional={() => {
                 dispatch(hideDeprecatedSources());
-                dispatch(initialiseLauncherStateStage2());
+                dispatch(initialiseLauncherState());
 
                 dispatch(doNotRemindDeprecatedSources());
             }}
             onCancel={() => {
                 dispatch(hideDeprecatedSources());
-                dispatch(initialiseLauncherStateStage2());
+                dispatch(initialiseLauncherState());
             }}
         >
             <p>Some sources you added are no longer supported.</p>

--- a/src/launcher/features/sources/MissingTokenWarning.tsx
+++ b/src/launcher/features/sources/MissingTokenWarning.tsx
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import React from 'react';
+import Form from 'react-bootstrap/Form';
+import {
+    ConfirmationDialog,
+    ErrorDialogActions,
+    ExternalLink,
+} from '@nordicsemiconductor/pc-nrfconnect-shared';
+import describeError from '@nordicsemiconductor/pc-nrfconnect-shared/src/logging/describeError';
+
+import cleanIpcErrorMessage from '../../../common/cleanIpcErrorMessage';
+import { inMain as artifactoryToken } from '../../../ipc/artifactoryToken';
+import { useLauncherDispatch, useLauncherSelector } from '../../util/hooks';
+import { setArtifactoryTokenInformation } from '../settings/settingsSlice';
+import { addSource } from './sourcesEffects';
+import {
+    getSourceToWarnAbout,
+    hideWarningAboutMissingToken,
+} from './sourcesSlice';
+
+export default () => {
+    const dispatch = useLauncherDispatch();
+    const sourceToAdd = useLauncherSelector(getSourceToWarnAbout);
+    const isVisible = sourceToAdd != null;
+
+    const [token, setToken] = React.useState('');
+
+    const confirm = async () => {
+        if (token.trim() === '') {
+            return;
+        }
+
+        dispatch(hideWarningAboutMissingToken());
+        setToken('');
+
+        let tokenInformation;
+        try {
+            tokenInformation = await artifactoryToken.setToken(token.trim());
+        } catch (error) {
+            dispatch(
+                ErrorDialogActions.showDialog(
+                    `Token got rejected. Check if you entered a wrong or expired token.`,
+                    undefined,
+                    cleanIpcErrorMessage(describeError(error))
+                )
+            );
+            return;
+        }
+        dispatch(setArtifactoryTokenInformation(tokenInformation));
+
+        dispatch(addSource(sourceToAdd!)); // eslint-disable-line @typescript-eslint/no-non-null-assertion -- If sourceToAdd is null, the whole dialog would not be visible
+    };
+
+    return (
+        <ConfirmationDialog
+            isVisible={isVisible}
+            title="Missing token"
+            confirmLabel="Set token"
+            onConfirm={confirm}
+            onCancel={() => {
+                dispatch(hideWarningAboutMissingToken());
+                setToken('');
+            }}
+        >
+            <p>
+                For accessing the source at the URL <code>{sourceToAdd}</code>{' '}
+                an Artifactory token is required but you have not set one yet.
+                Without providing a token, using the source will fail.
+            </p>
+            <p>
+                To get a token, go to{' '}
+                <ExternalLink href="https://files.nordicsemi.com/ui/user_profile" />
+                , log in and generate an Identity Token there. As Nordic
+                employee, you should be able to log in, otherwise ask your
+                Nordic contact for an account if you are eligible.
+            </p>
+            <p className="tw-m-0">Paste the token here:</p>
+            <Form onSubmit={confirm} className="tw-pb-4">
+                <Form.Control
+                    value={token}
+                    onChange={event => setToken(event.target.value)}
+                />
+            </Form>
+            <p>
+                You can also later view, remove, or set the token in the
+                settings.
+            </p>
+        </ConfirmationDialog>
+    );
+};

--- a/src/launcher/features/sources/MissingTokenWarning.tsx
+++ b/src/launcher/features/sources/MissingTokenWarning.tsx
@@ -38,7 +38,11 @@ export default () => {
         }
 
         if (isWarningAboutMissingTokenOnAddSource(missingTokenWarning))
-            dispatch(addSource(missingTokenWarning.sourceToAdd));
+            dispatch(
+                addSource(missingTokenWarning.sourceToAdd, {
+                    warnOnMissingToken: false,
+                })
+            );
 
         if (isWarningAboutMissingTokenOnMigratingSources(missingTokenWarning))
             dispatch(initialiseLauncherState());

--- a/src/launcher/features/sources/sourcesEffects.ts
+++ b/src/launcher/features/sources/sourcesEffects.ts
@@ -8,6 +8,7 @@ import { ErrorDialogActions } from '@nordicsemiconductor/pc-nrfconnect-shared';
 import { AnyAction } from 'redux';
 
 import cleanIpcErrorMessage from '../../../common/cleanIpcErrorMessage';
+import { isLegacyUrl } from '../../../common/legacySource';
 import { SourceWithError } from '../../../ipc/apps';
 import {
     AddSourceError,
@@ -26,6 +27,7 @@ import {
     addSource as addSourceAction,
     removeSource as removeSourceAction,
     warnAboutMissingTokenOnAddSource,
+    warnAddLegacySource,
 } from './sourcesSlice';
 
 const showError = (url: string, addSourceError: AddSourceError): AnyAction => {
@@ -56,8 +58,12 @@ export const hasRestrictedAccessLevel = (url: SourceUrl) =>
 export const addSource =
     (url: SourceUrl): AppThunk =>
     (dispatch, getState) => {
-        const noToken = getArtifactoryTokenInformation(getState()) == null;
+        if (isLegacyUrl(url)) {
+            dispatch(warnAddLegacySource(url));
+            return;
+        }
 
+        const noToken = getArtifactoryTokenInformation(getState()) == null;
         if (hasRestrictedAccessLevel(url) && noToken) {
             dispatch(warnAboutMissingTokenOnAddSource(url));
             return;

--- a/src/launcher/features/sources/sourcesEffects.ts
+++ b/src/launcher/features/sources/sourcesEffects.ts
@@ -25,7 +25,7 @@ import { getArtifactoryTokenInformation } from '../settings/settingsSlice';
 import {
     addSource as addSourceAction,
     removeSource as removeSourceAction,
-    warnAboutMissingToken,
+    warnAboutMissingTokenOnAddSource,
 } from './sourcesSlice';
 
 const showError = (url: string, addSourceError: AddSourceError): AnyAction => {
@@ -48,7 +48,7 @@ const showError = (url: string, addSourceError: AddSourceError): AnyAction => {
     }
 };
 
-const hasRestrictedAccessLevel = (url: SourceUrl) =>
+export const hasRestrictedAccessLevel = (url: SourceUrl) =>
     url.match(
         /https?:\/\/files\.nordicsemi\.com\/ui\/api\/v1\/download\?isNativeBrowsing=false&repoKey=swtools&path=(internal|external-confidential)/
     ) != null;
@@ -59,7 +59,7 @@ export const addSource =
         const noToken = getArtifactoryTokenInformation(getState()) == null;
 
         if (hasRestrictedAccessLevel(url) && noToken) {
-            dispatch(warnAboutMissingToken(url));
+            dispatch(warnAboutMissingTokenOnAddSource(url));
             return;
         }
 

--- a/src/launcher/features/sources/sourcesEffects.ts
+++ b/src/launcher/features/sources/sourcesEffects.ts
@@ -56,7 +56,10 @@ export const hasRestrictedAccessLevel = (url: SourceUrl) =>
     ) != null;
 
 export const addSource =
-    (url: SourceUrl): AppThunk =>
+    (
+        url: SourceUrl,
+        { warnOnMissingToken } = { warnOnMissingToken: true }
+    ): AppThunk =>
     (dispatch, getState) => {
         if (isLegacyUrl(url)) {
             dispatch(warnAddLegacySource(url));
@@ -64,7 +67,7 @@ export const addSource =
         }
 
         const noToken = getArtifactoryTokenInformation(getState()) == null;
-        if (hasRestrictedAccessLevel(url) && noToken) {
+        if (hasRestrictedAccessLevel(url) && noToken && warnOnMissingToken) {
             dispatch(warnAboutMissingTokenOnAddSource(url));
             return;
         }

--- a/src/launcher/features/sources/sourcesSlice.ts
+++ b/src/launcher/features/sources/sourcesSlice.ts
@@ -21,6 +21,7 @@ export type State = {
     deprecatedSources: Source[];
     doNotRemindDeprecatedSources: boolean;
     sourceToAdd: null | SourceUrl;
+    sourceToWarnAbout: null | SourceUrl;
 };
 
 const initialState: State = {
@@ -30,6 +31,7 @@ const initialState: State = {
     deprecatedSources: [],
     doNotRemindDeprecatedSources: getPersistedDoNotRemindDeprecatedSources(),
     sourceToAdd: null,
+    sourceToWarnAbout: null,
 };
 
 const sourcesWithout = (sources: Source[], sourceNameToBeRemoved: SourceName) =>
@@ -38,7 +40,7 @@ const sourcesWithout = (sources: Source[], sourceNameToBeRemoved: SourceName) =>
     );
 
 const slice = createSlice({
-    name: 'settings',
+    name: 'sources',
     initialState,
     reducers: {
         setSources(state, { payload: sources }: PayloadAction<Source[]>) {
@@ -92,6 +94,15 @@ const slice = createSlice({
         clearSourceToAdd(state) {
             state.sourceToAdd = null;
         },
+        warnAboutMissingToken(
+            state,
+            { payload: url }: PayloadAction<SourceUrl>
+        ) {
+            state.sourceToWarnAbout = url;
+        },
+        hideWarningAboutMissingToken(state) {
+            state.sourceToWarnAbout = null;
+        },
     },
 });
 
@@ -110,6 +121,8 @@ export const {
     doNotRemindDeprecatedSources,
     warnAddLegacySource,
     clearSourceToAdd,
+    warnAboutMissingToken,
+    hideWarningAboutMissingToken,
 } = slice.actions;
 
 export const getSources = (state: RootState) => state.sources.sources;
@@ -124,3 +137,5 @@ export const getDeprecatedSources = (state: RootState) =>
 export const getDoNotRemindDeprecatedSources = (state: RootState) =>
     state.sources.doNotRemindDeprecatedSources;
 export const getSourceToAdd = (state: RootState) => state.sources.sourceToAdd;
+export const getSourceToWarnAbout = (state: RootState) =>
+    state.sources.sourceToWarnAbout;

--- a/src/launcher/features/telemetry/telemetryEffects.ts
+++ b/src/launcher/features/telemetry/telemetryEffects.ts
@@ -59,7 +59,7 @@ export const checkTelemetrySetting = (): AppThunk => dispatch => {
     dispatch(setIsSendingTelemetry(telemetry.getIsSendingTelemetry()));
 };
 
-export const sendEnvInfo = () => {
+export const sendEnvInfo = (): AppThunk => () => {
     telemetry.sendEvent(EventAction.REPORT_LAUNCHER_INFO, {
         version: pkgJson.version,
         isDevelopment,


### PR DESCRIPTION
Part of [NCD-791](https://nordicsemi.atlassian.net/browse/NCD-791):

# Warning on migration

When migrating from `developer.nordicsemi.com` to `files.nordicsemi.com` and people previously had added a source that now has restricted access, show them a special warning and describe how they can solve the issue:

![image](https://github.com/user-attachments/assets/072def04-1d8b-416e-b601-7038f6ba216e)

The previous warning is shown only once, because people only migrate once from the old to the new server. But when you are **testing** this functionality, you might want to re-test it, in which case you need to edit your `config.json` and there remove the `wasWarnedOnMissingTokenAndMigratedSources` entry (or set it to `false`).

# Warning on adding sources

When users add a source which has restricted access and have not yet set a token, a similar warning is shown:

![image](https://github.com/user-attachments/assets/5b724e63-da7d-45fa-ad77-fc869c3f5fb5)
