### PR TITLE
Do not restrict the PR triggers to the main branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,8 +8,6 @@ on:
                 default: false
                 required: true
     pull_request:
-        branches:
-            - main
         paths-ignore:
             - 'doc/**'
     push:

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -7,13 +7,8 @@ on:
             - labeled
             - unlabeled
             - synchronize
-        branches:
-            - main
 
 jobs:
     check_labels:
         uses: NordicSemiconductor/pc-nrfconnect-shared/.github/workflows/labels.yml@main
         secrets: inherit
-
-
-


### PR DESCRIPTION
Reason: I created several PRs which were initially not aimed at the main branch and so wrongly didn't cause the actions to run. And there is little harm for running the actions on all PRs, even if they may be unnecessary sometimes.