### PR TITLE
Shorten workflow names

### DIFF
--- a/.github/actions/build-action/action.yml
+++ b/.github/actions/build-action/action.yml
@@ -1,4 +1,4 @@
-name: Build nRF Connect for Desktop
+name: Build
 
 runs:
     using: 'composite'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build nRF Connect for Desktop
+name: Build
 
 on:
     workflow_dispatch:

--- a/.github/workflows/build_darwin_arm64.yml
+++ b/.github/workflows/build_darwin_arm64.yml
@@ -1,4 +1,4 @@
-name: Build nRF Connect for Desktop for macOS arm64
+name: Build for macOS arm64
 
 on:
     workflow_dispatch:

--- a/.github/workflows/build_darwin_x64.yml
+++ b/.github/workflows/build_darwin_x64.yml
@@ -1,4 +1,4 @@
-name: Build nRF Connect for Desktop for macOS x64
+name: Build for macOS x64
 
 on:
     workflow_dispatch:

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -1,4 +1,4 @@
-name: Build nRF Connect for Desktop for Linux x64
+name: Build for Linux x64
 
 on:
     workflow_dispatch:

--- a/.github/workflows/build_win.yml
+++ b/.github/workflows/build_win.yml
@@ -1,4 +1,4 @@
-name: Build nRF Connect for Desktop for Windows x64
+name: Build for Windows x64
 
 on:
     workflow_dispatch:


### PR DESCRIPTION
The names were too long in the GitHub Actions UI and the relevant platform name at the end was only partially visible.