### PR TITLE
Bump version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nrfconnect",
-    "version": "5.1.0",
+    "version": "5.1.1",
     "description": "nRF Connect for Desktop",
     "repository": {
         "type": "git",


### PR DESCRIPTION
Given the switch from `developer.nordicsemi.com` to `files.nordicsemi.com`, the version number change for the actual release will probably be bigger. But for now I just want _some_ version change, so that for test builds handed out, it is easy to see that they are not the current release.