### PR TITLE
Artifactory: Update missing token warning

### DIFF
--- a/src/common/legacySource.ts
+++ b/src/common/legacySource.ts
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-import type { Source } from '../ipc/sources';
-
 export const isLegacyUrl = (url: string) =>
     url.match(/^https?:\/\/developer\.nordicsemi\.com\//);
 
@@ -30,21 +28,3 @@ export const migrateURL = (url: string) =>
 
 export const migrateAllURLsInJSON = (json: string) =>
     json.replace(/"https?:[^"]*"/g, migrateURL);
-
-const deprecatedSources = [
-    'toolchain-manager',
-    '3.8-release-test',
-    'neutrino-external',
-    'neutrino-internal',
-    'crasher',
-    'internal',
-    'experimental',
-];
-
-const deprecatedSourceURLs = deprecatedSources.map(
-    name =>
-        `https://files.nordicsemi.com/artifactory/swtools/internal/ncd/apps/${name}/source.json`
-);
-
-export const isDeprecatedSource = (url: Source) =>
-    deprecatedSourceURLs.includes(url.url);

--- a/src/common/persistedStore.ts
+++ b/src/common/persistedStore.ts
@@ -8,7 +8,7 @@ import Store from 'electron-store';
 
 import packageJson from '../../package.json';
 import type { TokenInformation } from '../ipc/artifactoryToken';
-import type { SourceName } from '../ipc/sources';
+import type { SourceName } from './sources';
 
 type WindowState = {
     x?: number;

--- a/src/common/persistedStore.ts
+++ b/src/common/persistedStore.ts
@@ -40,7 +40,6 @@ interface Schema {
     encryptedArtifactoryToken?: string;
     artifactoryTokenInformation?: TokenInformation;
     doNotRemindDeprecatedSources?: boolean;
-    wasWarnedOnMissingTokenAndMigratedSources?: boolean;
     useChineseAppServer?: boolean;
 }
 
@@ -124,11 +123,6 @@ export const getDoNotRemindDeprecatedSources = () =>
     store.get('doNotRemindDeprecatedSources', false);
 export const setDoNotRemindDeprecatedSources = () =>
     store.set('doNotRemindDeprecatedSources', true);
-
-export const wasWarnedOnMissingTokenAndMigratedSources = () =>
-    store.get('wasWarnedOnMissingTokenAndMigratedSources', false);
-export const setWarnedOnMissingTokenAndMigratedSources = () =>
-    store.set('wasWarnedOnMissingTokenAndMigratedSources', true);
 
 export const getUseChineseAppServer = () =>
     store.get('useChineseAppServer', false);

--- a/src/common/persistedStore.ts
+++ b/src/common/persistedStore.ts
@@ -40,6 +40,7 @@ interface Schema {
     encryptedArtifactoryToken?: string;
     artifactoryTokenInformation?: TokenInformation;
     doNotRemindDeprecatedSources?: boolean;
+    doNotRemindOnMissingToken?: boolean;
     useChineseAppServer?: boolean;
 }
 
@@ -123,6 +124,11 @@ export const getDoNotRemindDeprecatedSources = () =>
     store.get('doNotRemindDeprecatedSources', false);
 export const setDoNotRemindDeprecatedSources = () =>
     store.set('doNotRemindDeprecatedSources', true);
+
+export const getDoNotRemindOnMissingToken = () =>
+    store.get('doNotRemindOnMissingToken', false);
+export const setDoNotRemindOnMissingToken = () =>
+    store.set('doNotRemindOnMissingToken', true);
 
 export const getUseChineseAppServer = () =>
     store.get('useChineseAppServer', false);

--- a/src/common/sources.ts
+++ b/src/common/sources.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import {
+    allStandardSourceNames,
+    LOCAL,
+    OFFICIAL,
+    Source,
+    SourceName,
+    SourceUrl,
+} from '@nordicsemiconductor/pc-nrfconnect-shared/ipc/sources';
+
+export {
+    allStandardSourceNames,
+    LOCAL,
+    OFFICIAL,
+    type Source,
+    type SourceName,
+    type SourceUrl,
+};
+
+export const hasRestrictedAccessLevel = (url: SourceUrl) =>
+    url.startsWith(
+        'https://files.nordicsemi.com/artifactory/swtools/internal'
+    ) ||
+    url.startsWith(
+        'https://files.nordicsemi.com/artifactory/swtools/external-confidential'
+    ) ||
+    url.startsWith(
+        'https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=internal'
+    ) ||
+    url.startsWith(
+        'https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=external-confidential'
+    );
+
+const deprecatedSources = [
+    'toolchain-manager',
+    '3.8-release-test',
+    'neutrino-external',
+    'neutrino-internal',
+    'crasher',
+    'internal',
+    'experimental',
+];
+
+const deprecatedSourceURLs = deprecatedSources.map(
+    name =>
+        `https://files.nordicsemi.com/artifactory/swtools/internal/ncd/apps/${name}/source.json`
+);
+
+export const isDeprecatedSource = (url: Source) =>
+    deprecatedSourceURLs.includes(url.url);

--- a/src/ipc/sources.ts
+++ b/src/ipc/sources.ts
@@ -8,25 +8,9 @@ import {
     handle,
     invoke,
 } from '@nordicsemiconductor/pc-nrfconnect-shared/ipc/infrastructure/rendererToMain';
-import {
-    allStandardSourceNames,
-    LOCAL,
-    OFFICIAL,
-    Source,
-    SourceName,
-    SourceUrl,
-} from '@nordicsemiconductor/pc-nrfconnect-shared/ipc/sources';
 
+import type { Source, SourceName, SourceUrl } from '../common/sources';
 import type { DownloadableApp } from './apps';
-
-export {
-    allStandardSourceNames,
-    LOCAL,
-    OFFICIAL,
-    type Source,
-    type SourceName,
-    type SourceUrl,
-};
 
 const channel = {
     get: 'sources:get',

--- a/src/launcher/features/apps/App/App.tsx
+++ b/src/launcher/features/apps/App/App.tsx
@@ -11,8 +11,8 @@ import DropdownButton from 'react-bootstrap/DropdownButton';
 import ListGroup from 'react-bootstrap/ListGroup';
 import Row from 'react-bootstrap/Row';
 
+import { OFFICIAL } from '../../../../common/sources';
 import { isInstalled, isUpdatable, isWithdrawn } from '../../../../ipc/apps';
-import { OFFICIAL } from '../../../../ipc/sources';
 import formatPublishTimestamp from '../../../util/formatTimestamp';
 import { DisplayedApp } from '../appsSlice';
 import AppIcon from './AppIcon';

--- a/src/launcher/features/apps/appsSlice.ts
+++ b/src/launcher/features/apps/appsSlice.ts
@@ -13,6 +13,11 @@ import {
     setLastUpdateCheckDate,
 } from '../../../common/persistedStore';
 import {
+    allStandardSourceNames,
+    OFFICIAL,
+    SourceName,
+} from '../../../common/sources';
+import {
     App,
     AppSpec,
     DownloadableApp,
@@ -25,11 +30,6 @@ import {
     LocalApp,
 } from '../../../ipc/apps';
 import { Progress } from '../../../ipc/downloadProgress';
-import {
-    allStandardSourceNames,
-    OFFICIAL,
-    SourceName,
-} from '../../../ipc/sources';
 import type { RootState } from '../../store';
 import { getAppsFilter } from '../filter/filterSlice';
 

--- a/src/launcher/features/filter/filterSlice.ts
+++ b/src/launcher/features/filter/filterSlice.ts
@@ -16,8 +16,8 @@ import {
     setShownStates as setPersistedShownStates,
     type ShownStates,
 } from '../../../common/persistedStore';
+import { SourceName } from '../../../common/sources';
 import { App, isInstalled } from '../../../ipc/apps';
-import { SourceName } from '../../../ipc/sources';
 import type { RootState } from '../../store';
 
 export type State = {

--- a/src/launcher/features/initialisation/initialiseLauncherState.ts
+++ b/src/launcher/features/initialisation/initialiseLauncherState.ts
@@ -12,6 +12,7 @@ import {
 
 import cleanIpcErrorMessage from '../../../common/cleanIpcErrorMessage';
 import { isDeprecatedSource } from '../../../common/legacySource';
+import { getDoNotRemindOnMissingToken } from '../../../common/persistedStore';
 import { inMain } from '../../../ipc/apps';
 import { inMain as artifactoryToken } from '../../../ipc/artifactoryToken';
 import { inMain as sources } from '../../../ipc/sources';
@@ -111,6 +112,8 @@ const checkForDeprecatedSources =
 const checkForMissingToken =
     (): AppThunk<undefined | typeof INTERRUPT_INITIALISATION> =>
     (dispatch, getState) => {
+        if (getDoNotRemindOnMissingToken()) return;
+
         const token = getArtifactoryTokenInformation(getState());
         const sourcesWithRestrictedAccessLevel = getSources(getState()).filter(
             source => hasRestrictedAccessLevel(source.url)

--- a/src/launcher/features/initialisation/initialiseLauncherState.ts
+++ b/src/launcher/features/initialisation/initialiseLauncherState.ts
@@ -11,8 +11,11 @@ import {
 } from '@nordicsemiconductor/pc-nrfconnect-shared';
 
 import cleanIpcErrorMessage from '../../../common/cleanIpcErrorMessage';
-import { isDeprecatedSource } from '../../../common/legacySource';
 import { getDoNotRemindOnMissingToken } from '../../../common/persistedStore';
+import {
+    hasRestrictedAccessLevel,
+    isDeprecatedSource,
+} from '../../../common/sources';
 import { inMain } from '../../../ipc/apps';
 import { inMain as artifactoryToken } from '../../../ipc/artifactoryToken';
 import { inMain as sources } from '../../../ipc/sources';
@@ -28,10 +31,7 @@ import {
     getShouldCheckForUpdatesAtStartup,
     setArtifactoryTokenInformation,
 } from '../settings/settingsSlice';
-import {
-    handleSourcesWithErrors,
-    hasRestrictedAccessLevel,
-} from '../sources/sourcesEffects';
+import { handleSourcesWithErrors } from '../sources/sourcesEffects';
 import {
     getDoNotRemindDeprecatedSources,
     getSources,

--- a/src/launcher/features/settings/Cards/AppSources.tsx
+++ b/src/launcher/features/settings/Cards/AppSources.tsx
@@ -18,7 +18,7 @@ import Col from 'react-bootstrap/Col';
 import Row from 'react-bootstrap/Row';
 import { clipboard } from 'electron';
 
-import { OFFICIAL } from '../../../../ipc/sources';
+import { OFFICIAL } from '../../../../common/sources';
 import { useLauncherDispatch, useLauncherSelector } from '../../../util/hooks';
 import {
     getSources,

--- a/src/launcher/features/settings/RemoveArtifactoryTokenDialog.tsx
+++ b/src/launcher/features/settings/RemoveArtifactoryTokenDialog.tsx
@@ -12,9 +12,9 @@ import {
 } from '@nordicsemiconductor/pc-nrfconnect-shared';
 
 import cleanIpcErrorMessage from '../../../common/cleanIpcErrorMessage';
+import { hasRestrictedAccessLevel } from '../../../common/sources';
 import { inMain as artifactoryToken } from '../../../ipc/artifactoryToken';
 import { useLauncherDispatch, useLauncherSelector } from '../../util/hooks';
-import { hasRestrictedAccessLevel } from '../sources/sourcesEffects';
 import { getSources } from '../sources/sourcesSlice';
 import {
     getIsRemoveArtifactoryTokenVisible,

--- a/src/launcher/features/sources/MissingTokenWarning.tsx
+++ b/src/launcher/features/sources/MissingTokenWarning.tsx
@@ -91,7 +91,7 @@ export default () => {
                     For accessing the source at the URL{' '}
                     <code>{missingTokenWarning.sourceToAdd}</code> an identity
                     token is required but you have not set one yet. Without
-                    providing a token, is it not possible to add this source.
+                    providing a token, it is not possible to add this source.
                 </p>
             )}
             {isWarningAboutMissingTokenOnStartup(missingTokenWarning) && (

--- a/src/launcher/features/sources/MissingTokenWarning.tsx
+++ b/src/launcher/features/sources/MissingTokenWarning.tsx
@@ -19,7 +19,7 @@ import {
     getMissingTokenWarning,
     hideWarningAboutMissingToken,
     isWarningAboutMissingTokenOnAddSource,
-    isWarningAboutMissingTokenOnMigratingSources,
+    isWarningAboutMissingTokenOnStartup,
 } from './sourcesSlice';
 
 export default () => {
@@ -44,7 +44,7 @@ export default () => {
                 })
             );
 
-        if (isWarningAboutMissingTokenOnMigratingSources(missingTokenWarning))
+        if (isWarningAboutMissingTokenOnStartup(missingTokenWarning))
             dispatch(initialiseLauncherState());
     };
 
@@ -79,14 +79,13 @@ export default () => {
                     providing a token, using the source will fail.
                 </p>
             )}
-            {isWarningAboutMissingTokenOnMigratingSources(
-                missingTokenWarning
-            ) && (
+            {isWarningAboutMissingTokenOnStartup(missingTokenWarning) && (
                 <>
                     <p>
                         For accessing the following sources, an identity token
-                        is now required. Without providing a token, using the
-                        source will fail.
+                        is required. Without providing a token, the source will
+                        not be updated, and trying to install apps from them
+                        will fail.
                     </p>
                     <ul>
                         {missingTokenWarning.sourcesWithRestrictedAccessLevel.map(

--- a/src/launcher/features/sources/MissingTokenWarning.tsx
+++ b/src/launcher/features/sources/MissingTokenWarning.tsx
@@ -11,6 +11,7 @@ import {
     ExternalLink,
 } from '@nordicsemiconductor/pc-nrfconnect-shared';
 
+import { setDoNotRemindOnMissingToken } from '../../../common/persistedStore';
 import { useLauncherDispatch, useLauncherSelector } from '../../util/hooks';
 import initialiseLauncherState from '../initialisation/initialiseLauncherState';
 import { setArtifactoryToken } from '../settings/settingsEffects';
@@ -68,7 +69,16 @@ export default () => {
             isVisible={isVisible}
             title="Missing token"
             confirmLabel="Set token"
+            optionalLabel={
+                isWarningAboutMissingTokenOnStartup(missingTokenWarning)
+                    ? 'Do not remind me again'
+                    : undefined
+            }
             onConfirm={storeTokenAndAddSource}
+            onOptional={() => {
+                setDoNotRemindOnMissingToken();
+                hideDialog();
+            }}
             onCancel={() => hideDialog()}
         >
             {isWarningAboutMissingTokenOnAddSource(missingTokenWarning) && (

--- a/src/launcher/features/sources/MissingTokenWarning.tsx
+++ b/src/launcher/features/sources/MissingTokenWarning.tsx
@@ -38,13 +38,6 @@ export default () => {
             return;
         }
 
-        if (isWarningAboutMissingTokenOnAddSource(missingTokenWarning))
-            dispatch(
-                addSource(missingTokenWarning.sourceToAdd, {
-                    warnOnMissingToken: false,
-                })
-            );
-
         if (isWarningAboutMissingTokenOnStartup(missingTokenWarning))
             dispatch(initialiseLauncherState());
     };
@@ -61,6 +54,13 @@ export default () => {
             return;
         }
 
+        if (isWarningAboutMissingTokenOnAddSource(missingTokenWarning))
+            dispatch(
+                addSource(missingTokenWarning.sourceToAdd, {
+                    warnOnMissingToken: false,
+                })
+            );
+
         hideDialog();
     };
 
@@ -69,6 +69,11 @@ export default () => {
             isVisible={isVisible}
             title="Missing token"
             confirmLabel="Set token"
+            cancelLabel={
+                isWarningAboutMissingTokenOnAddSource(missingTokenWarning)
+                    ? 'Cancel adding source'
+                    : 'Cancel'
+            }
             optionalLabel={
                 isWarningAboutMissingTokenOnStartup(missingTokenWarning)
                     ? 'Do not remind me again'
@@ -86,7 +91,7 @@ export default () => {
                     For accessing the source at the URL{' '}
                     <code>{missingTokenWarning.sourceToAdd}</code> an identity
                     token is required but you have not set one yet. Without
-                    providing a token, using the source will fail.
+                    providing a token, is it not possible to add this source.
                 </p>
             )}
             {isWarningAboutMissingTokenOnStartup(missingTokenWarning) && (

--- a/src/launcher/features/sources/sourcesEffects.ts
+++ b/src/launcher/features/sources/sourcesEffects.ts
@@ -9,15 +9,15 @@ import { AnyAction } from 'redux';
 
 import cleanIpcErrorMessage from '../../../common/cleanIpcErrorMessage';
 import { isLegacyUrl } from '../../../common/legacySource';
-import { SourceWithError } from '../../../ipc/apps';
 import {
-    AddSourceError,
-    inMain as sources,
+    hasRestrictedAccessLevel,
     OFFICIAL,
     Source,
     SourceName,
     SourceUrl,
-} from '../../../ipc/sources';
+} from '../../../common/sources';
+import { SourceWithError } from '../../../ipc/apps';
+import { AddSourceError, inMain as sources } from '../../../ipc/sources';
 import type { AppThunk } from '../../store';
 import { addDownloadableApps, removeAppsOfSource } from '../apps/appsSlice';
 import { hideSource, showSource } from '../filter/filterSlice';
@@ -49,20 +49,6 @@ const showError = (url: string, addSourceError: AddSourceError): AnyAction => {
             );
     }
 };
-
-export const hasRestrictedAccessLevel = (url: SourceUrl) =>
-    url.startsWith(
-        'https://files.nordicsemi.com/artifactory/swtools/internal'
-    ) ||
-    url.startsWith(
-        'https://files.nordicsemi.com/artifactory/swtools/external-confidential'
-    ) ||
-    url.startsWith(
-        'https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=internal'
-    ) ||
-    url.startsWith(
-        'https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=external-confidential'
-    );
 
 export const addSource =
     (

--- a/src/launcher/features/sources/sourcesSlice.ts
+++ b/src/launcher/features/sources/sourcesSlice.ts
@@ -26,19 +26,19 @@ export const isWarningAboutMissingTokenOnAddSource = (
 ): warning is WarnAboutMissingTokenOnAddSource =>
     warning.isVisible && 'sourceToAdd' in warning;
 
-type WarnAboutMissingTokenOnMigratingSources = {
+type WarnAboutMissingTokenOnStartup = {
     isVisible: true;
     sourcesWithRestrictedAccessLevel: Source[];
 };
-export const isWarningAboutMissingTokenOnMigratingSources = (
+export const isWarningAboutMissingTokenOnStartup = (
     warning: MissingTokenWarning
-): warning is WarnAboutMissingTokenOnMigratingSources =>
+): warning is WarnAboutMissingTokenOnStartup =>
     warning.isVisible && 'sourcesWithRestrictedAccessLevel' in warning;
 
 type MissingTokenWarning =
     | Hidden
     | WarnAboutMissingTokenOnAddSource
-    | WarnAboutMissingTokenOnMigratingSources;
+    | WarnAboutMissingTokenOnStartup;
 
 export type State = {
     sources: Source[];
@@ -129,7 +129,7 @@ const slice = createSlice({
                 sourceToAdd,
             };
         },
-        warnAboutMissingTokenOnMigratingSources(
+        warnAboutMissingTokenOnStartup(
             state,
             { payload: sources }: PayloadAction<Source[]>
         ) {
@@ -160,7 +160,7 @@ export const {
     warnAddLegacySource,
     clearSourceToAdd,
     warnAboutMissingTokenOnAddSource,
-    warnAboutMissingTokenOnMigratingSources,
+    warnAboutMissingTokenOnStartup,
     hideWarningAboutMissingToken,
 } = slice.actions;
 

--- a/src/launcher/features/sources/sourcesSlice.ts
+++ b/src/launcher/features/sources/sourcesSlice.ts
@@ -11,7 +11,7 @@ import {
     getDoNotRemindDeprecatedSources as getPersistedDoNotRemindDeprecatedSources,
     setDoNotRemindDeprecatedSources as setPersistedDoNotRemindDeprecatedSources,
 } from '../../../common/persistedStore';
-import { Source, SourceName, SourceUrl } from '../../../ipc/sources';
+import { Source, SourceName, SourceUrl } from '../../../common/sources';
 import type { RootState } from '../../store';
 
 type Hidden = typeof hidden;

--- a/src/main/apps/app.ts
+++ b/src/main/apps/app.ts
@@ -11,6 +11,7 @@ import {
 import fs from 'fs-extra';
 import path, { basename } from 'path';
 
+import { LOCAL, Source, SourceName } from '../../common/sources';
 import {
     AppSpec,
     DownloadableApp,
@@ -18,7 +19,6 @@ import {
     LocalApp,
     WithdrawnApp,
 } from '../../ipc/apps';
-import { LOCAL, Source, SourceName } from '../../ipc/sources';
 import { getAppsLocalDir, getAppsRootDir, getNodeModulesDir } from '../config';
 import { ifExists, readFile, readJsonFile, writeJsonFile } from '../fileUtil';
 import { appResourceProperties } from './appResource';

--- a/src/main/apps/appResource.ts
+++ b/src/main/apps/appResource.ts
@@ -7,8 +7,8 @@
 import { AppInfo } from '@nordicsemiconductor/pc-nrfconnect-shared/main';
 import path from 'path';
 
+import type { SourceName } from '../../common/sources';
 import type { AppSpec } from '../../ipc/apps';
-import type { SourceName } from '../../ipc/sources';
 import { getAppsRootDir } from '../config';
 import describeError from '../describeError';
 import { readFile } from '../fileUtil';

--- a/src/main/apps/apps.ts
+++ b/src/main/apps/apps.ts
@@ -8,6 +8,7 @@ import { AppInfo } from '@nordicsemiconductor/pc-nrfconnect-shared/main';
 import { omit } from 'lodash';
 import path, { basename } from 'path';
 
+import { Source } from '../../common/sources';
 import {
     AppWithError,
     DownloadableApp,
@@ -17,7 +18,6 @@ import {
     UninstalledDownloadableApp,
 } from '../../ipc/apps';
 import { inRenderer } from '../../ipc/showErrorDialog';
-import { Source } from '../../ipc/sources';
 import { getAppsLocalDir } from '../config';
 import describeError from '../describeError';
 import { listDirectories } from '../fileUtil';

--- a/src/main/apps/createDesktopShortcut.ts
+++ b/src/main/apps/createDesktopShortcut.ts
@@ -9,9 +9,9 @@ import Mustache from 'mustache';
 import path from 'path';
 import { uuid } from 'short-uuid';
 
+import { OFFICIAL } from '../../common/sources';
 import { isDownloadable, LaunchableApp } from '../../ipc/apps';
 import { inRenderer } from '../../ipc/showErrorDialog';
-import { OFFICIAL } from '../../ipc/sources';
 import argv from '../argv';
 import { chmod, chmodDir, copy, readFile, untar, writeFile } from '../fileUtil';
 import { getShortcutIcon } from '../icons';

--- a/src/main/apps/dataMigration/legacyMetaFiles.ts
+++ b/src/main/apps/dataMigration/legacyMetaFiles.ts
@@ -11,7 +11,7 @@ import {
 import fs from 'fs-extra';
 import path from 'path';
 
-import { Source } from '../../../ipc/sources';
+import { Source } from '../../../common/sources';
 import { getAppsRootDir, getNodeModulesDir } from '../../config';
 import { readFile, readJsonFile } from '../../fileUtil';
 import { installedAppPath, writeAppInfo } from '../app';

--- a/src/main/apps/sources/sourceChanges.ts
+++ b/src/main/apps/sources/sourceChanges.ts
@@ -8,13 +8,13 @@ import { SourceJson } from '@nordicsemiconductor/pc-nrfconnect-shared/main';
 import fs from 'fs-extra';
 
 import {
-    AddSourceResult,
     allStandardSourceNames,
     OFFICIAL,
     Source,
     SourceName,
     SourceUrl,
-} from '../../../ipc/sources';
+} from '../../../common/sources';
+import { type AddSourceResult } from '../../../ipc/sources';
 import { getAppsRootDir } from '../../config';
 import describeError from '../../describeError';
 import { addDownloadAppData } from '../app';

--- a/src/main/apps/sources/sourceJson.ts
+++ b/src/main/apps/sources/sourceJson.ts
@@ -11,7 +11,7 @@ import {
 import fs from 'fs-extra';
 import path from 'path';
 
-import { Source, SourceUrl } from '../../../ipc/sources';
+import { Source, SourceUrl } from '../../../common/sources';
 import { getAppsRootDir } from '../../config';
 import { readSchemedJsonFile, writeSchemedJsonFile } from '../../fileUtil';
 import { downloadToJson } from '../../net';

--- a/src/main/apps/sources/sources.ts
+++ b/src/main/apps/sources/sources.ts
@@ -7,8 +7,8 @@
 import fs from 'fs-extra';
 import path from 'path';
 
+import { OFFICIAL, Source, SourceName } from '../../../common/sources';
 import { SourceWithError } from '../../../ipc/apps';
-import { OFFICIAL, Source, SourceName } from '../../../ipc/sources';
 import {
     getAppsRootDir,
     getBundledResourcesDir,

--- a/src/main/apps/sources/sources.ts
+++ b/src/main/apps/sources/sources.ts
@@ -7,8 +7,14 @@
 import fs from 'fs-extra';
 import path from 'path';
 
-import { OFFICIAL, Source, SourceName } from '../../../common/sources';
+import {
+    hasRestrictedAccessLevel,
+    OFFICIAL,
+    Source,
+    SourceName,
+} from '../../../common/sources';
 import { SourceWithError } from '../../../ipc/apps';
+import { retrieveToken } from '../../artifactoryTokenStorage';
 import {
     getAppsRootDir,
     getBundledResourcesDir,
@@ -99,8 +105,12 @@ export const downloadAllSources = async () => {
     const successful: Source[] = [];
     const erroneos: SourceWithError[] = [];
 
+    const hasToken = retrieveToken() != null;
+
     await Promise.allSettled(
         sources.map(async source => {
+            if (!hasToken && hasRestrictedAccessLevel(source.url)) return;
+
             try {
                 const oldWithdrawnJson = readWithdrawnJson(source);
                 const oldSourceJson = readSourceJson(source);

--- a/src/main/apps/sources/sourcesVersionedJson.ts
+++ b/src/main/apps/sources/sourcesVersionedJson.ts
@@ -9,7 +9,7 @@ import fs from 'fs-extra';
 import path from 'path';
 import { z } from 'zod';
 
-import { Source } from '../../../ipc/sources';
+import { Source } from '../../../common/sources';
 import { getAppsExternalDir } from '../../config';
 import describeError from '../../describeError';
 import { readSchemedJsonFile, writeSchemedJsonFile } from '../../fileUtil';

--- a/src/main/apps/sources/withdrawnJson.ts
+++ b/src/main/apps/sources/withdrawnJson.ts
@@ -11,7 +11,7 @@ import {
 } from '@nordicsemiconductor/pc-nrfconnect-shared/main';
 import path from 'path';
 
-import { Source } from '../../../ipc/sources';
+import { Source } from '../../../common/sources';
 import { getAppsRootDir } from '../../config';
 import { readSchemedJsonFile, writeSchemedJsonFile } from '../../fileUtil';
 

--- a/src/main/argv.ts
+++ b/src/main/argv.ts
@@ -10,7 +10,7 @@ import {
 } from '@nordicsemiconductor/pc-nrfconnect-shared/main';
 import parseArgs from 'minimist';
 
-import { OFFICIAL } from '../ipc/sources';
+import { OFFICIAL } from '../common/sources';
 
 const helpText = `
 Supported command line arguments:

--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -7,7 +7,7 @@
 import { app } from 'electron';
 import path from 'path';
 
-import { OFFICIAL, SourceName } from '../ipc/sources';
+import { OFFICIAL, SourceName } from '../common/sources';
 import argv from './argv';
 
 const appsRootDir =

--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -23,13 +23,13 @@ import {
     getLastWindowState,
     setLastWindowState,
 } from '../common/persistedStore';
+import { LOCAL } from '../common/sources';
 import {
     AppSpec,
     isInstalled,
     isQuickStartApp,
     LaunchableApp,
 } from '../ipc/apps';
-import { LOCAL } from '../ipc/sources';
 import { getDownloadableApps, getLocalApps } from './apps/apps';
 import argv, { appArguments, mergeAppArguments } from './argv';
 import { createWindow } from './browser';

--- a/src/test/testFixtures.tsx
+++ b/src/test/testFixtures.tsx
@@ -6,12 +6,12 @@
 
 import { lowerCase, startCase } from 'lodash';
 
+import { LOCAL, OFFICIAL } from '../common/sources';
 import {
     InstalledDownloadableApp,
     LocalApp,
     UninstalledDownloadableApp,
 } from '../ipc/apps';
-import { LOCAL, OFFICIAL } from '../ipc/sources';
 
 const path = (appName: string) => `/path/to/${appName}`;
 // AppIcon.tsx rebuilds the path with path.sep


### PR DESCRIPTION
Group of smallish changes:
- When users habe non-public sources and no token, we used to warn them only once. Now we warn them on every startup.
- But we add a “Do not remind me again” button to that, so they can get rid of the warning if they want to.
- If we do not have a token, we do not try to load updates for non-public any longer, since we anyhow know that it will fail and we informed the users about this before.
- When a user has no token, tries to add a non-public source, and then cancels the request to enter a token in the missing token warning, we previously still tried to load that source. Because of the missing token this always failed and lead to an error message and the source not being added. Now we do not even try to load the source, sparing the user from the error message and do not add the source right away.

With these changes, the wording in both variants of the missing token dialog was also updated. 

If the user tries to add a non-public source it now looks like this:

![image](https://github.com/user-attachments/assets/97c00cec-cb90-44e0-bdfb-023f4f68a50b)

If the user already has a non-public source from before it now looks like this:

![image](https://github.com/user-attachments/assets/6f7927e8-742f-4861-8b57-2fa068d3e760)
