### PR TITLE
doc: supported os: macOS 26

### DIFF
--- a/doc/docs/os_support.md
+++ b/doc/docs/os_support.md
@@ -9,6 +9,7 @@ The following table lists operating systems supported by nRF Connect for Desktop
 | Linux - Ubuntu 24.04 LTS  | Not supported  | Tier 2        | Not supported |
 | Linux - Ubuntu 22.04 LTS  | Not supported  | Tier 1        | Not supported |
 | Linux - Ubuntu 20.04 LTS  | Not supported  | Not supported | Not supported |
+| macOS 26                  | Not applicable | Tier 3        | Tier 3        |
 | macOS 15                  | Not applicable | Tier 3        | Tier 3        |
 | macOS 14                  | Not applicable | Tier 3        | Tier 3        |
 | macOS 13                  | Not applicable | Tier 1        | Tier 1        |


### PR DESCRIPTION
Added macOS 26 Tier 3 to the supported operating systems table. NRFU-1594.