### PR TITLE
Support simpler Artifactory URLs

### DIFF
--- a/build/bundleApps.js
+++ b/build/bundleApps.js
@@ -10,7 +10,7 @@ const { execSync } = require('child_process');
 const downloadFile = require('../scripts/downloadFile');
 
 const SOURCE_URL =
-    'https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=external/ncd/apps/official/source.json';
+    'https://files.nordicsemi.com/artifactory/swtools/external/ncd/apps/official/source.json';
 
 const BUNDLE_APPS = ['pc-nrfconnect-quickstart'];
 

--- a/src/common/legacySource.test.ts
+++ b/src/common/legacySource.test.ts
@@ -13,7 +13,7 @@ describe('converting URLs from developer.nordicsemi.com to files.nordicsemi.com'
                 'https://developer.nordicsemi.com/.pc-tools/nrfconnect-apps/source.json'
             )
         ).toBe(
-            'https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=external/ncd/apps/official/source.json'
+            'https://files.nordicsemi.com/artifactory/swtools/external/ncd/apps/official/source.json'
         );
     });
 
@@ -23,7 +23,7 @@ describe('converting URLs from developer.nordicsemi.com to files.nordicsemi.com'
                 'https://developer.nordicsemi.com/.pc-tools/nrfconnect-apps/3.7-apps/pc-nrfconnect-rssi.json'
             )
         ).toBe(
-            'https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=external/ncd/apps/3.7-apps/pc-nrfconnect-rssi.json'
+            'https://files.nordicsemi.com/artifactory/swtools/external/ncd/apps/3.7-apps/pc-nrfconnect-rssi.json'
         );
 
         expect(
@@ -31,7 +31,7 @@ describe('converting URLs from developer.nordicsemi.com to files.nordicsemi.com'
                 'https://developer.nordicsemi.com/.pc-tools/nrfconnect-apps/3.11-apps/pc-nrfconnect-ble.json'
             )
         ).toBe(
-            'https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=external/ncd/apps/3.11-apps/pc-nrfconnect-ble.json'
+            'https://files.nordicsemi.com/artifactory/swtools/external/ncd/apps/3.11-apps/pc-nrfconnect-ble.json'
         );
     });
 
@@ -41,7 +41,7 @@ describe('converting URLs from developer.nordicsemi.com to files.nordicsemi.com'
                 'https://developer.nordicsemi.com/.pc-tools/nrfconnect-apps/directionfinding/source.json'
             )
         ).toBe(
-            'https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=external-confidential/ncd/apps/directionfinding/source.json'
+            'https://files.nordicsemi.com/artifactory/swtools/external-confidential/ncd/apps/directionfinding/source.json'
         );
     });
 
@@ -51,7 +51,7 @@ describe('converting URLs from developer.nordicsemi.com to files.nordicsemi.com'
                 'https://developer.nordicsemi.com/.pc-tools/nrfconnect-apps/secret/pc-nrfconnect-secret.json'
             )
         ).toBe(
-            'https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=internal/ncd/apps/secret/pc-nrfconnect-secret.json'
+            'https://files.nordicsemi.com/artifactory/swtools/internal/ncd/apps/secret/pc-nrfconnect-secret.json'
         );
     });
 });
