### PR TITLE
feat: update bundled jlink version to 8.66

### DIFF
--- a/src/main/bundledJlink.js
+++ b/src/main/bundledJlink.js
@@ -4,4 +4,4 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-module.exports = 'V8.18';
+module.exports = 'V8.66';


### PR DESCRIPTION
This is the version that is upstream on artifactory now.
I figured we should update the bundled version to reflect that.

Waiting for your review just in case @datenreisender 