### PR TITLE
Disable signature verification on Windows

### DIFF
--- a/Changelog.minor.md
+++ b/Changelog.minor.md
@@ -19,6 +19,7 @@ release the new version.
 -   #1133: Rewrote network code to use the fetch API.
 -   #1134: Collected knowledge about Artifactory URL in central place.
 -   #1149: Cleaned up the build workflows.
+-   #1136: Disable signature verification on Windows.
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
         "win": {
             "target": "nsis",
             "icon": "resources/icon.ico",
+            "verifyUpdateCodeSignature": false,
             "azureSignOptions": {
                 "publisherName": "Nordic Semiconductor ASA",
                 "endpoint": "https://weu.codesigning.azure.net",


### PR DESCRIPTION
For [NCD-1389](https://nordicsemi.atlassian.net/browse/NCD-1389):

Because we want to change the used signature for the next release.

https://www.electron.build/electron-builder.interface.windowsconfiguration#verifyupdatecodesignature

This change will later be undone by #1153.