### PR TITLE
Create a generic process concept

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
             "devDependencies": {
                 "@electron/notarize": "^2.2.0",
                 "@nordicsemiconductor/nrf-jlink-js": "^0.9.0",
-                "@nordicsemiconductor/pc-nrfconnect-shared": "^221.0.0",
+                "@nordicsemiconductor/pc-nrfconnect-shared": "^223.0.0",
                 "@playwright/test": "^1.16.3",
                 "@testing-library/user-event": "^14.4.3",
                 "@types/chmodr": "1.0.0",
@@ -3201,9 +3201,9 @@
             }
         },
         "node_modules/@nordicsemiconductor/pc-nrfconnect-shared": {
-            "version": "221.0.0",
-            "resolved": "https://registry.npmjs.org/@nordicsemiconductor/pc-nrfconnect-shared/-/pc-nrfconnect-shared-221.0.0.tgz",
-            "integrity": "sha512-XG8C1H8oxdiKh7sbiw/cVQ7C4H+WlYdFx3Y9mQGL5ibEMwmwTjCh8XzXtKU+akadgDfkhrRV+EE8AyOZQzl5pA==",
+            "version": "223.0.0",
+            "resolved": "https://registry.npmjs.org/@nordicsemiconductor/pc-nrfconnect-shared/-/pc-nrfconnect-shared-223.0.0.tgz",
+            "integrity": "sha512-ZIU09wmJArPjk5CPbmD/QJpXucOoG0bVwtZsOxRUJrvY3RmZQgwUfJ3wqFnQ56jwwy98wgj3GyfLJB2jAme2tw==",
             "dev": true,
             "hasInstallScript": true,
             "license": "ISC",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
             "devDependencies": {
                 "@electron/notarize": "^2.2.0",
                 "@nordicsemiconductor/nrf-jlink-js": "^0.9.0",
-                "@nordicsemiconductor/pc-nrfconnect-shared": "^223.0.0",
+                "@nordicsemiconductor/pc-nrfconnect-shared": "^224.0.0",
                 "@playwright/test": "^1.16.3",
                 "@testing-library/user-event": "^14.4.3",
                 "@types/chmodr": "1.0.0",
@@ -3201,12 +3201,12 @@
             }
         },
         "node_modules/@nordicsemiconductor/pc-nrfconnect-shared": {
-            "version": "223.0.0",
-            "resolved": "https://registry.npmjs.org/@nordicsemiconductor/pc-nrfconnect-shared/-/pc-nrfconnect-shared-223.0.0.tgz",
-            "integrity": "sha512-ZIU09wmJArPjk5CPbmD/QJpXucOoG0bVwtZsOxRUJrvY3RmZQgwUfJ3wqFnQ56jwwy98wgj3GyfLJB2jAme2tw==",
+            "version": "224.0.0",
+            "resolved": "https://registry.npmjs.org/@nordicsemiconductor/pc-nrfconnect-shared/-/pc-nrfconnect-shared-224.0.0.tgz",
+            "integrity": "sha512-2vZCOT9eBvysCW7bkmzOCGnmMZyySs71LMZeAhA2VyeSdYFjYRmPg423/jTgxiuZj8YKzvTxcgMK+oHrNVbQ7w==",
             "dev": true,
             "hasInstallScript": true,
-            "license": "ISC",
+            "license": "SEE LICENSE IN LICENSE",
             "dependencies": {
                 "@electron/remote": "^2.1.2",
                 "@mdi/font": "7.2.96",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "devDependencies": {
         "@electron/notarize": "^2.2.0",
         "@nordicsemiconductor/nrf-jlink-js": "^0.9.0",
-        "@nordicsemiconductor/pc-nrfconnect-shared": "^223.0.0",
+        "@nordicsemiconductor/pc-nrfconnect-shared": "^224.0.0",
         "@playwright/test": "^1.16.3",
         "@testing-library/user-event": "^14.4.3",
         "@types/chmodr": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "devDependencies": {
         "@electron/notarize": "^2.2.0",
         "@nordicsemiconductor/nrf-jlink-js": "^0.9.0",
-        "@nordicsemiconductor/pc-nrfconnect-shared": "^221.0.0",
+        "@nordicsemiconductor/pc-nrfconnect-shared": "^223.0.0",
         "@playwright/test": "^1.16.3",
         "@testing-library/user-event": "^14.4.3",
         "@types/chmodr": "1.0.0",

--- a/src/common/sources.ts
+++ b/src/common/sources.ts
@@ -4,25 +4,23 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
+import type { UrlString } from '@nordicsemiconductor/pc-nrfconnect-shared/ipc/MetaFiles';
 import {
-    allStandardSourceNames,
     LOCAL,
     OFFICIAL,
-    Source,
     SourceName,
-    SourceUrl,
 } from '@nordicsemiconductor/pc-nrfconnect-shared/ipc/sources';
 
 import { asShortNordicArtifactoryUrl } from './artifactoryUrl';
 
-export {
-    allStandardSourceNames,
-    LOCAL,
-    OFFICIAL,
-    type Source,
-    type SourceName,
-    type SourceUrl,
-};
+export { LOCAL, OFFICIAL, type SourceName };
+
+export const allStandardSourceNames: SourceName[] = [OFFICIAL, LOCAL];
+
+export type SourceUrl = UrlString;
+export type Source = { name: SourceName; url: SourceUrl };
+
+export type SourceWithError = { source: Source; reason?: string };
 
 const deprecatedSources = [
     'toolchain-manager',

--- a/src/launcher/features/apps/AppListEmpty.tsx
+++ b/src/launcher/features/apps/AppListEmpty.tsx
@@ -13,7 +13,7 @@ import React, {
 import { ExternalLink } from '@nordicsemiconductor/pc-nrfconnect-shared';
 
 import { useLauncherDispatch, useLauncherSelector } from '../../util/hooks';
-import { checkForUpdatesManually } from '../launcherUpdate/launcherUpdateEffects';
+import { startUpdateProcess } from '../process/updateProcess';
 import { getShouldCheckForUpdatesAtStartup } from '../settings/settingsSlice';
 import { getNoAppsExist } from './appsSlice';
 
@@ -52,7 +52,7 @@ const CheckForUpdatesDisabled = () => {
             <p>
                 You can enable it there or now just{' '}
                 <InlineButton
-                    onClick={() => dispatch(checkForUpdatesManually())}
+                    onClick={() => dispatch(startUpdateProcess(true))}
                 >
                     check once for updates
                 </InlineButton>

--- a/src/launcher/features/jlinkUpdate/JLinkUpdateDialog.tsx
+++ b/src/launcher/features/jlinkUpdate/JLinkUpdateDialog.tsx
@@ -15,13 +15,11 @@ import {
 import { inMain } from '../../../ipc/installJLink';
 import bundledJlinkVersion from '../../../main/bundledJlink';
 import { useLauncherDispatch, useLauncherSelector } from '../../util/hooks';
-import { continueLauncherInitialisation } from '../process/initialiseLauncher';
 import { continueUpdateProcess } from '../process/updateProcess';
 import {
     getInstalledJLinkVersion,
     getJLinkVersionToBeInstalled,
     isJLinkUpdateDialogVisible,
-    ranJLinkCheckDuringStartup,
     reset,
     showProgressDialog,
 } from './jlinkUpdateSlice';
@@ -29,9 +27,6 @@ import {
 export default () => {
     const dispatch = useLauncherDispatch();
     const isVisible = useLauncherSelector(isJLinkUpdateDialogVisible);
-    const ranJlinkCheckDuringStartup = useLauncherSelector(
-        ranJLinkCheckDuringStartup
-    );
     const versionToBeInstalled = useLauncherSelector(
         getJLinkVersionToBeInstalled
     );
@@ -76,12 +71,8 @@ export default () => {
                         <DialogButton
                             variant="secondary"
                             onClick={() => {
-                                if (!ranJlinkCheckDuringStartup) {
-                                    dispatch(continueUpdateProcess());
-                                } else {
-                                    dispatch(continueLauncherInitialisation());
-                                }
                                 dispatch(reset());
+                                dispatch(continueUpdateProcess());
                             }}
                         >
                             Close

--- a/src/launcher/features/jlinkUpdate/JLinkUpdateDialog.tsx
+++ b/src/launcher/features/jlinkUpdate/JLinkUpdateDialog.tsx
@@ -15,8 +15,8 @@ import {
 import { inMain } from '../../../ipc/installJLink';
 import bundledJlinkVersion from '../../../main/bundledJlink';
 import { useLauncherDispatch, useLauncherSelector } from '../../util/hooks';
-import { checkForAppAndLauncherUpdateManually } from '../launcherUpdate/launcherUpdateEffects';
 import { continueLauncherInitialisation } from '../process/initialiseLauncher';
+import { continueUpdateProcess } from '../process/updateProcess';
 import {
     getInstalledJLinkVersion,
     getJLinkVersionToBeInstalled,
@@ -77,9 +77,7 @@ export default () => {
                             variant="secondary"
                             onClick={() => {
                                 if (!ranJlinkCheckDuringStartup) {
-                                    dispatch(
-                                        checkForAppAndLauncherUpdateManually()
-                                    );
+                                    dispatch(continueUpdateProcess());
                                 } else {
                                     dispatch(continueLauncherInitialisation());
                                 }

--- a/src/launcher/features/jlinkUpdate/JLinkUpdateDialog.tsx
+++ b/src/launcher/features/jlinkUpdate/JLinkUpdateDialog.tsx
@@ -15,8 +15,8 @@ import {
 import { inMain } from '../../../ipc/installJLink';
 import bundledJlinkVersion from '../../../main/bundledJlink';
 import { useLauncherDispatch, useLauncherSelector } from '../../util/hooks';
-import continueLauncherInitialisation from '../initialisation/initialiseLauncher';
 import { checkForAppAndLauncherUpdateManually } from '../launcherUpdate/launcherUpdateEffects';
+import { continueLauncherInitialisation } from '../process/initialiseLauncher';
 import {
     getInstalledJLinkVersion,
     getJLinkVersionToBeInstalled,

--- a/src/launcher/features/jlinkUpdate/JLinkUpdateProgressDialog.tsx
+++ b/src/launcher/features/jlinkUpdate/JLinkUpdateProgressDialog.tsx
@@ -12,8 +12,8 @@ import {
 } from '@nordicsemiconductor/pc-nrfconnect-shared';
 
 import { useLauncherDispatch, useLauncherSelector } from '../../util/hooks';
-import continueLauncherInitialisation from '../initialisation/initialiseLauncher';
 import { checkForAppAndLauncherUpdateManually } from '../launcherUpdate/launcherUpdateEffects';
+import { continueLauncherInitialisation } from '../process/initialiseLauncher';
 import {
     getInstalledJLinkVersion,
     getJLinkUpdateProgress,

--- a/src/launcher/features/jlinkUpdate/JLinkUpdateProgressDialog.tsx
+++ b/src/launcher/features/jlinkUpdate/JLinkUpdateProgressDialog.tsx
@@ -12,8 +12,8 @@ import {
 } from '@nordicsemiconductor/pc-nrfconnect-shared';
 
 import { useLauncherDispatch, useLauncherSelector } from '../../util/hooks';
-import { checkForAppAndLauncherUpdateManually } from '../launcherUpdate/launcherUpdateEffects';
 import { continueLauncherInitialisation } from '../process/initialiseLauncher';
+import { continueUpdateProcess } from '../process/updateProcess';
 import {
     getInstalledJLinkVersion,
     getJLinkUpdateProgress,
@@ -45,7 +45,7 @@ export default () => {
                 <DialogButton
                     onClick={() => {
                         if (!ranJlinkCheckDuringStartup) {
-                            dispatch(checkForAppAndLauncherUpdateManually());
+                            dispatch(continueUpdateProcess());
                         } else {
                             dispatch(continueLauncherInitialisation());
                         }

--- a/src/launcher/features/jlinkUpdate/JLinkUpdateProgressDialog.tsx
+++ b/src/launcher/features/jlinkUpdate/JLinkUpdateProgressDialog.tsx
@@ -12,13 +12,11 @@ import {
 } from '@nordicsemiconductor/pc-nrfconnect-shared';
 
 import { useLauncherDispatch, useLauncherSelector } from '../../util/hooks';
-import { continueLauncherInitialisation } from '../process/initialiseLauncher';
 import { continueUpdateProcess } from '../process/updateProcess';
 import {
     getInstalledJLinkVersion,
     getJLinkUpdateProgress,
     isJLinkUpdateProgressDialogVisible,
-    ranJLinkCheckDuringStartup,
     reset,
 } from './jlinkUpdateSlice';
 
@@ -27,9 +25,6 @@ export default () => {
     const isJLinkInstalled = !!useLauncherSelector(getInstalledJLinkVersion);
     const isVisible = useLauncherSelector(isJLinkUpdateProgressDialogVisible);
     const progress = useLauncherSelector(getJLinkUpdateProgress);
-    const ranJlinkCheckDuringStartup = useLauncherSelector(
-        ranJLinkCheckDuringStartup
-    );
     const finished =
         progress && progress.step === 'install' && progress.percentage === 100;
 
@@ -40,16 +35,12 @@ export default () => {
                 isJLinkInstalled ? 'Updating' : 'Installing'
             } SEGGER J-Link`}
             showSpinner={!finished}
-            onHide={() => dispatch(continueLauncherInitialisation())}
+            onHide={() => dispatch(continueUpdateProcess())}
             footer={
                 <DialogButton
                     onClick={() => {
-                        if (!ranJlinkCheckDuringStartup) {
-                            dispatch(continueUpdateProcess());
-                        } else {
-                            dispatch(continueLauncherInitialisation());
-                        }
                         dispatch(reset());
+                        dispatch(continueUpdateProcess());
                     }}
                     disabled={!finished}
                 >

--- a/src/launcher/features/jlinkUpdate/jlinkUpdateEffects.ts
+++ b/src/launcher/features/jlinkUpdate/jlinkUpdateEffects.ts
@@ -11,8 +11,7 @@ import { AppThunk } from '../../store';
 import { updateAvailable } from './jlinkUpdateSlice';
 
 export const checkForJLinkUpdate =
-    (inStartup = true): AppThunk<Promise<{ isUpdateAvailable: boolean }>> =>
-    dispatch =>
+    (): AppThunk<Promise<{ isUpdateAvailable: boolean }>> => dispatch =>
         getVersionToInstall(bundledJlinkVersion).then(status => {
             const isUpdateAvailable = !!(
                 status.outdated && status.versionToBeInstalled
@@ -23,7 +22,6 @@ export const checkForJLinkUpdate =
                     updateAvailable({
                         versionToBeInstalled: status.versionToBeInstalled!, // eslint-disable-line @typescript-eslint/no-non-null-assertion -- Must be non-null because of the check above
                         installedVersion: status.installedVersion,
-                        inStartup,
                     })
                 );
             }

--- a/src/launcher/features/jlinkUpdate/jlinkUpdateEffects.ts
+++ b/src/launcher/features/jlinkUpdate/jlinkUpdateEffects.ts
@@ -11,18 +11,21 @@ import { AppThunk } from '../../store';
 import { updateAvailable } from './jlinkUpdateSlice';
 
 export const checkForJLinkUpdate =
-    (inStartup = true): AppThunk<Promise<boolean>> =>
+    (inStartup = true): AppThunk<Promise<{ isUpdateAvailable: boolean }>> =>
     dispatch =>
         getVersionToInstall(bundledJlinkVersion).then(status => {
-            if (status.outdated && status.versionToBeInstalled) {
+            const isUpdateAvailable = !!(
+                status.outdated && status.versionToBeInstalled
+            );
+
+            if (isUpdateAvailable) {
                 dispatch(
                     updateAvailable({
-                        versionToBeInstalled: status.versionToBeInstalled,
+                        versionToBeInstalled: status.versionToBeInstalled!, // eslint-disable-line @typescript-eslint/no-non-null-assertion -- Must be non-null because of the check above
                         installedVersion: status.installedVersion,
                         inStartup,
                     })
                 );
-                return true;
             }
-            return false;
+            return { isUpdateAvailable };
         });

--- a/src/launcher/features/jlinkUpdate/jlinkUpdateSlice.ts
+++ b/src/launcher/features/jlinkUpdate/jlinkUpdateSlice.ts
@@ -16,11 +16,9 @@ export type State = {
     isJLinkUpdateAvailableDialogVisible: boolean;
     isJLinkUpdateProgressDialogVisible: boolean;
     updateProgress?: JLinkUpdate;
-    inStartup: boolean;
 };
 
 const initialState: State = {
-    inStartup: true,
     installedVersion: undefined,
     isJLinkUpdateAvailableDialogVisible: false,
     isJLinkUpdateProgressDialogVisible: false,
@@ -36,18 +34,15 @@ const slice = createSlice({
                 payload: {
                     versionToBeInstalled: availableVersion,
                     installedVersion,
-                    inStartup = true,
                 },
             }: PayloadAction<{
                 versionToBeInstalled: string;
                 installedVersion: string | undefined;
-                inStartup: boolean;
             }>
         ) {
             state.isJLinkUpdateAvailableDialogVisible = true;
             state.versionToBeInstalled = availableVersion;
             state.installedVersion = installedVersion;
-            state.inStartup = inStartup;
         },
         showProgressDialog(state) {
             state.isJLinkUpdateAvailableDialogVisible = false;
@@ -77,5 +72,3 @@ export const getJLinkVersionToBeInstalled = (state: RootState) =>
     state.jlinkUpdate.versionToBeInstalled;
 export const getInstalledJLinkVersion = (state: RootState) =>
     state.jlinkUpdate.installedVersion;
-export const ranJLinkCheckDuringStartup = (state: RootState) =>
-    state.jlinkUpdate.inStartup;

--- a/src/launcher/features/launcherUpdate/UpdateAvailableDialog.tsx
+++ b/src/launcher/features/launcherUpdate/UpdateAvailableDialog.tsx
@@ -12,6 +12,7 @@ import {
 
 import { inMain } from '../../../ipc/launcherUpdate';
 import { useLauncherDispatch, useLauncherSelector } from '../../util/hooks';
+import { continueUpdateProcess } from '../process/updateProcess';
 import { getLauncherUpdate, reset } from './launcherUpdateSlice';
 
 const releaseNotesUrl =
@@ -31,7 +32,10 @@ export default () => {
             confirmLabel="Yes"
             cancelLabel="No"
             onConfirm={() => inMain.startUpdate()}
-            onCancel={() => dispatch(reset())}
+            onCancel={() => {
+                dispatch(reset());
+                dispatch(continueUpdateProcess());
+            }}
         >
             <p>
                 A new version ({version}) of nRF Connect for Desktop is

--- a/src/launcher/features/launcherUpdate/launcherUpdateEffects.ts
+++ b/src/launcher/features/launcherUpdate/launcherUpdateEffects.ts
@@ -4,19 +4,10 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-import {
-    describeError,
-    ErrorDialogActions,
-    logger,
-} from '@nordicsemiconductor/pc-nrfconnect-shared';
+import { logger } from '@nordicsemiconductor/pc-nrfconnect-shared';
 
 import { inMain } from '../../../ipc/launcherUpdate';
 import type { AppThunk } from '../../store';
-import { downloadLatestAppInfos } from '../apps/appsEffects';
-import { checkForJLinkUpdate } from '../jlinkUpdate/jlinkUpdateEffects';
-import { isJLinkUpdateDialogVisible } from '../jlinkUpdate/jlinkUpdateSlice';
-import { getIsErrorVisible as getIsProxyErrorShown } from '../proxyLogin/proxyLoginSlice';
-import { showUpdateCheckComplete } from '../settings/settingsSlice';
 import { reset, updateAvailable } from './launcherUpdateSlice';
 
 export const checkForLauncherUpdate =
@@ -43,35 +34,3 @@ export const cancelDownload = (): AppThunk => dispatch => {
     inMain.cancelUpdate();
     dispatch(reset());
 };
-
-export const checkForUpdatesManually =
-    (): AppThunk => async (dispatch, getState) => {
-        try {
-            await dispatch(checkForJLinkUpdate(false));
-            if (isJLinkUpdateDialogVisible(getState())) {
-                return;
-            }
-        } catch (error) {
-            logger.error(error);
-        }
-
-        await dispatch(checkForLauncherUpdate());
-    };
-
-export const checkForAppAndLauncherUpdateManually =
-    (): AppThunk => async (dispatch, getState) => {
-        try {
-            await dispatch(downloadLatestAppInfos());
-            if (!getIsProxyErrorShown(getState())) {
-                dispatch(showUpdateCheckComplete());
-
-                dispatch(checkForLauncherUpdate());
-            }
-        } catch (error) {
-            dispatch(
-                ErrorDialogActions.showDialog(
-                    `Unable to check for updates: ${describeError(error)}`
-                )
-            );
-        }
-    };

--- a/src/launcher/features/launcherUpdate/launcherUpdateEffects.ts
+++ b/src/launcher/features/launcherUpdate/launcherUpdateEffects.ts
@@ -20,7 +20,7 @@ import { showUpdateCheckComplete } from '../settings/settingsSlice';
 import { reset, updateAvailable } from './launcherUpdateSlice';
 
 export const checkForLauncherUpdate =
-    (): AppThunk<Promise<void>> => async dispatch => {
+    (): AppThunk<Promise<{ isUpdateAvailable: boolean }>> => async dispatch => {
         try {
             const { isUpdateAvailable, newVersion } =
                 await inMain.checkForUpdate();
@@ -30,8 +30,12 @@ export const checkForLauncherUpdate =
             } else {
                 dispatch(reset());
             }
+
+            return { isUpdateAvailable };
         } catch (error) {
             logger.warn(error);
+
+            return { isUpdateAvailable: false };
         }
     };
 

--- a/src/launcher/features/process/initialiseLauncher.ts
+++ b/src/launcher/features/process/initialiseLauncher.ts
@@ -7,7 +7,6 @@
 import {
     describeError,
     ErrorDialogActions,
-    launcherConfig,
     telemetry,
 } from '@nordicsemiconductor/pc-nrfconnect-shared';
 import { getHasUserAgreedToTelemetry } from '@nordicsemiconductor/pc-nrfconnect-shared/src/utils/persistentStore';
@@ -158,7 +157,7 @@ const downloadLatestAppInfoAtStartup: ProcessStep = (dispatch, getState) => {
         getState()
     );
 
-    if (shouldCheckForUpdatesAtStartup && !launcherConfig().isSkipUpdateApps) {
+    if (shouldCheckForUpdatesAtStartup) {
         dispatch(downloadLatestAppInfos());
     }
 };
@@ -173,7 +172,6 @@ const checkForLauncherUpdateAtStartup: ProcessStep = async (
 
     if (
         shouldCheckForUpdatesAtStartup &&
-        !launcherConfig().isSkipUpdateLauncher &&
         process.env.NODE_ENV !== 'development'
     ) {
         await dispatch(checkForLauncherUpdate());

--- a/src/launcher/features/process/initialiseLauncher.ts
+++ b/src/launcher/features/process/initialiseLauncher.ts
@@ -181,8 +181,8 @@ const checkForLauncherUpdateAtStartup: ProcessStep = async (
 const checkForLinkUpdate: ProcessStep = async (dispatch, getState) => {
     if (getShouldCheckForUpdatesAtStartup(getState())) {
         try {
-            const updateAvailable = await dispatch(checkForJLinkUpdate());
-            if (updateAvailable) {
+            const { isUpdateAvailable } = await dispatch(checkForJLinkUpdate());
+            if (isUpdateAvailable) {
                 return INTERRUPT_PROCESS;
             }
         } catch (e) {

--- a/src/launcher/features/process/thunkProcess.ts
+++ b/src/launcher/features/process/thunkProcess.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import type { AppThunk } from '../../store';
+
+export const INTERRUPT_PROCESS = Symbol('interrupt process');
+
+export type ProcessStep = AppThunk<
+    void | typeof INTERRUPT_PROCESS | Promise<void | typeof INTERRUPT_PROCESS>
+>;
+
+export const runRemainingProcessStepsSequentially =
+    (processSteps: ProcessStep[]): AppThunk =>
+    async dispatch => {
+        while (processSteps.length > 0) {
+            const action = processSteps.shift()!; // eslint-disable-line @typescript-eslint/no-non-null-assertion -- Must be non-null because of the check above
+
+            const result = await dispatch(action); // eslint-disable-line no-await-in-loop -- Must be awaited because some actions are asynchronous
+
+            if (result === INTERRUPT_PROCESS) {
+                return;
+            }
+        }
+    };

--- a/src/launcher/features/process/updateProcess.ts
+++ b/src/launcher/features/process/updateProcess.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2025 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import {
+    describeError,
+    ErrorDialogActions,
+} from '@nordicsemiconductor/pc-nrfconnect-shared';
+
+import type { AppThunk } from '../../store';
+import { downloadLatestAppInfos as downloadLatestAppInfosEffect } from '../apps/appsEffects';
+import { checkForJLinkUpdate as checkForJLinkUpdateEffect } from '../jlinkUpdate/jlinkUpdateEffects';
+import { checkForLauncherUpdate as checkForLauncherUpdateEffect } from '../launcherUpdate/launcherUpdateEffects';
+import { getIsErrorVisible as getIsProxyErrorShown } from '../proxyLogin/proxyLoginSlice';
+import { showUpdateCheckComplete } from '../settings/settingsSlice';
+import {
+    INTERRUPT_PROCESS,
+    type ProcessStep,
+    runRemainingProcessStepsSequentially,
+} from './thunkProcess';
+
+const checkForJLinkUpdate: ProcessStep = async dispatch => {
+    try {
+        const { isUpdateAvailable } = await dispatch(
+            checkForJLinkUpdateEffect()
+        );
+
+        if (isUpdateAvailable) {
+            return INTERRUPT_PROCESS;
+        }
+    } catch (e) {
+        dispatch(ErrorDialogActions.showDialog(describeError(e)));
+    }
+};
+
+const checkForLauncherUpdate: ProcessStep = async dispatch => {
+    if (process.env.NODE_ENV !== 'development') {
+        const { isUpdateAvailable } = await dispatch(
+            checkForLauncherUpdateEffect()
+        );
+
+        if (isUpdateAvailable) {
+            return INTERRUPT_PROCESS;
+        }
+    }
+};
+
+const downloadLatestAppInfo =
+    (showDialogOnComplete: boolean): ProcessStep =>
+    async (dispatch, getState) => {
+        try {
+            await dispatch(downloadLatestAppInfosEffect());
+            if (showDialogOnComplete && !getIsProxyErrorShown(getState())) {
+                dispatch(showUpdateCheckComplete());
+            }
+        } catch (error) {
+            dispatch(
+                ErrorDialogActions.showDialog(
+                    `Unable to check for updates: ${describeError(error)}`
+                )
+            );
+        }
+    };
+
+let currentProcessSteps: ProcessStep[] = [];
+
+export const startUpdateProcess =
+    (showDialogOnComplete: boolean): AppThunk =>
+    dispatch => {
+        currentProcessSteps = [
+            checkForJLinkUpdate,
+            checkForLauncherUpdate,
+            downloadLatestAppInfo(showDialogOnComplete),
+        ];
+        dispatch(continueUpdateProcess());
+    };
+
+export const continueUpdateProcess = (): AppThunk => dispatch => {
+    dispatch(runRemainingProcessStepsSequentially(currentProcessSteps));
+};

--- a/src/launcher/features/settings/Cards/Updates.tsx
+++ b/src/launcher/features/settings/Cards/Updates.tsx
@@ -14,7 +14,7 @@ import formatDate from 'date-fns/format';
 
 import { useLauncherDispatch, useLauncherSelector } from '../../../util/hooks';
 import { getUpdateCheckStatus } from '../../apps/appsSlice';
-import { checkForUpdatesManually } from '../../launcherUpdate/launcherUpdateEffects';
+import { startUpdateProcess } from '../../process/updateProcess';
 import {
     getShouldCheckForUpdatesAtStartup,
     setCheckForUpdatesAtStartup,
@@ -41,7 +41,7 @@ export default () => {
                 <Col xs="auto">
                     <Button
                         variant="outline-primary"
-                        onClick={() => dispatch(checkForUpdatesManually())}
+                        onClick={() => dispatch(startUpdateProcess(true))}
                         disabled={isCheckingForUpdates}
                     >
                         {isCheckingForUpdates

--- a/src/launcher/features/sources/DeprecatedSourcesDialog.tsx
+++ b/src/launcher/features/sources/DeprecatedSourcesDialog.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 import { ConfirmationDialog } from '@nordicsemiconductor/pc-nrfconnect-shared';
 
 import { useLauncherDispatch, useLauncherSelector } from '../../util/hooks';
-import continueLauncherInitialisation from '../initialisation/initialiseLauncher';
+import { continueLauncherInitialisation } from '../process/initialiseLauncher';
 import { removeSource } from './sourcesEffects';
 import {
     doNotRemindDeprecatedSources,

--- a/src/launcher/features/sources/MissingTokenWarning.tsx
+++ b/src/launcher/features/sources/MissingTokenWarning.tsx
@@ -13,7 +13,7 @@ import {
 
 import { setDoNotRemindOnMissingToken } from '../../../common/persistedStore';
 import { useLauncherDispatch, useLauncherSelector } from '../../util/hooks';
-import continueLauncherInitialisation from '../initialisation/initialiseLauncher';
+import { continueLauncherInitialisation } from '../process/initialiseLauncher';
 import { setArtifactoryToken } from '../settings/settingsEffects';
 import { addSource } from './sourcesEffects';
 import {

--- a/src/launcher/features/sources/sourcesEffects.ts
+++ b/src/launcher/features/sources/sourcesEffects.ts
@@ -15,8 +15,8 @@ import {
     Source,
     SourceName,
     SourceUrl,
+    SourceWithError,
 } from '../../../common/sources';
-import { SourceWithError } from '../../../ipc/apps';
 import { AddSourceError, inMain as sources } from '../../../ipc/sources';
 import type { AppThunk } from '../../store';
 import { addDownloadableApps, removeAppsOfSource } from '../apps/appsSlice';

--- a/src/launcher/features/telemetry/TelemetryDialog.tsx
+++ b/src/launcher/features/telemetry/TelemetryDialog.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 import { ConfirmationDialog } from '@nordicsemiconductor/pc-nrfconnect-shared';
 
 import { useLauncherDispatch, useLauncherSelector } from '../../util/hooks';
-import continueLauncherInitialisation from '../initialisation/initialiseLauncher';
+import { continueLauncherInitialisation } from '../process/initialiseLauncher';
 import {
     cancelSendingTelemetry,
     confirmSendingTelemetry,

--- a/src/launcher/features/telemetry/telemetryEffects.ts
+++ b/src/launcher/features/telemetry/telemetryEffects.ts
@@ -48,7 +48,7 @@ export const toggleSendingTelemetry = (): AppThunk => (dispatch, getState) => {
     dispatch(setIsSendingTelemetry(!isSendingTelemetry));
 };
 
-export const sendEnvInfo = (): AppThunk => () => {
+export const sendEnvInfo: AppThunk = () => {
     telemetry.sendEvent(EventAction.REPORT_LAUNCHER_INFO, {
         version: pkgJson.version,
         isDevelopment,

--- a/src/launcher/index.tsx
+++ b/src/launcher/index.tsx
@@ -10,7 +10,7 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import { render, telemetry } from '@nordicsemiconductor/pc-nrfconnect-shared';
 
-import initialiseLauncher from './features/initialisation/initialiseLauncher';
+import { startLauncherInitialisation } from './features/process/initialiseLauncher';
 import Root from './Root';
 import store from './store';
 import registerIpcHandler from './util/registerIpcHandler';
@@ -27,4 +27,4 @@ render(
     </Provider>
 );
 
-dispatch(initialiseLauncher());
+dispatch(startLauncherInitialisation());

--- a/src/launcher/util/appCompatibilityWarning.tsx
+++ b/src/launcher/util/appCompatibilityWarning.tsx
@@ -203,7 +203,7 @@ export const checkJLinkRequirements: AppCompatibilityChecker = async (
         coreVersion
     );
 
-    if (jlinkCompatibility.kind === 'No J-Link installed') {
+    if (jlinkCompatibility.kind === 'No SEGGER J-Link installed') {
         const { requiredJlink } = jlinkCompatibility;
 
         return incompatible(
@@ -230,7 +230,7 @@ export const checkJLinkRequirements: AppCompatibilityChecker = async (
         );
     }
 
-    if (jlinkCompatibility.kind === 'Outdated J-Link') {
+    if (jlinkCompatibility.kind === 'Outdated SEGGER J-Link') {
         const { actualJlink, requiredJlink } = jlinkCompatibility;
 
         return incompatible(

--- a/src/main/apps/apps.ts
+++ b/src/main/apps/apps.ts
@@ -8,13 +8,12 @@ import { AppInfo } from '@nordicsemiconductor/pc-nrfconnect-shared/main';
 import { omit } from 'lodash';
 import path, { basename } from 'path';
 
-import { Source } from '../../common/sources';
+import { Source, type SourceWithError } from '../../common/sources';
 import {
     AppWithError,
     DownloadableApp,
     isWithdrawn,
     LocalApp,
-    SourceWithError,
     UninstalledDownloadableApp,
 } from '../../ipc/apps';
 import { inRenderer } from '../../ipc/showErrorDialog';

--- a/src/main/apps/dataMigration/sourcesVersionedJsonV1.ts
+++ b/src/main/apps/dataMigration/sourcesVersionedJsonV1.ts
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-import type { Source } from '@nordicsemiconductor/pc-nrfconnect-shared/ipc/sources';
 import fs from 'fs';
 
+import type { Source } from '../../../common/sources';
 import { readSchemedJsonFile, writeSchemedJsonFile } from '../../fileUtil';
 import {
     sourcesVersionedJsonPath,

--- a/src/main/apps/sources/sources.ts
+++ b/src/main/apps/sources/sources.ts
@@ -13,8 +13,8 @@ import {
     OFFICIAL,
     Source,
     SourceName,
+    SourceWithError,
 } from '../../../common/sources';
-import { SourceWithError } from '../../../ipc/apps';
 import { retrieveToken } from '../../artifactoryTokenStorage';
 import {
     getAppsRootDir,

--- a/src/main/argv.ts
+++ b/src/main/argv.ts
@@ -36,10 +36,6 @@ Directories
 
 Startup behaviour
 =================
---skip-update-apps      Do not download info/updates about apps.
-                        Default: false
---skip-update-launcher  Skip checking for updates for nRF Connect for Desktop.
-                        Default: false
 --skip-splash-screen    Skip the splash screen at startup.
                         Default: false
 --new-instance          Launch a new instance, independent of other, potentially
@@ -70,8 +66,6 @@ interface CommandLineArguments {
     'user-data-dir': string | undefined;
 
     'skip-splash-screen': boolean;
-    'skip-update-apps': boolean;
-    'skip-update-launcher': boolean;
 
     'install-devtools': boolean;
     'remove-devtools': boolean;
@@ -84,8 +78,6 @@ const argv = parseArgs<CommandLineArguments>(argSlice, {
     '--': true,
     boolean: [
         'skip-splash-screen',
-        'skip-update-apps',
-        'skip-update-launcher',
         'new-instance',
         'install-devtools',
         'remove-devtools',

--- a/src/main/registerIpcHandler.ts
+++ b/src/main/registerIpcHandler.ts
@@ -43,7 +43,6 @@ import {
 import createDesktopShortcut from './apps/createDesktopShortcut';
 import { addSource, removeSource } from './apps/sources/sourceChanges';
 import { getAllSources } from './apps/sources/sources';
-import argv from './argv';
 import { getTokenInformation, removeToken, setToken } from './artifactoryToken';
 import installJLink from './jlinkInstall';
 import {
@@ -69,8 +68,6 @@ const getConfigForRenderer = () => ({
     isRunningLauncherFromSource: fs.existsSync(
         path.join(app.getAppPath(), 'README.md')
     ),
-    isSkipUpdateApps: argv['skip-update-apps'],
-    isSkipUpdateLauncher: argv['skip-update-launcher'],
     launcherVersion: packageJson.version,
     userDataDir: app.getPath('userData'),
 });

--- a/test-e2e/launcher/basicBehaviour.spec.ts
+++ b/test-e2e/launcher/basicBehaviour.spec.ts
@@ -44,7 +44,6 @@ test.describe('automatic update check', () => {
         test.beforeAll(async () => {
             app = await setup({
                 appsRootDir,
-                skipUpdateApps: false,
             });
 
             page = await app.firstWindow();
@@ -84,7 +83,6 @@ test.describe('automatic update check', () => {
         test.beforeAll(async () => {
             app = await setup({
                 appsRootDir,
-                skipUpdateApps: false,
             });
 
             page = await app.firstWindow();
@@ -125,7 +123,6 @@ test.describe('showing apps available on the server', () => {
     test.beforeAll(async () => {
         app = await setup({
             appsRootDir,
-            skipUpdateApps: false,
         });
 
         page = await app.firstWindow();

--- a/test-e2e/launcher/installingApps.spec.ts
+++ b/test-e2e/launcher/installingApps.spec.ts
@@ -20,7 +20,6 @@ test.describe('app installation', () => {
         test.beforeAll(async () => {
             app = await setup({
                 appsRootDir,
-                skipUpdateApps: false,
             });
 
             page = await app.firstWindow();

--- a/test-e2e/setupTestApp.ts
+++ b/test-e2e/setupTestApp.ts
@@ -11,12 +11,7 @@ import { _electron as electron } from 'playwright';
 
 const startApp = async (extraArgs: string[]) => {
     const projectPath = path.resolve(__dirname, '../');
-    const electronArgs = [
-        projectPath,
-        '--skip-update-launcher',
-        '--skip-splash-screen',
-        ...extraArgs,
-    ];
+    const electronArgs = [projectPath, '--skip-splash-screen', ...extraArgs];
 
     if (process.env.LOG_ELECTRON_ARGS) {
         console.log(
@@ -36,7 +31,6 @@ interface setupConfig {
     additionalBeforeEach?: () => void;
     openLocalApp?: string;
     openDownloadableApp?: string;
-    skipUpdateApps?: boolean;
 }
 
 export const setup = async ({
@@ -44,14 +38,12 @@ export const setup = async ({
     additionalBeforeEach = () => {},
     openLocalApp,
     openDownloadableApp,
-    skipUpdateApps = true,
 }: setupConfig) => {
     const absoluteAppsRootDir = path.resolve(__dirname, appsRootDir);
     additionalBeforeEach();
 
     const electronArgs = [
         `--apps-root-dir=${absoluteAppsRootDir}`,
-        ...(skipUpdateApps ? ['--skip-update-apps'] : []),
         ...(openLocalApp ? [`--open-local-app=${openLocalApp}`] : []),
         ...(openDownloadableApp
             ? [`--open-downloadable-app=${openDownloadableApp}`]


### PR DESCRIPTION
Extract the process concept from `initialiseLauncher` and also apply it to fetching update information (for J-Link, the launcher, and apps). Some other changes were needed for updating shared, but these should be collected in 7339122b4e1aef3c68b7001aed9525f6df60afb7.