### PR TITLE
Fix: Error when running binary

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "build": {
         "appId": "com.nordicsemi.nrfconnect",
         "productName": "nRF Connect for Desktop",
+        "asarUnpack": "resources/nrfutil-sandboxes",
         "publish": {
             "provider": "generic",
             "url": "https://files.nordicsemi.com/artifactory/swtools/external/ncd/launcher/"

--- a/src/main/configureElectronApp.ts
+++ b/src/main/configureElectronApp.ts
@@ -94,10 +94,9 @@ const copyNrfutil = () => {
 };
 
 const copyNrfutilSandboxes = async () => {
-    const nrfutilBundledSandboxes = path.join(
-        getBundledResourcesDir(),
-        'nrfutil-sandboxes'
-    );
+    const nrfutilBundledSandboxes = path
+        .join(getBundledResourcesDir(), 'nrfutil-sandboxes')
+        .replace('app.asar', 'app.asar.unpacked');
 
     if (!fs.existsSync(nrfutilBundledSandboxes)) return;
 


### PR DESCRIPTION
Fixes a problem introduced in #1122.

`fs.cpSync` failed, when the source was in the asar archive. This only happened when running the binary, not when running from source because only in the binary an asar archive is used.

So now the files in nrfutil-sandboxes are unpacked from the asar archive to `app.asar.unpacked` and then copied from there.