### PR TITLE
Specify core version of nrfutil

### DIFF
--- a/Changelog.minor.md
+++ b/Changelog.minor.md
@@ -9,6 +9,10 @@ release the new version.
 
 ## Unreleased
 
+### Changed
+
+-   #1125: Handle specifying the core version of nrfutil.
+
 ### Fixed
 
 -   #1116: Opening some files, e.g. log files, failed. E.g. on Windows and Linux

--- a/build/bundleApps.js
+++ b/build/bundleApps.js
@@ -16,12 +16,17 @@ const BUNDLE_APPS = ['pc-nrfconnect-quickstart'];
 
 const alreadyPreparedSandboxes = new Set();
 
-const bundleNrfutilModule = (module, version) => {
-    const key = `${module}-${version}}`;
+const bundleNrfutilModule = (module, version, coreVersion) => {
+    const key = `${module}-${version}-${coreVersion}`;
     if (alreadyPreparedSandboxes.has(key)) return; // Already bundled
+
     alreadyPreparedSandboxes.add(key);
 
-    console.log(`Bundling nrfutil module ${module} version ${version}`);
+    console.log(
+        `Bundling nrfutil module ${module} version ${version} and core ${
+            coreVersion ?? '(defaulting to 8.0.0)'
+        }`
+    );
 
     const nrfUtilBinary = path.join('resources', 'nrfutil');
     const env = {
@@ -32,14 +37,23 @@ const bundleNrfutilModule = (module, version) => {
             ...(process.platform === 'darwin' && process.arch !== 'x64'
                 ? [process.arch]
                 : []),
+            ...(coreVersion != null ? [coreVersion] : []),
             module,
             version
         ),
     };
 
+    execSync(
+        `${nrfUtilBinary} self-upgrade --to-version ${coreVersion ?? '8.0.0'}`,
+        { env }
+    );
     execSync(`${nrfUtilBinary} install ${module}=${version} --force`, { env });
 
-    console.log(`🏁 Bundled nrfutil module ${module} version ${version}`);
+    console.log(
+        `🏁 Bundled nrfutil module ${module} version ${version} and core ${
+            coreVersion ?? '(defaulting to 8.0.0)'
+        }`
+    );
 };
 
 const isAppBundled = appJSONUrl =>

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
             },
             "devDependencies": {
                 "@electron/notarize": "^2.2.0",
-                "@nordicsemiconductor/pc-nrfconnect-shared": "^210.0.0",
+                "@nordicsemiconductor/pc-nrfconnect-shared": "^212.0.0",
                 "@playwright/test": "^1.16.3",
                 "@testing-library/user-event": "^14.4.3",
                 "@types/chmodr": "1.0.0",
@@ -3105,9 +3105,9 @@
             }
         },
         "node_modules/@nordicsemiconductor/pc-nrfconnect-shared": {
-            "version": "210.0.0",
-            "resolved": "https://registry.npmjs.org/@nordicsemiconductor/pc-nrfconnect-shared/-/pc-nrfconnect-shared-210.0.0.tgz",
-            "integrity": "sha512-KphgF+dH1KWJ+gzC2HC8iQ3jI2+2BzTmu1tlM18r0w63alUBVvUCPy8afKxbk2HBkc0PMqgTskld2RRIlxJVoA==",
+            "version": "212.0.0",
+            "resolved": "https://registry.npmjs.org/@nordicsemiconductor/pc-nrfconnect-shared/-/pc-nrfconnect-shared-212.0.0.tgz",
+            "integrity": "sha512-8/fCcENlvItucaeWM/9F1hlH+27Uk4YNvaaEwXYV6vqo64YAvI6f+RfxySJ+yuTmRcLWjcPHP+wWGNJxr1eXfQ==",
             "dev": true,
             "hasInstallScript": true,
             "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     },
     "devDependencies": {
         "@electron/notarize": "^2.2.0",
-        "@nordicsemiconductor/pc-nrfconnect-shared": "^210.0.0",
+        "@nordicsemiconductor/pc-nrfconnect-shared": "^212.0.0",
         "@playwright/test": "^1.16.3",
         "@testing-library/user-event": "^14.4.3",
         "@types/chmodr": "1.0.0",

--- a/src/launcher/util/appCompatibilityWarning.tsx
+++ b/src/launcher/util/appCompatibilityWarning.tsx
@@ -166,17 +166,20 @@ const checkMinimalRequiredAppVersions: AppCompatibilityChecker = app => {
           );
 };
 
-const getJlinkCompatibility = memoize(async (nrfutilDeviceVersion: string) => {
-    const userDir = getUserDataDir();
-    const sandbox = await prepareSandbox(
-        userDir,
-        'device',
-        nrfutilDeviceVersion
-    );
-    const moduleVersion = await sandbox.getModuleVersion();
+const getJlinkCompatibility = memoize(
+    async (nrfutilDeviceVersion: string, nrfutilCoreVersion?: string) => {
+        const userDir = getUserDataDir();
+        const sandbox = await prepareSandbox(
+            userDir,
+            'device',
+            nrfutilDeviceVersion,
+            nrfutilCoreVersion
+        );
+        const moduleVersion = await sandbox.getModuleVersion();
 
-    return getJlinkCompatibilityFromModuleVersion(moduleVersion);
-});
+        return getJlinkCompatibilityFromModuleVersion(moduleVersion);
+    }
+);
 
 export const checkJLinkRequirements: AppCompatibilityChecker = async (
     app: LaunchableApp
@@ -186,12 +189,16 @@ export const checkJLinkRequirements: AppCompatibilityChecker = async (
     }
 
     const deviceVersion = app.nrfutil?.device?.at(0);
+    const coreVersion = app.nrfutilCore;
 
     if (!deviceVersion) {
         return undecided;
     }
 
-    const jlinkCompatibility = await getJlinkCompatibility(deviceVersion);
+    const jlinkCompatibility = await getJlinkCompatibility(
+        deviceVersion,
+        coreVersion
+    );
 
     if (jlinkCompatibility.kind === 'No J-Link installed') {
         const { requiredJlink } = jlinkCompatibility;

--- a/src/main/apps/app.ts
+++ b/src/main/apps/app.ts
@@ -144,6 +144,7 @@ export const addInstalledAppData = (
         html: packageJson.nrfConnectForDesktop?.html,
 
         nrfutil: packageJson.nrfConnectForDesktop?.nrfutil,
+        nrfutilCore: packageJson.nrfConnectForDesktop?.nrfutilCore,
     };
 };
 

--- a/src/main/apps/appChanges.ts
+++ b/src/main/apps/appChanges.ts
@@ -244,7 +244,11 @@ const download = async (app: AppSpec, version?: string) => {
             enableProxyLogin: true,
             app,
         }),
-        ...assertPreparedNrfutilModules(app, versionToInstall.nrfutilModules),
+        ...assertPreparedNrfutilModules(
+            app,
+            versionToInstall.nrfutilModules,
+            versionToInstall.nrfutilCore
+        ),
     ]);
     verifyShasum(packageFilePath, versionToInstall.shasum);
 


### PR DESCRIPTION
Accompanying PR to https://github.com/NordicSemiconductor/pc-nrfconnect-shared/pull/1000

Handle if apps specify do or do not specify the version of nrfutil-core they require:
- Create their nrfutil sandbox in the right place
- Create the bundled nrfutil sandbox with the right path

