### PR TITLE
Update macOS CI runner from macOS-13 to macOS-15

### DIFF
--- a/.github/workflows/build_darwin.yml
+++ b/.github/workflows/build_darwin.yml
@@ -30,8 +30,8 @@ on:
 jobs:
     build:
         name: Build macOS ${{ inputs.arch }}
-        # For arm64 use macos-latest, for x64 use macos-15 (See https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#choosing-github-hosted-runners)
-        runs-on: ${{ inputs.arch == 'arm64' && 'macos-latest' || 'macos-15' }}
+        # For arm64 use macos-latest, for x64 use macos-15-intel (See https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#choosing-github-hosted-runners)
+        runs-on: ${{ inputs.arch == 'arm64' && 'macos-latest' || 'macos-15-intel' }}
         steps:
             - uses: actions/checkout@v4
               with:


### PR DESCRIPTION
- Update GitHub Actions workflow to use macOS-15 instead of deprecated macOS-13
- macOS-13 is deprecated and will be removed soon  
- macOS-15 provides better performance and updated tooling