### PR TITLE
Fix: Asynchronicity of `openFile` and `openUrl`

### DIFF
--- a/Changelog.minor.md
+++ b/Changelog.minor.md
@@ -15,6 +15,7 @@ release the new version.
     with a space or on macOS with a semicolon in their names.
 -   #1120: App windows used to increase in size on every launch.
 -   #1122: Updated fs related code to not need fs-extra anymore.
+-   #1123: Asynchronicity of `openFile` and `openUrl`.
 
 ## 5.2.0
 

--- a/src/main/open.ts
+++ b/src/main/open.ts
@@ -5,19 +5,17 @@
  */
 
 import { shell } from 'electron';
-import fs from 'fs';
+import fs from 'node:fs';
 
 export const openFile = (filePath: string) => {
     if (!fs.existsSync(filePath)) {
         throw new Error(`Could not find file at path: ${filePath}`);
     }
 
-    shell.openPath(filePath);
+    return shell.openPath(filePath);
 };
 
-export const openUrl = (url: string) => {
-    shell.openExternal(url);
-};
+export const openUrl = (url: string) => shell.openExternal(url);
 
 export const openFileLocation = (filePath: string) => {
     shell.showItemInFolder(filePath);


### PR DESCRIPTION
`openFile` and `openUrl` did not pass through when the underlying async functions (e.g. `shell.openPath`) finished. This was not used anywhere, but this change at least opens up the possibility of using that in the future.