### PR TITLE
Fix J-Link detection on macOS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
             },
             "devDependencies": {
                 "@electron/notarize": "^2.2.0",
-                "@nordicsemiconductor/nrf-jlink-js": "^0.13.0",
+                "@nordicsemiconductor/nrf-jlink-js": "^0.13.1",
                 "@nordicsemiconductor/pc-nrfconnect-shared": "^224.0.0",
                 "@playwright/test": "^1.16.3",
                 "@testing-library/user-event": "^14.4.3",
@@ -3178,9 +3178,9 @@
             }
         },
         "node_modules/@nordicsemiconductor/nrf-jlink-js": {
-            "version": "0.13.0",
-            "resolved": "https://registry.npmjs.org/@nordicsemiconductor/nrf-jlink-js/-/nrf-jlink-js-0.13.0.tgz",
-            "integrity": "sha512-ZMrsf6k22Vq7lJsxr092LvuTqLDvcw9BwZyDBl5PJ5vCZrN/Ox4MJvjYHQKxtg2HcGrA90LNnjwOtCbFxwZypA==",
+            "version": "0.13.1",
+            "resolved": "https://registry.npmjs.org/@nordicsemiconductor/nrf-jlink-js/-/nrf-jlink-js-0.13.1.tgz",
+            "integrity": "sha512-42Wszivq3sgT8fZtYEa5woiKdlUL5N+PLkBJH8bxGpaHEvC5A1i7tHVp5VL7LfTkpJKk3oxAeytiy8U5SNy9TA==",
             "dev": true,
             "license": "SEE LICENSE IN LICENSE",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     },
     "devDependencies": {
         "@electron/notarize": "^2.2.0",
-        "@nordicsemiconductor/nrf-jlink-js": "^0.13.0",
+        "@nordicsemiconductor/nrf-jlink-js": "^0.13.1",
         "@nordicsemiconductor/pc-nrfconnect-shared": "^224.0.0",
         "@playwright/test": "^1.16.3",
         "@testing-library/user-event": "^14.4.3",


### PR DESCRIPTION
Fixes [NCD-1460](https://nordicsemi.atlassian.net/browse/NCD-1460): When NCD was started from the GUI, J-Link was never detected.