### PR TITLE
Warn if people do not allow access to the keychain

### DIFF
--- a/src/ipc/artifactoryToken.ts
+++ b/src/ipc/artifactoryToken.ts
@@ -22,7 +22,10 @@ export type TokenInformation = {
 };
 
 // GetInformation
-type GetTokenInformation = () => Promise<TokenInformation> | undefined;
+type GetTokenInformation = () =>
+    | { type: 'No token set' }
+    | { type: 'Encryption not available' }
+    | { type: 'Success'; information: TokenInformation };
 
 const getTokenInformation = invoke<GetTokenInformation>(channel.getInformation);
 const registerGetTokenInformation = handle<GetTokenInformation>(

--- a/src/launcher/features/initialisation/initialiseLauncherState.ts
+++ b/src/launcher/features/initialisation/initialiseLauncherState.ts
@@ -78,8 +78,22 @@ const loadTokenInformation = (): AppThunk => async (dispatch, getState) => {
     if (!shouldCheckForUpdatesAtStartup) return;
 
     try {
-        const token = await artifactoryToken.getTokenInformation();
-        if (token != null) dispatch(setArtifactoryTokenInformation(token));
+        const informationResult = await artifactoryToken.getTokenInformation();
+
+        if (informationResult.type === 'Success')
+            dispatch(
+                setArtifactoryTokenInformation(informationResult.information)
+            );
+
+        if (informationResult.type === 'Encryption not available') {
+            dispatch(
+                ErrorDialogActions.showDialog(
+                    'You must grant nRF Connect for Desktop permission to access your Keychain. ' +
+                        'Otherwise restricted sources will not be updated and ' +
+                        'trying to install apps from them will fail.'
+                )
+            );
+        }
     } catch (error) {
         dispatch(
             ErrorDialogActions.showDialog(

--- a/src/main/apps/sources/sources.ts
+++ b/src/main/apps/sources/sources.ts
@@ -105,7 +105,7 @@ export const downloadAllSources = async () => {
     const successful: Source[] = [];
     const erroneos: SourceWithError[] = [];
 
-    const hasToken = retrieveToken() != null;
+    const hasToken = retrieveToken().type === 'Success';
 
     await Promise.allSettled(
         sources.map(async source => {

--- a/src/main/artifactoryToken.ts
+++ b/src/main/artifactoryToken.ts
@@ -9,11 +9,14 @@ import type { TokenInformation } from '../ipc/artifactoryToken';
 import { retrieveToken, storeToken } from './artifactoryTokenStorage';
 import { getArtifactoryTokenInformation } from './net';
 
-export const getTokenInformation = () => {
-    const token = retrieveToken();
-    if (token == null) return;
+export const getTokenInformation = async () => {
+    const tokenResult = retrieveToken();
+    if (tokenResult.type !== 'Success') return tokenResult;
 
-    return getArtifactoryTokenInformation(token);
+    return {
+        type: 'Success',
+        information: await getArtifactoryTokenInformation(tokenResult.token),
+    } as const;
 };
 
 export const setToken = async (token: string): Promise<TokenInformation> => {

--- a/src/main/artifactoryTokenStorage.ts
+++ b/src/main/artifactoryTokenStorage.ts
@@ -11,15 +11,22 @@ import {
     setEncryptedArtifactoryToken,
 } from '../common/persistedStore';
 
-export const retrieveToken = () => {
+export type RetrieveTokenResult =
+    | { type: 'No token set' }
+    | { type: 'Encryption not available' }
+    | { type: 'Success'; token: string };
+
+export const retrieveToken = (): RetrieveTokenResult => {
     const encryptedToken = getEncryptedArtifactoryToken();
-    if (encryptedToken == null) return;
+    if (encryptedToken == null) return { type: 'No token set' };
 
-    if (!safeStorage.isEncryptionAvailable()) {
-        throw new Error('Encryption not available');
-    }
+    if (!safeStorage.isEncryptionAvailable())
+        return { type: 'Encryption not available' };
 
-    return safeStorage.decryptString(Buffer.from(encryptedToken, 'base64'));
+    return {
+        type: 'Success',
+        token: safeStorage.decryptString(Buffer.from(encryptedToken, 'base64')),
+    };
 };
 
 export const storeToken = (token: string) => {

--- a/src/main/net.ts
+++ b/src/main/net.ts
@@ -37,10 +37,13 @@ const isPublicUrl = (url: string) =>
         'https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=external/'
     );
 
-const determineBearer = (url: string) =>
-    url.startsWith('https://files.nordicsemi.com/') && !isPublicUrl(url)
-        ? retrieveToken()
-        : undefined;
+const determineBearer = (url: string) => {
+    if (!url.startsWith('https://files.nordicsemi.com/') || isPublicUrl(url))
+        return;
+
+    const tokenResult = retrieveToken();
+    return tokenResult.type === 'Success' ? tokenResult.token : undefined;
+};
 
 export type NetError = Error & { statusCode?: number };
 


### PR DESCRIPTION
According to https://www.electronjs.org/docs/latest/api/safe-storage this warning should never show up on Windows. On Linux it is more complicated, since there may be a variety of options there. I do not want to make this too complicated, just give folks an idea why it failed after they didn't allow access to the keychain.

I am uncertain about this change, whether it really helps or rather opens up more edge cases, leading us to play Whac-A-Mole. What do you think?

The warning currently would look like this and it would come up on startup:
<img width="761" alt="image" src="https://github.com/user-attachments/assets/88bf1e92-9a44-4baf-ba1c-3b560af1e52d" />
