### PR TITLE
Fix: Asking for token for deprecated sources

### DIFF
--- a/src/common/sources.ts
+++ b/src/common/sources.ts
@@ -51,5 +51,5 @@ const deprecatedSourceURLs = deprecatedSources.map(
         `https://files.nordicsemi.com/artifactory/swtools/internal/ncd/apps/${name}/source.json`
 );
 
-export const isDeprecatedSource = (url: Source) =>
-    deprecatedSourceURLs.includes(url.url);
+export const isDeprecatedSource = (source: Source) =>
+    deprecatedSourceURLs.includes(source.url);

--- a/src/launcher/features/initialisation/initialiseLauncherState.ts
+++ b/src/launcher/features/initialisation/initialiseLauncherState.ts
@@ -12,10 +12,7 @@ import {
 
 import cleanIpcErrorMessage from '../../../common/cleanIpcErrorMessage';
 import { getDoNotRemindOnMissingToken } from '../../../common/persistedStore';
-import {
-    hasRestrictedAccessLevel,
-    isDeprecatedSource,
-} from '../../../common/sources';
+import { isDeprecatedSource } from '../../../common/sources';
 import { inMain } from '../../../ipc/apps';
 import { inMain as artifactoryToken } from '../../../ipc/artifactoryToken';
 import { inMain as sources } from '../../../ipc/sources';
@@ -35,6 +32,7 @@ import { handleSourcesWithErrors } from '../sources/sourcesEffects';
 import {
     getDoNotRemindDeprecatedSources,
     getSources,
+    getSourcesWithRestrictedAccessLevel,
     setSources,
     showDeprecatedSources,
     warnAboutMissingTokenOnStartup,
@@ -132,9 +130,8 @@ const checkForMissingToken =
         if (getDoNotRemindOnMissingToken()) return;
 
         const token = getArtifactoryTokenInformation(getState());
-        const sourcesWithRestrictedAccessLevel = getSources(getState()).filter(
-            source => hasRestrictedAccessLevel(source.url)
-        );
+        const sourcesWithRestrictedAccessLevel =
+            getSourcesWithRestrictedAccessLevel(getState());
 
         if (token == null && sourcesWithRestrictedAccessLevel.length > 0) {
             dispatch(

--- a/src/launcher/features/settings/RemoveArtifactoryTokenDialog.tsx
+++ b/src/launcher/features/settings/RemoveArtifactoryTokenDialog.tsx
@@ -12,10 +12,9 @@ import {
 } from '@nordicsemiconductor/pc-nrfconnect-shared';
 
 import cleanIpcErrorMessage from '../../../common/cleanIpcErrorMessage';
-import { hasRestrictedAccessLevel } from '../../../common/sources';
 import { inMain as artifactoryToken } from '../../../ipc/artifactoryToken';
 import { useLauncherDispatch, useLauncherSelector } from '../../util/hooks';
-import { getSources } from '../sources/sourcesSlice';
+import { getSourcesWithRestrictedAccessLevel } from '../sources/sourcesSlice';
 import {
     getIsRemoveArtifactoryTokenVisible,
     hideRemoveArtifactoryToken,
@@ -25,8 +24,8 @@ import {
 export default () => {
     const dispatch = useLauncherDispatch();
     const isVisible = useLauncherSelector(getIsRemoveArtifactoryTokenVisible);
-    const nonPublicSources = useLauncherSelector(getSources).filter(source =>
-        hasRestrictedAccessLevel(source.url)
+    const nonPublicSources = useLauncherSelector(
+        getSourcesWithRestrictedAccessLevel
     );
 
     const hideDialog = () => dispatch(hideRemoveArtifactoryToken());

--- a/src/launcher/features/sources/DeprecatedSourcesDialog.tsx
+++ b/src/launcher/features/sources/DeprecatedSourcesDialog.tsx
@@ -56,8 +56,8 @@ export default () => {
                 ))}
             </ul>
             <p>
-                You will get an error message each time nRF Connect for Desktop
-                tries to update app information using these sources.
+                These sources will not be updated, and trying to install apps
+                from them will fail.
             </p>
             <p>
                 You can remove these sources. If you do, the apps you installed

--- a/src/launcher/features/sources/sourcesSlice.ts
+++ b/src/launcher/features/sources/sourcesSlice.ts
@@ -11,7 +11,13 @@ import {
     getDoNotRemindDeprecatedSources as getPersistedDoNotRemindDeprecatedSources,
     setDoNotRemindDeprecatedSources as setPersistedDoNotRemindDeprecatedSources,
 } from '../../../common/persistedStore';
-import { Source, SourceName, SourceUrl } from '../../../common/sources';
+import {
+    hasRestrictedAccessLevel,
+    isDeprecatedSource,
+    Source,
+    SourceName,
+    SourceUrl,
+} from '../../../common/sources';
 import type { RootState } from '../../store';
 
 type Hidden = typeof hidden;
@@ -165,6 +171,11 @@ export const {
 } = slice.actions;
 
 export const getSources = (state: RootState) => state.sources.sources;
+export const getSourcesWithRestrictedAccessLevel = (state: RootState) =>
+    state.sources.sources.filter(
+        source =>
+            hasRestrictedAccessLevel(source.url) && !isDeprecatedSource(source)
+    );
 export const getIsAddSourceVisible = (state: RootState) =>
     state.sources.isAddSourceVisible;
 export const getIsRemoveSourceVisible = (state: RootState) =>

--- a/src/main/apps/sources/sources.ts
+++ b/src/main/apps/sources/sources.ts
@@ -9,6 +9,7 @@ import path from 'path';
 
 import {
     hasRestrictedAccessLevel,
+    isDeprecatedSource,
     OFFICIAL,
     Source,
     SourceName,
@@ -110,6 +111,7 @@ export const downloadAllSources = async () => {
     await Promise.allSettled(
         sources.map(async source => {
             if (!hasToken && hasRestrictedAccessLevel(source.url)) return;
+            if (isDeprecatedSource(source)) return;
 
             try {
                 const oldWithdrawnJson = readWithdrawnJson(source);


### PR DESCRIPTION
Fixes [NCD-1318](https://nordicsemi.atlassian.net/browse/NCD-1318):

Hide deprecated sources from the “Missing token” and “Remove token” dialogs. 

Also, do not ask for updates to deprecated sources on the server (which would fail anyhow). To reflect this, the “Remove deprecated sources” dialog was also reworded a bit:

![image](https://github.com/user-attachments/assets/e298d071-6b7b-415c-9fc6-aca76c14945d)
