### PR TITLE
Fix opening files with spaces

### DIFF
--- a/src/main/open.ts
+++ b/src/main/open.ts
@@ -4,27 +4,15 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-import childProcess from 'child_process';
 import { shell } from 'electron';
 import fs from 'fs';
-import os from 'os';
 
 export const openFile = (filePath: string) => {
-    const exists = fs.existsSync(filePath);
-    if (!exists) {
+    if (!fs.existsSync(filePath)) {
         throw new Error(`Could not find file at path: ${filePath}`);
     }
 
-    const escapedPath = filePath.replace(/ /g, '\\ ');
-
-    // Could not find a method that works on all three platforms:
-    // * shell.openItem works on Windows and Linux but not on OSX
-    // * childProcess.execSync works on OSX but not on Windows
-    if (os.type() === 'Darwin') {
-        childProcess.execSync(`open ${escapedPath}`);
-    } else {
-        shell.openPath(filePath);
-    }
+    shell.openPath(filePath);
 };
 
 export const openUrl = (url: string) => {

--- a/src/main/open.ts
+++ b/src/main/open.ts
@@ -23,7 +23,7 @@ export const openFile = (filePath: string) => {
     if (os.type() === 'Darwin') {
         childProcess.execSync(`open ${escapedPath}`);
     } else {
-        shell.openPath(escapedPath);
+        shell.openPath(filePath);
     }
 };
 


### PR DESCRIPTION
I think occasionally users mentioned that they cannot open the log if there is a space in the path. Maybe this was caused by this. At least the code didn't work for me in other test cases when opening files which have spaces in them.

Also: The exception for macOS does not seem to be necessary anymore.
