### PR TITLE
doc: jlink: bump version to 8.66

### DIFF
--- a/doc/docs/download_cfd.md
+++ b/doc/docs/download_cfd.md
@@ -20,18 +20,18 @@ Make sure you meet the following requirements for your operating system:
 
 === "Windows"
 
-    - [**SEGGER J-Link** v8.18](https://www.segger.com/downloads/jlink/#J-LinkSoftwareAndDocumentationPack)
+    - [**SEGGER J-Link** v8.66](https://www.segger.com/downloads/jlink/#J-LinkSoftwareAndDocumentationPack)
     - **SEGGER USB Driver for J-Link** - Required for correctly detecting the development kits from nRF52 Series, nRF53 Series, and nRF91 Series using [legacy probes](https://kb.segger.com/J-Link_Installer#USB_Driver). Install it manually from the command line together with the downloaded version of **SEGGER J-Link** installer. Use the `-InstUSBDriver=1` parameter to trigger the driver installation, for example:
 
         ```
-        JLink_Windows_V818_x86_64.exe -InstUSBDriver=1
+        JLink_Windows_V866_x86_64.exe -InstUSBDriver=1
         ```
 
         Make sure to use the correct J-Link installer version, and to add the J-Link executable to system path (environment variables).
 
 === "Linux"
 
-    - [**SEGGER J-Link** v8.18](https://www.segger.com/downloads/jlink/#J-LinkSoftwareAndDocumentationPack)
+    - [**SEGGER J-Link** v8.66](https://www.segger.com/downloads/jlink/#J-LinkSoftwareAndDocumentationPack)
     - **libusb-1.0-0** - Usually comes installed with Ubuntu and you can install it with the following command:
 
         ```
@@ -58,7 +58,7 @@ Make sure you meet the following requirements for your operating system:
 
 === "macOS"
 
-    - [**SEGGER J-Link** v8.18](https://www.segger.com/downloads/jlink/#J-LinkSoftwareAndDocumentationPack)
+    - [**SEGGER J-Link** v8.66](https://www.segger.com/downloads/jlink/#J-LinkSoftwareAndDocumentationPack)
 
 
 !!! note "Note"


### PR DESCRIPTION
Updated J-Link version in the docs to v8.66.
NRFU-1645.

----

- [x] Waiting for [NCD-1474](https://nordicsemi.atlassian.net/browse/NCD-1474)