### PR TITLE
Fix apps wrongly shown as withdrawn

### DIFF
--- a/src/main/apps/sources/withdrawnJson.test.ts
+++ b/src/main/apps/sources/withdrawnJson.test.ts
@@ -27,7 +27,7 @@ test('computing the new list of withdrawn apps', () => {
         apps: [
             'http://example.org/oldAvailableApp.json',
             'http://example.org/newlyAvailableApp.json',
-            'http://example.org/revivedApp.json',
+            'http://example.org/under/new/path/revivedApp.json',
         ],
     };
 

--- a/src/main/apps/sources/withdrawnJson.ts
+++ b/src/main/apps/sources/withdrawnJson.ts
@@ -39,18 +39,20 @@ export const isInListOfWithdrawnApps = (
         appUrl.endsWith(`/${appinfoFilename}`)
     ) != null;
 
-const without = <T>(arr1: T[], arr2: T[]) =>
-    arr1.filter(element => !arr2.includes(element));
+const lastSegment = (url: string) => url.split('/').at(-1)!; // eslint-disable-line @typescript-eslint/no-non-null-assertion
+
+const without = (arr1: string[], arr2: string[]) =>
+    arr1.filter(element => !arr2.includes(lastSegment(element)));
 
 const stillWithdrawnApps = (
     oldWithdrawnJson: WithdrawnJson,
     newSourceJson: SourceJson
-) => without(oldWithdrawnJson, newSourceJson.apps);
+) => without(oldWithdrawnJson, newSourceJson.apps.map(lastSegment));
 
 const freshlyWithdrawnApps = (
     oldSourceJson: SourceJson,
     newSourceJson: SourceJson
-) => without(oldSourceJson.apps, newSourceJson.apps);
+) => without(oldSourceJson.apps, newSourceJson.apps.map(lastSegment));
 
 export const newWithdrawnJson = (
     oldWithdrawnJson: WithdrawnJson,


### PR DESCRIPTION
When jumping back and forth between launcher versions that use developer.nordicsemi.com and files.nordicsemi.com, apps may be incorrectly shown as withdrawn.

This is caused by them coming from different URLs on both servers, e.g. https://developer.nordicsemi.com/.pc-tools/nrfconnect-apps/release-test/pc-nrfconnect-npm.json on the old and
https://files.nordicsemi.com/artifactory/swtools/internal/ncd/apps/release-test/pc-nrfconnect-npm.json on the new one.

The fix here is to only compare the last segment of the URL.