### PR TITLE
Support fixed size apps

### DIFF
--- a/Changelog.minor.md
+++ b/Changelog.minor.md
@@ -12,6 +12,18 @@ release the new version.
 ### Added
 
 -   #1147: Mechanism for automatic release candidates.
+-   #1199: Support for fixed size apps. Before, the fixed size of the Quick
+    Start app was hard coded. With this, every app can specify its own fixed
+    size by adding something like this to its package.json:
+
+    ```json
+    "nrfConnectForDesktop": {
+        "fixedSize": {
+            "width": 800,
+            "height": 600
+        }
+    }
+    ```
 
 ### Changed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
             "devDependencies": {
                 "@electron/notarize": "^2.2.0",
                 "@nordicsemiconductor/nrf-jlink-js": "^0.13.1",
-                "@nordicsemiconductor/pc-nrfconnect-shared": "^228.0.0",
+                "@nordicsemiconductor/pc-nrfconnect-shared": "^230.0.0",
                 "@playwright/test": "^1.16.3",
                 "@testing-library/user-event": "^14.4.3",
                 "@types/chmodr": "1.0.0",
@@ -3201,9 +3201,9 @@
             }
         },
         "node_modules/@nordicsemiconductor/pc-nrfconnect-shared": {
-            "version": "228.0.0",
-            "resolved": "https://registry.npmjs.org/@nordicsemiconductor/pc-nrfconnect-shared/-/pc-nrfconnect-shared-228.0.0.tgz",
-            "integrity": "sha512-5cW2StLrOEP7XQnmACTTUgo6v1kBkAaESHnPv+O1duAmH5hzL8HeD+2Z+xv9YQPIedvqSkoXYnskT8GGJGg+Ig==",
+            "version": "230.0.0",
+            "resolved": "https://registry.npmjs.org/@nordicsemiconductor/pc-nrfconnect-shared/-/pc-nrfconnect-shared-230.0.0.tgz",
+            "integrity": "sha512-gOPUSp3WvFNnIeUePb6tKsrOPA8Ybq0Ww7pkTpvqBYS514kd97SbQU4tSyIWmWzIaK55CNR3wnqhJTnayq7scQ==",
             "dev": true,
             "hasInstallScript": true,
             "license": "SEE LICENSE IN LICENSE",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "devDependencies": {
         "@electron/notarize": "^2.2.0",
         "@nordicsemiconductor/nrf-jlink-js": "^0.13.1",
-        "@nordicsemiconductor/pc-nrfconnect-shared": "^228.0.0",
+        "@nordicsemiconductor/pc-nrfconnect-shared": "^230.0.0",
         "@playwright/test": "^1.16.3",
         "@testing-library/user-event": "^14.4.3",
         "@types/chmodr": "1.0.0",

--- a/src/ipc/apps.ts
+++ b/src/ipc/apps.ts
@@ -53,6 +53,11 @@ const quickStartAppName = 'pc-nrfconnect-quickstart';
 
 export const isQuickStartApp = (app: App) => app.name === quickStartAppName;
 
+type AppWithFixedSize = LaunchableApp &
+    Required<Pick<LaunchableApp, 'fixedSize'>>;
+export const hasFixedSize = (app: App): app is AppWithFixedSize =>
+    isInstalled(app) && app.fixedSize != null;
+
 const channel = {
     downloadLatestAppInfos: 'apps:download-latest-app-infos',
     getLocalApps: 'apps:get-local-apps',

--- a/src/main/apps/app.ts
+++ b/src/main/apps/app.ts
@@ -142,6 +142,7 @@ export const addInstalledAppData = (
         homepage: packageJson.homepage ?? app.homepage,
         repositoryUrl: packageJson.repository?.url,
         html: packageJson.nrfConnectForDesktop?.html,
+        fixedSize: packageJson.nrfConnectForDesktop?.fixedSize,
 
         nrfutil: packageJson.nrfConnectForDesktop?.nrfutil,
         nrfutilCore: packageJson.nrfConnectForDesktop?.nrfutilCore,

--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -26,6 +26,7 @@ import {
 import { LOCAL } from '../common/sources';
 import {
     AppSpec,
+    hasFixedSize,
     isInstalled,
     isQuickStartApp,
     LaunchableApp,
@@ -86,10 +87,19 @@ export const hideLauncherWindow = () => {
 };
 
 const getSizeOptions = (app: LaunchableApp) => {
+    // Legacy, this should be kept for at least two more versions after NCD 5.2.0, so it keeps on working with versions of the Quick Start app which do not yet have the property fixedSize.
     if (isQuickStartApp(app)) {
         return {
             width: 800,
             height: 550,
+            useContentSize: true,
+            resizable: false,
+        };
+    }
+
+    if (hasFixedSize(app)) {
+        return {
+            ...app.fixedSize,
             useContentSize: true,
             resizable: false,
         };


### PR DESCRIPTION
Before, the fixed size of the Quick Start app was hard coded. With this, every app can specify its own fixed size by adding something like this to its package.json:

```json
"nrfConnectForDesktop": {
    "fixedSize": {
        "width": 800,
        "height": 600
    }
}   
```