### PR TITLE
Fix: Migrating sources

### DIFF
--- a/src/common/legacySource.test.ts
+++ b/src/common/legacySource.test.ts
@@ -74,14 +74,14 @@ test('migrateAllURLsInJSON', () => {
     ).toBe(
         `{
   "homepage": "https://github.com/NordicPlayground/pc-nrfconnect-boilerplate",
-  "iconUrl": "https://files.nordicsemi.com/artifactory/swtools/external/ncd/apps/official/pc-nrfconnect-boilerplate.svg",
-  "releaseNotesUrl": "https://files.nordicsemi.com/artifactory/swtools/external/ncd/apps/3.7-apps/pc-nrfconnect-boilerplate-Changelog.md",
+  "iconUrl": "https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=external/ncd/apps/official/pc-nrfconnect-boilerplate.svg",
+  "releaseNotesUrl": "https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=external/ncd/apps/3.7-apps/pc-nrfconnect-boilerplate-Changelog.md",
   "versions": {
     "1.0.0": {
-      "tarballUrl": "https://files.nordicsemi.com/artifactory/swtools/external-confidential/ncd/apps/directionfinding/pc-nrfconnect-npm-1.0.0.tgz"
+      "tarballUrl": "https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=external-confidential/ncd/apps/directionfinding/pc-nrfconnect-npm-1.0.0.tgz"
     },
     "2.0.0": {
-      "tarballUrl": "https://files.nordicsemi.com/artifactory/swtools/internal/ncd/apps/secret/pc-nrfconnect-npm-2.0.0.tgz"
+      "tarballUrl": "https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=false&repoKey=swtools&path=internal/ncd/apps/secret/pc-nrfconnect-npm-2.0.0.tgz"
     }
   }
 }`

--- a/src/common/legacySource.ts
+++ b/src/common/legacySource.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
+import { urlWithDownloadApi } from '../main/net';
+
 export const isLegacyUrl = (url: string) =>
     url.match(/^https?:\/\/developer\.nordicsemi\.com\//);
 
@@ -27,4 +29,7 @@ export const migrateURL = (url: string) =>
         );
 
 export const migrateAllURLsInJSON = (json: string) =>
-    json.replace(/"https?:[^"]*"/g, migrateURL);
+    json.replace(
+        /"(https?:[^"]*)"/g,
+        (_, url) => `"${urlWithDownloadApi(migrateURL(url))}"`
+    );

--- a/src/main/net.ts
+++ b/src/main/net.ts
@@ -53,19 +53,22 @@ type DownloadOptions = {
     bearer?: string;
 };
 
-export const determineEffectiveUrl = (url: string) => {
-    let effectiveUrl = url;
-
+export const urlWithDownloadApi = (url: string) => {
     const shortArtifactoryUrlRegex =
         /^https:\/\/files\.nordicsemi\.(?<tld>cn|com)\/artifactory\/(?<repo>[^/]+)\/(?<path>.*)/;
-    const match = effectiveUrl.match(shortArtifactoryUrlRegex);
-    if (match != null) {
-        const {
-            groups: { tld, repo, path },
-        } = match as { groups: Record<string, string> };
+    const match = url.match(shortArtifactoryUrlRegex);
 
-        effectiveUrl = `https://files.nordicsemi.${tld}/ui/api/v1/download?isNativeBrowsing=false&repoKey=${repo}&path=${path}`;
-    }
+    if (match == null) return url;
+
+    const {
+        groups: { tld, repo, path },
+    } = match as { groups: Record<string, string> };
+
+    return `https://files.nordicsemi.${tld}/ui/api/v1/download?isNativeBrowsing=false&repoKey=${repo}&path=${path}`;
+};
+
+export const determineEffectiveUrl = (url: string) => {
+    let effectiveUrl = urlWithDownloadApi(url);
 
     if (isPublicUrl(effectiveUrl) && getUseChineseAppServer()) {
         effectiveUrl = effectiveUrl.replace(


### PR DESCRIPTION
This error was introduced when switching to also supporting short Artifactory URLs. In the files on the server we still use URLs with the download API (so they also work with old versions of the launcher). But when it comes to detect which apps are installed locally, we also compare these URLs, so they have to be identical in the case we migrate here.

STR:
1. Run launcher 5.1.0
2. Add Direction Viewer source https://developer.nordicsemi.com/.pc-tools/nrfconnect-apps/directionfinding/source.json
3. Install the Direction Viewer app
4. Run launcher 5.2.0
5. Set token

ER:
- Direction Viewer app shown as still normally installed (and being able to reinstall)

AR:
- Direction Viewer app shown as “not available for download anymore” (and if it is uninstalled, it vanishes, so it is impossible to install it again)