### PR TITLE
doc: jlink: bump version to 8.60

### DIFF
--- a/doc/docs/download_cfd.md
+++ b/doc/docs/download_cfd.md
@@ -18,7 +18,7 @@ All nRF Connect for Desktop applications require the launcher v4.1.0 or later.
 
 Running nRF Connect for Desktop has the following additional requirements:
 
-- [**SEGGER J-Link** v8.18](https://www.segger.com/downloads/jlink/#J-LinkSoftwareAndDocumentationPack) - required for all platforms.
+- [**SEGGER J-Link** v8.60](https://www.segger.com/downloads/jlink/#J-LinkSoftwareAndDocumentationPack) - required for all platforms.
 
     - On Windows, the driver comes bundled with nRF Connect for Desktop.
     - On macOS and Linux, you must install the driver manually. Download the installer for your platform from [SEGGER J-Link Software](https://www.segger.com/downloads/jlink/#J-LinkSoftwareAndDocumentationPack).


### PR DESCRIPTION
Updated J-Link version in the docs to v8.60.
NRFU-1607.

----

- [ ] Waiting for [NCD-1431](https://nordicsemi.atlassian.net/browse/NCD-1431) to be done --> superseded by NRFU-1645 for v8.66 of J-Link