### PR TITLE
Enhance UX around removing tokens

### DIFF
--- a/src/launcher/features/initialisation/initialiseLauncherState.ts
+++ b/src/launcher/features/initialisation/initialiseLauncherState.ts
@@ -86,7 +86,7 @@ const loadTokenInformation = (): AppThunk => async (dispatch, getState) => {
     } catch (error) {
         dispatch(
             ErrorDialogActions.showDialog(
-                `Your identity token could not be validated. If you are online it may have expired.`,
+                `Your identity token could not be validated. If you are online, it may have expired.`,
                 undefined,
                 cleanIpcErrorMessage(describeError(error))
             )

--- a/src/launcher/features/initialisation/initialiseLauncherState.ts
+++ b/src/launcher/features/initialisation/initialiseLauncherState.ts
@@ -86,7 +86,7 @@ const loadTokenInformation = (): AppThunk => async (dispatch, getState) => {
     } catch (error) {
         dispatch(
             ErrorDialogActions.showDialog(
-                `Your Artifactory token could not be validated. If you are online it may have expired.`,
+                `Your identity token could not be validated. If you are online it may have expired.`,
                 undefined,
                 cleanIpcErrorMessage(describeError(error))
             )

--- a/src/launcher/features/settings/AddArtifactoryTokenDialog.tsx
+++ b/src/launcher/features/settings/AddArtifactoryTokenDialog.tsx
@@ -55,11 +55,11 @@ export default () => {
                 Enter an identity token to use for retrieving apps. To get a
                 token, go to{' '}
                 <ExternalLink href="https://files.nordicsemi.com/ui/user_profile" />
-                , log in and generate an identity token there.
+                , log in, and generate an identity token there.
             </p>
             <p>
-                As Nordic employee, you should be able to log in, otherwise ask
-                your Nordic contact for an account if you are eligible.
+                As Nordic employee, you are able to log in. If not a Nordic
+                employee, ask your Nordic contact for an account.
             </p>
             {hasToken && (
                 <p>The current token will be forgotten by this app.</p>

--- a/src/launcher/features/settings/AddArtifactoryTokenDialog.tsx
+++ b/src/launcher/features/settings/AddArtifactoryTokenDialog.tsx
@@ -52,10 +52,14 @@ export default () => {
             onCancel={hideDialog}
         >
             <p>
-                Enter an Artifactory token to use for retrieving apps. You can
-                get an identity token from{' '}
+                Enter an identity token to use for retrieving apps. To get a
+                token, go to{' '}
                 <ExternalLink href="https://files.nordicsemi.com/ui/user_profile" />
-                .
+                , log in and generate an identity token there.
+            </p>
+            <p>
+                As Nordic employee, you should be able to log in, otherwise ask
+                your Nordic contact for an account if you are eligible.
             </p>
             {hasToken && (
                 <p>The current token will be forgotten by this app.</p>

--- a/src/launcher/features/settings/Cards/Authentication.tsx
+++ b/src/launcher/features/settings/Cards/Authentication.tsx
@@ -9,22 +9,14 @@ import Button from 'react-bootstrap/Button';
 import Card from 'react-bootstrap/Card';
 import Col from 'react-bootstrap/Col';
 import Row from 'react-bootstrap/Row';
-import {
-    ErrorDialogActions,
-    ExternalLink,
-} from '@nordicsemiconductor/pc-nrfconnect-shared';
-import describeError from '@nordicsemiconductor/pc-nrfconnect-shared/src/logging/describeError';
+import { ExternalLink } from '@nordicsemiconductor/pc-nrfconnect-shared';
 
-import cleanIpcErrorMessage from '../../../../common/cleanIpcErrorMessage';
-import {
-    inMain as artifactoryToken,
-    type TokenInformation,
-} from '../../../../ipc/artifactoryToken';
+import { type TokenInformation } from '../../../../ipc/artifactoryToken';
 import { useLauncherDispatch, useLauncherSelector } from '../../../util/hooks';
 import {
     getArtifactoryTokenInformation,
-    removeArtifactoryTokenInformation,
     showAddArtifactoryToken,
+    showRemoveArtifactoryToken,
 } from '../settingsSlice';
 
 const Token: React.FC<{ token: TokenInformation }> = ({ token }) => (
@@ -49,21 +41,6 @@ export default () => {
     const dispatch = useLauncherDispatch();
 
     const token = useLauncherSelector(getArtifactoryTokenInformation);
-
-    const forgetToken = async () => {
-        try {
-            await artifactoryToken.removeToken();
-            dispatch(removeArtifactoryTokenInformation());
-        } catch (error) {
-            dispatch(
-                ErrorDialogActions.showDialog(
-                    `Unable to forget token.`,
-                    undefined,
-                    cleanIpcErrorMessage(describeError(error))
-                )
-            );
-        }
-    };
 
     return (
         <Card body id="app-sources">
@@ -97,7 +74,9 @@ export default () => {
                             <Button
                                 variant="outline-secondary"
                                 size="sm"
-                                onClick={forgetToken}
+                                onClick={() =>
+                                    dispatch(showRemoveArtifactoryToken())
+                                }
                                 title="Remove identity token"
                             >
                                 Remove

--- a/src/launcher/features/settings/Cards/Authentication.tsx
+++ b/src/launcher/features/settings/Cards/Authentication.tsx
@@ -98,9 +98,9 @@ export default () => {
                                 variant="outline-secondary"
                                 size="sm"
                                 onClick={forgetToken}
-                                title="Forget identity token"
+                                title="Remove identity token"
                             >
-                                Forget
+                                Remove
                             </Button>
                         </Col>
                     </>

--- a/src/launcher/features/settings/RemoveArtifactoryTokenDialog.tsx
+++ b/src/launcher/features/settings/RemoveArtifactoryTokenDialog.tsx
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import React from 'react';
+import {
+    ConfirmationDialog,
+    describeError,
+    ErrorDialogActions,
+} from '@nordicsemiconductor/pc-nrfconnect-shared';
+
+import cleanIpcErrorMessage from '../../../common/cleanIpcErrorMessage';
+import { inMain as artifactoryToken } from '../../../ipc/artifactoryToken';
+import { useLauncherDispatch, useLauncherSelector } from '../../util/hooks';
+import { hasRestrictedAccessLevel } from '../sources/sourcesEffects';
+import { getSources } from '../sources/sourcesSlice';
+import {
+    getIsRemoveArtifactoryTokenVisible,
+    hideRemoveArtifactoryToken,
+    removeArtifactoryTokenInformation,
+} from './settingsSlice';
+
+export default () => {
+    const dispatch = useLauncherDispatch();
+    const isVisible = useLauncherSelector(getIsRemoveArtifactoryTokenVisible);
+    const nonPublicSources = useLauncherSelector(getSources).filter(source =>
+        hasRestrictedAccessLevel(source.url)
+    );
+
+    const hideDialog = () => dispatch(hideRemoveArtifactoryToken());
+
+    const removeToken = async () => {
+        try {
+            hideDialog();
+
+            await artifactoryToken.removeToken();
+            dispatch(removeArtifactoryTokenInformation());
+        } catch (error) {
+            dispatch(
+                ErrorDialogActions.showDialog(
+                    `Unable to remove token.`,
+                    undefined,
+                    cleanIpcErrorMessage(describeError(error))
+                )
+            );
+        }
+    };
+
+    return (
+        <ConfirmationDialog
+            isVisible={isVisible}
+            title="Remove token"
+            confirmLabel="Remove token"
+            onConfirm={removeToken}
+            onCancel={hideDialog}
+        >
+            <p>
+                After removing the identity token, you will no longer be able to
+                add non-external sources from Nordic Semiconductor, until you
+                set a token again.
+            </p>
+            {nonPublicSources.length > 0 && (
+                <>
+                    <p>
+                        You currently have these non-external sources added.
+                        Until you set an identity token again, updating these
+                        sources will lead to errors and you will be unable to
+                        install apps from them:
+                    </p>
+                    <ul>
+                        {nonPublicSources.map(source => (
+                            <li key={source.url}>{source.name}</li>
+                        ))}
+                    </ul>
+                </>
+            )}
+        </ConfirmationDialog>
+    );
+};

--- a/src/launcher/features/settings/Settings.tsx
+++ b/src/launcher/features/settings/Settings.tsx
@@ -15,6 +15,7 @@ import Authentication from './Cards/Authentication';
 import ChineseAppServer from './Cards/ChineseAppServer';
 import Updates from './Cards/Updates';
 import UsageStatistics from './Cards/UsageStatistics';
+import RemoveArtifactoryTokenDialog from './RemoveArtifactoryTokenDialog';
 import UpdateCheckCompleteDialog from './UpdateCheckCompleteDialog';
 
 export default () => (
@@ -30,6 +31,7 @@ export default () => (
             <AddSourceDialog />
             <ConfirmRemoveSourceDialog />
             <AddArtifactoryTokenDialog />
+            <RemoveArtifactoryTokenDialog />
         </div>
     </WithScrollbarContainer>
 );

--- a/src/launcher/features/settings/__snapshots__/Settings.test.tsx.snap
+++ b/src/launcher/features/settings/__snapshots__/Settings.test.tsx.snap
@@ -836,10 +836,10 @@ exports[`SettingsView should render the token information 1`] = `
                 >
                   <button
                     class="btn btn-outline-secondary btn-sm"
-                    title="Forget identity token"
+                    title="Remove identity token"
                     type="button"
                   >
-                    Forget
+                    Remove
                   </button>
                 </div>
               </div>

--- a/src/launcher/features/settings/settingsSlice.ts
+++ b/src/launcher/features/settings/settingsSlice.ts
@@ -26,6 +26,7 @@ export type State = {
     isUpdateCheckCompleteVisible: boolean;
     isQuickStartInfoShownBefore: boolean;
     isAddArtifactoryTokenVisible: boolean;
+    isRemoveArtifactoryTokenVisible: boolean;
     artifactoryTokenInformation?: TokenInformation;
     useChineseAppServer: boolean;
 };
@@ -35,6 +36,7 @@ const initialState: State = {
     isUpdateCheckCompleteVisible: false,
     isQuickStartInfoShownBefore: getPersistedIsQuickStartInfoShownBefore(),
     isAddArtifactoryTokenVisible: false,
+    isRemoveArtifactoryTokenVisible: false,
     artifactoryTokenInformation: getPersistedArtifactoryTokenInformation(),
     useChineseAppServer: getPersistedUseChineseAppServer(),
 };
@@ -66,6 +68,12 @@ const slice = createSlice({
         hideAddArtifactoryToken(state) {
             state.isAddArtifactoryTokenVisible = false;
         },
+        showRemoveArtifactoryToken(state) {
+            state.isRemoveArtifactoryTokenVisible = true;
+        },
+        hideRemoveArtifactoryToken(state) {
+            state.isRemoveArtifactoryTokenVisible = false;
+        },
         setArtifactoryTokenInformation(
             state,
             { payload: tokenInformation }: PayloadAction<TokenInformation>
@@ -91,14 +99,16 @@ export default slice.reducer;
 
 export const {
     hideAddArtifactoryToken,
+    hideRemoveArtifactoryToken,
     hideUpdateCheckComplete,
     quickStartInfoWasShown,
     removeArtifactoryTokenInformation,
     setArtifactoryTokenInformation,
     setCheckForUpdatesAtStartup,
-    showAddArtifactoryToken,
-    showUpdateCheckComplete,
     setUseChineseAppServer,
+    showAddArtifactoryToken,
+    showRemoveArtifactoryToken,
+    showUpdateCheckComplete,
 } = slice.actions;
 
 export const getShouldCheckForUpdatesAtStartup = (state: RootState) =>
@@ -111,5 +121,7 @@ export const getArtifactoryTokenInformation = (state: RootState) =>
     state.settings.artifactoryTokenInformation;
 export const getIsAddArtifactoryTokenVisible = (state: RootState) =>
     state.settings.isAddArtifactoryTokenVisible;
+export const getIsRemoveArtifactoryTokenVisible = (state: RootState) =>
+    state.settings.isRemoveArtifactoryTokenVisible;
 export const getUseChineseAppServer = (state: RootState) =>
     state.settings.useChineseAppServer;

--- a/src/launcher/features/sources/MissingTokenWarning.tsx
+++ b/src/launcher/features/sources/MissingTokenWarning.tsx
@@ -74,9 +74,9 @@ export default () => {
             {isWarningAboutMissingTokenOnAddSource(missingTokenWarning) && (
                 <p>
                     For accessing the source at the URL{' '}
-                    <code>{missingTokenWarning.sourceToAdd}</code> an
-                    Artifactory token is required but you have not set one yet.
-                    Without providing a token, using the source will fail.
+                    <code>{missingTokenWarning.sourceToAdd}</code> an identity
+                    token is required but you have not set one yet. Without
+                    providing a token, using the source will fail.
                 </p>
             )}
             {isWarningAboutMissingTokenOnMigratingSources(
@@ -84,9 +84,9 @@ export default () => {
             ) && (
                 <>
                     <p>
-                        For accessing the following sources, an Artifactory
-                        token is now required. Without providing a token, using
-                        the source will fail.
+                        For accessing the following sources, an identity token
+                        is now required. Without providing a token, using the
+                        source will fail.
                     </p>
                     <ul>
                         {missingTokenWarning.sourcesWithRestrictedAccessLevel.map(

--- a/src/launcher/features/sources/MissingTokenWarning.tsx
+++ b/src/launcher/features/sources/MissingTokenWarning.tsx
@@ -100,7 +100,7 @@ export default () => {
             <p>
                 To get a token, go to{' '}
                 <ExternalLink href="https://files.nordicsemi.com/ui/user_profile" />
-                , log in and generate an Identity Token there. As Nordic
+                , log in and generate an identity token there. As Nordic
                 employee, you should be able to log in, otherwise ask your
                 Nordic contact for an account if you are eligible.
             </p>

--- a/src/launcher/features/sources/MissingTokenWarning.tsx
+++ b/src/launcher/features/sources/MissingTokenWarning.tsx
@@ -100,9 +100,11 @@ export default () => {
             <p>
                 To get a token, go to{' '}
                 <ExternalLink href="https://files.nordicsemi.com/ui/user_profile" />
-                , log in and generate an identity token there. As Nordic
-                employee, you should be able to log in, otherwise ask your
-                Nordic contact for an account if you are eligible.
+                , log in, and generate an identity token there.
+            </p>
+            <p>
+                As Nordic employee, you are able to log in. If not a Nordic
+                employee, ask your Nordic contact for an account.
             </p>
             <p className="tw-m-0">Paste the token here:</p>
             <Form onSubmit={storeTokenAndAddSource} className="tw-pb-4">


### PR DESCRIPTION
Mitigates some of [NCD-1287](https://nordicsemi.atlassian.net/browse/NCD-1287):

The button to remove the Artifactory token was renamed from “Forget” to “Remove”. “Forget” was a strange and rather unusual term, which might confuse people:

![Screenshot 2025-04-08 at 12 11 19](https://github.com/user-attachments/assets/92e95699-b908-401e-b583-103fd1c8c514)

After clicking on that button, the token was previously just removed, without informing the users of the consequence. This is now changed. If the user does not have any sources added which require the token now this dialog is shown:

![image](https://github.com/user-attachments/assets/6efa31a1-254c-49bf-b553-187d27e8f930)

If, more grave, the user also has non-external sources added which require the token, then those are listed and the situation is also explained:

![image](https://github.com/user-attachments/assets/f621dfa3-d3e0-49b1-9d2a-4719e1c108d6)

### Small things

Also did some small rewordings, especially purged all mentions of “Artifactory” since we didn't want to reflect this in the UI.