@@ -74,14 +74,14 @@ test('migrateAllURLsInJSON', () => {
     ).toBe(
         `{
   "homepage": "https://github.com/NordicPlayground/pc-nrfconnect-boilerplate",
-  "iconUrl": "https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=external/ncd/apps/official/pc-nrfconnect-boilerplate.svg",
-  "releaseNotesUrl": "https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=external/ncd/apps/3.7-apps/pc-nrfconnect-boilerplate-Changelog.md",
+  "iconUrl": "https://files.nordicsemi.com/artifactory/swtools/external/ncd/apps/official/pc-nrfconnect-boilerplate.svg",
+  "releaseNotesUrl": "https://files.nordicsemi.com/artifactory/swtools/external/ncd/apps/3.7-apps/pc-nrfconnect-boilerplate-Changelog.md",
   "versions": {
     "1.0.0": {
-      "tarballUrl": "https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=external-confidential/ncd/apps/directionfinding/pc-nrfconnect-npm-1.0.0.tgz"
+      "tarballUrl": "https://files.nordicsemi.com/artifactory/swtools/external-confidential/ncd/apps/directionfinding/pc-nrfconnect-npm-1.0.0.tgz"
     },
     "2.0.0": {
-      "tarballUrl": "https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=internal/ncd/apps/secret/pc-nrfconnect-npm-2.0.0.tgz"
+      "tarballUrl": "https://files.nordicsemi.com/artifactory/swtools/internal/ncd/apps/secret/pc-nrfconnect-npm-2.0.0.tgz"
     }
   }
 }`

--- a/src/common/legacySource.ts
+++ b/src/common/legacySource.ts
@@ -13,19 +13,19 @@ export const migrateURL = (url: string) =>
     url
         .replace(
             /https?:\/\/developer\.nordicsemi\.com\/\.pc-tools\/nrfconnect-apps\/(3\.\d+-apps)\/(.+)/,
-            'https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=external/ncd/apps/$1/$2'
+            'https://files.nordicsemi.com/artifactory/swtools/external/ncd/apps/$1/$2'
         )
         .replace(
             /https?:\/\/developer\.nordicsemi\.com\/\.pc-tools\/nrfconnect-apps\/directionfinding\/(.+)/,
-            'https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=external-confidential/ncd/apps/directionfinding/$1'
+            'https://files.nordicsemi.com/artifactory/swtools/external-confidential/ncd/apps/directionfinding/$1'
         )
         .replace(
             /https?:\/\/developer\.nordicsemi\.com\/\.pc-tools\/nrfconnect-apps\/([^/]+)\/(.+)/,
-            'https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=internal/ncd/apps/$1/$2'
+            'https://files.nordicsemi.com/artifactory/swtools/internal/ncd/apps/$1/$2'
         )
         .replace(
             /https?:\/\/developer.nordicsemi.com\/\.pc-tools\/nrfconnect-apps\/(.+)/,
-            'https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=external/ncd/apps/official/$1'
+            'https://files.nordicsemi.com/artifactory/swtools/external/ncd/apps/official/$1'
         );
 
 export const migrateAllURLsInJSON = (json: string) =>
@@ -43,7 +43,7 @@ const deprecatedSources = [
 
 const deprecatedSourceURLs = deprecatedSources.map(
     name =>
-        `https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=internal/ncd/apps/${name}/source.json`
+        `https://files.nordicsemi.com/artifactory/swtools/internal/ncd/apps/${name}/source.json`
 );
 
 export const isDeprecatedSource = (url: Source) =>

--- a/src/launcher/features/sources/sourcesEffects.ts
+++ b/src/launcher/features/sources/sourcesEffects.ts
@@ -51,9 +51,18 @@ const showError = (url: string, addSourceError: AddSourceError): AnyAction => {
 };
 
 export const hasRestrictedAccessLevel = (url: SourceUrl) =>
-    url.match(
-        /https?:\/\/files\.nordicsemi\.com\/ui\/api\/v1\/download\?isNativeBrowsing=false&repoKey=swtools&path=(internal|external-confidential)/
-    ) != null;
+    url.startsWith(
+        'https://files.nordicsemi.com/artifactory/swtools/internal'
+    ) ||
+    url.startsWith(
+        'https://files.nordicsemi.com/artifactory/swtools/external-confidential'
+    ) ||
+    url.startsWith(
+        'https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=internal'
+    ) ||
+    url.startsWith(
+        'https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=external-confidential'
+    );
 
 export const addSource =
     (

--- a/src/main/apps/dataMigration/migrateSourcesVersionedJson.test.ts
+++ b/src/main/apps/dataMigration/migrateSourcesVersionedJson.test.ts
@@ -38,7 +38,7 @@ describe('migrating sources-versioned.json from V1 to V2', () => {
                 },
                 {
                     name: 'Latest',
-                    url: 'https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=internal/ncd/apps/latest/source.json',
+                    url: 'https://files.nordicsemi.com/artifactory/swtools/internal/ncd/apps/latest/source.json',
                 },
                 {
                     name: '3rd Party',
@@ -61,7 +61,7 @@ describe('migrating sources-versioned.json from V1 to V2', () => {
                 },
                 {
                     name: 'Latest',
-                    url: 'https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=internal/ncd/apps/latest/source.json',
+                    url: 'https://files.nordicsemi.com/artifactory/swtools/internal/ncd/apps/latest/source.json',
                 },
                 {
                     name: '3rd Party',
@@ -71,15 +71,15 @@ describe('migrating sources-versioned.json from V1 to V2', () => {
             v2: [
                 {
                     name: 'official',
-                    url: 'https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=external/ncd/apps/official/source.json',
+                    url: 'https://files.nordicsemi.com/artifactory/swtools/external/ncd/apps/official/source.json',
                 },
                 {
                     name: '3.7 compatible apps',
-                    url: 'https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=external/ncd/apps/3.7-apps/source.json',
+                    url: 'https://files.nordicsemi.com/artifactory/swtools/external/ncd/apps/3.7-apps/source.json',
                 },
                 {
                     name: 'Latest',
-                    url: 'https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=internal/ncd/apps/latest/source.json',
+                    url: 'https://files.nordicsemi.com/artifactory/swtools/internal/ncd/apps/latest/source.json',
                 },
                 {
                     name: '3rd Party',

--- a/src/main/apps/sources/sources.ts
+++ b/src/main/apps/sources/sources.ts
@@ -29,7 +29,7 @@ let sources: Source[] = [];
 
 const officialSource = {
     name: OFFICIAL,
-    url: 'https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=external/ncd/apps/official/source.json',
+    url: 'https://files.nordicsemi.com/artifactory/swtools/external/ncd/apps/official/source.json',
 };
 
 const saveAllSources = () => {

--- a/src/main/net.test.ts
+++ b/src/main/net.test.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import { getUseChineseAppServer } from '../common/persistedStore';
+import { determineEffectiveUrl } from './net';
+
+jest.mock('../common/persistedStore');
+
+describe('determineEffectiveUrl', () => {
+    it('does not change URLs which already use the download API', () => {
+        expect(
+            determineEffectiveUrl(
+                'https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=external/ncd/apps/official/source.json'
+            )
+        ).toBe(
+            'https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=external/ncd/apps/official/source.json'
+        );
+    });
+
+    it('does not change URLs on other servers', () => {
+        expect(
+            determineEffectiveUrl('https://example.org/artifactory/this/that')
+        ).toBe('https://example.org/artifactory/this/that');
+    });
+
+    it('changes URLs from short artifactory format to download API format', () => {
+        expect(
+            determineEffectiveUrl(
+                'https://files.nordicsemi.com/artifactory/swtools/internal/ncd/apps/experimental/source.json'
+            )
+        ).toBe(
+            'https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=internal/ncd/apps/experimental/source.json'
+        );
+    });
+
+    it('uses the chinese server when requested', () => {
+        jest.mocked(getUseChineseAppServer).mockReturnValue(true);
+
+        expect(
+            determineEffectiveUrl(
+                'https://files.nordicsemi.com/artifactory/swtools/external/ncd/apps/official/source.json'
+            )
+        ).toBe(
+            'https://files.nordicsemi.cn/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=external/ncd/apps/official/source.json'
+        );
+    });
+
+    it('does not use the Chinese server for non-public sources', () => {
+        jest.mocked(getUseChineseAppServer).mockReturnValue(true);
+
+        expect(
+            determineEffectiveUrl(
+                'https://files.nordicsemi.com/artifactory/swtools/internal/ncd/apps/experimental/source.json'
+            )
+        ).toBe(
+            'https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=internal/ncd/apps/experimental/source.json'
+        );
+    });
+});


### PR DESCRIPTION
Implements [NCD-1289](https://nordicsemi.atlassian.net/browse/NCD-1289):

When accessing Artifactory we have to use the download API, so instead of using a more simple URL like 

> `https://files.nordicsemi.com/artifactory/swtools/external/ncd/apps/3.7-apps/source.json` 

we have to use 

> `https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=external/ncd/apps/3.7-apps/source.json`

But the latter is more cumbersome, e.g. reads worse when it appears in error dialogs. And some folks might  copy the shorter URLs from Artifactory (where they are shown as "File URL") and expecting them to work.

This PR makes the shorter URLs work in the launcher, by detecting them in `net.ts` and replacing them with URLs using the download API.