### PR TITLE
Always check with bundled J-Link on startup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
             },
             "devDependencies": {
                 "@electron/notarize": "^2.2.0",
-                "@nordicsemiconductor/nrf-jlink-js": "^0.9.0",
+                "@nordicsemiconductor/nrf-jlink-js": "^0.10.0",
                 "@nordicsemiconductor/pc-nrfconnect-shared": "^224.0.0",
                 "@playwright/test": "^1.16.3",
                 "@testing-library/user-event": "^14.4.3",
@@ -3178,9 +3178,9 @@
             }
         },
         "node_modules/@nordicsemiconductor/nrf-jlink-js": {
-            "version": "0.9.0",
-            "resolved": "https://registry.npmjs.org/@nordicsemiconductor/nrf-jlink-js/-/nrf-jlink-js-0.9.0.tgz",
-            "integrity": "sha512-mb88XM+XlYyLtNBYGM57RUlIan21JoIFsEquDm16o+AuNL9gtqAom0y6BxY/c1vNp4Hc8jpJYEBauP24mIiaPA==",
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/@nordicsemiconductor/nrf-jlink-js/-/nrf-jlink-js-0.10.0.tgz",
+            "integrity": "sha512-i/JCo6/hZyN7bucHKsvMUfI6HBieEWcyUVn3b3AIj6WqtHrmwZHSAQbiP+6M8jZktQv2mIzWmgNN0TvSlFVezw==",
             "dev": true,
             "license": "Proprietary",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     },
     "devDependencies": {
         "@electron/notarize": "^2.2.0",
-        "@nordicsemiconductor/nrf-jlink-js": "^0.9.0",
+        "@nordicsemiconductor/nrf-jlink-js": "^0.10.0",
         "@nordicsemiconductor/pc-nrfconnect-shared": "^224.0.0",
         "@playwright/test": "^1.16.3",
         "@testing-library/user-event": "^14.4.3",

--- a/src/launcher/features/jlinkUpdate/jlinkUpdateEffects.ts
+++ b/src/launcher/features/jlinkUpdate/jlinkUpdateEffects.ts
@@ -11,8 +11,16 @@ import { AppThunk } from '../../store';
 import { updateAvailable } from './jlinkUpdateSlice';
 
 export const checkForJLinkUpdate =
-    (): AppThunk<Promise<{ isUpdateAvailable: boolean }>> => dispatch =>
-        getVersionToInstall(bundledJlinkVersion).then(status => {
+    ({
+        checkOnline,
+    }: {
+        checkOnline: boolean;
+    }): AppThunk<Promise<{ isUpdateAvailable: boolean }>> =>
+    dispatch =>
+        getVersionToInstall({
+            fallbackVersion: bundledJlinkVersion,
+            checkOnline,
+        }).then(status => {
             const isUpdateAvailable = !!(
                 status.outdated && status.versionToBeInstalled
             );

--- a/src/launcher/features/process/initialiseLauncher.ts
+++ b/src/launcher/features/process/initialiseLauncher.ts
@@ -20,6 +20,7 @@ import { inMain as sources } from '../../../ipc/sources';
 import type { AppThunk } from '../../store';
 import { handleAppsWithErrors } from '../apps/appsEffects';
 import { addDownloadableApps, setAllLocalApps } from '../apps/appsSlice';
+import { checkForJLinkUpdate } from '../jlinkUpdate/jlinkUpdateEffects';
 import {
     getArtifactoryTokenInformation,
     getShouldCheckForUpdatesAtStartup,
@@ -160,11 +161,10 @@ export const startLauncherInitialisation =
             checkForDeprecatedSources,
             checkForMissingToken,
             sendEnvInfo,
+            getShouldCheckForUpdatesAtStartup(getState())
+                ? startUpdateProcess(false)
+                : checkForJLinkUpdate({ checkOnline: false }),
         ];
-
-        if (getShouldCheckForUpdatesAtStartup(getState())) {
-            currentProcessSteps.push(startUpdateProcess(false));
-        }
 
         dispatch(continueLauncherInitialisation());
     };

--- a/src/launcher/features/process/updateProcess.ts
+++ b/src/launcher/features/process/updateProcess.ts
@@ -24,7 +24,7 @@ import {
 const checkForJLinkUpdate: ProcessStep = async dispatch => {
     try {
         const { isUpdateAvailable } = await dispatch(
-            checkForJLinkUpdateEffect()
+            checkForJLinkUpdateEffect({ checkOnline: true })
         );
 
         if (isUpdateAvailable) {


### PR DESCRIPTION
[NCD-1435](https://nordicsemi.atlassian.net/browse/NCD-1435): When users deactivate “Check for updates at startup” we still check with the bundled J-Link if that should be installed.

Also: In #1080 I broke the whole “Check for updates at startup” 🙈 which is now fixed again in a807668b5ed7de65776c098645f9750ac58931ae. 