### PR TITLE
Better download progress of apps

### DIFF
--- a/Changelog.minor.md
+++ b/Changelog.minor.md
@@ -20,6 +20,7 @@ release the new version.
 -   #1134: Collected knowledge about Artifactory URL in central place.
 -   #1149: Cleaned up the build workflows.
 -   #1136: Disable signature verification on Windows.
+-   #1163: Better implementation for download progress of apps.
 
 ### Fixed
 

--- a/src/common/artifactoryUrl.ts
+++ b/src/common/artifactoryUrl.ts
@@ -14,10 +14,6 @@ type ArtifactoryUrlMatch = {
     groups: ArtifactoryUrlSpec;
 } | null;
 
-export const isNordicArtifactoryUrl = (url: string) =>
-    url.startsWith('https://files.nordicsemi.com/') ||
-    url.startsWith('https://files.nordicsemi.cn/');
-
 export const shortNordicArtifactoryUrl = ({
     tld,
     repo,


### PR DESCRIPTION
Implements [NCD-1371](https://nordicsemi.atlassian.net/browse/NCD-1371):

Learned from Buran that we can get a `content-length` header from the server by setting the range header to `bytes=0-`.

The previous workaround also only worked for files from `external/`, the new implementation works for all files from Artifactory.