### PR TITLE
Harden against future broken nrfutils

### DIFF
--- a/src/main/configureElectronApp.ts
+++ b/src/main/configureElectronApp.ts
@@ -89,23 +89,8 @@ const copyNrfutil = () => {
 
     const nrfutilBundled = path.join(getBundledResourcesDir(), binName);
     const nrfutilInAppPath = path.join(getUserDataDir(), binName);
-    const nrfutilBundledStats = fse.statSync(nrfutilBundled);
 
-    const nrfutilInstalled = fse.existsSync(nrfutilInAppPath);
-    const installedNrfutilOlderThenBundledNrfutil =
-        nrfutilInstalled &&
-        Math.round(nrfutilBundledStats.mtimeMs) >
-            Math.round(fse.statSync(nrfutilInAppPath).mtimeMs);
-
-    if (!nrfutilInstalled || installedNrfutilOlderThenBundledNrfutil) {
-        fse.copyFileSync(nrfutilBundled, nrfutilInAppPath);
-        fse.utimes(
-            nrfutilInAppPath,
-            nrfutilBundledStats.atime,
-            nrfutilBundledStats.mtime
-        );
-        logger.info('update nrfutil exe');
-    }
+    fse.copyFileSync(nrfutilBundled, nrfutilInAppPath);
 };
 
 const copyNrfutilSandboxes = () => {

--- a/src/main/configureElectronApp.ts
+++ b/src/main/configureElectronApp.ts
@@ -84,7 +84,7 @@ const fatalError = (error: unknown) => {
     app.quit();
 };
 
-const initNrfutil = () => {
+const copyNrfutil = () => {
     const binName = `nrfutil${process.platform === 'win32' ? '.exe' : ''}`;
 
     const nrfutilBundled = path.join(getBundledResourcesDir(), binName);
@@ -106,7 +106,9 @@ const initNrfutil = () => {
         );
         logger.info('update nrfutil exe');
     }
+};
 
+const copyNrfutilSandboxes = () => {
     const nrfutilBundledSandboxes = path.join(
         getBundledResourcesDir(),
         'nrfutil-sandboxes'
@@ -130,6 +132,11 @@ const initNrfutil = () => {
     if (os.platform() !== 'win32') {
         execSync(`chmod -R 744 '${nrfutilBundledSandboxesDest}'`);
     }
+};
+
+const initNrfutil = () => {
+    copyNrfutil();
+    copyNrfutilSandboxes();
 };
 
 export default () => {


### PR DESCRIPTION
Always copy bundled `nrfutil` to user data dir.

Rationale: If a future launcher contains a `nrfutil` executable which does not work properly (like we see coming up for Ubuntu 20.04), we want to enable users to get back to a working launcher by installing an old launcher which still contains a working `nrfutil` executable. This is only possible if we always copy the bundled `nrfutil`, even if it is already there.