### PR TITLE
Build binaries with a different version of the J-Link installer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,12 @@ on:
                     Ref (Tag, branch, commit SHA) to build.
                     Defaults to the ref of the workflow.
                 type: string
+            jlink-version:
+                description:
+                    Which J-Link version is bundled with the launcher, e.g. v8.76.
+                    Only version available on files.nordicsemi.com can be used.
+                    Use this only for testing purposes.
+                type: string
     workflow_call:
         inputs:
             ref:
@@ -41,30 +47,38 @@ jobs:
               env:
                   REF: ${{ inputs.ref }}
                   FALLBACK_REF: ${{ github.ref_name }}
+                  JLINK_VERSION: ${{ inputs.jlink-version }}
               with:
                   script: |
                       core.summary.addHeading('Workflow inputs', '2');
-                      core.summary.addTable([['Ref', process.env.REF ? `<code>${process.env.REF}</code>` : `not set explicitly, using ref <code>${process.env.FALLBACK_REF}</code>`]]);
+                      core.summary.addTable([
+                          ['Ref', process.env.REF ? `<code>${process.env.REF}</code>` : `not set explicitly, using ref <code>${process.env.FALLBACK_REF}</code>`],
+                          ['J-Link version', process.env.JLINK_VERSION ? `<code>${process.env.JLINK_VERSION}</code>` : `not set`],
+                      ]);
                       core.summary.write();
     windows:
         uses: ./.github/workflows/build_win.yml
         secrets: inherit
         with:
             ref: ${{ inputs.ref }}
+            jlink-version: ${{ inputs.jlink-version }}
     linux:
         uses: ./.github/workflows/build_linux.yml
         secrets: inherit
         with:
             ref: ${{ inputs.ref }}
+            jlink-version: ${{ inputs.jlink-version }}
     darwin_x64:
         uses: ./.github/workflows/build_darwin.yml
         secrets: inherit
         with:
             arch: x64
             ref: ${{ inputs.ref }}
+            jlink-version: ${{ inputs.jlink-version }}
     darwin_arm64:
         uses: ./.github/workflows/build_darwin.yml
         secrets: inherit
         with:
             arch: arm64
             ref: ${{ inputs.ref }}
+            jlink-version: ${{ inputs.jlink-version }}

--- a/.github/workflows/build_darwin.yml
+++ b/.github/workflows/build_darwin.yml
@@ -17,6 +17,12 @@ on:
                     Ref (Tag, branch, commit SHA) to build.
                     Defaults to the ref of the workflow.
                 type: string
+            jlink-version:
+                description:
+                    Which J-Link version is bundled with the launcher, e.g. v8.76.
+                    Only version available on files.nordicsemi.com can be used.
+                    Use this only for testing purposes.
+                type: string
             echo-inputs:
                 description: Print the workflow inputs.
                 type: boolean
@@ -29,6 +35,8 @@ on:
                 type: string
             ref:
                 description: Ref to build from
+                type: string
+            jlink-version:
                 type: string
             echo-inputs:
                 type: boolean
@@ -45,10 +53,16 @@ jobs:
               env:
                   REF: ${{ inputs.ref }}
                   FALLBACK_REF: ${{ github.ref_name }}
+                  ARCH: ${{ inputs.arch }}
+                  JLINK_VERSION: ${{ inputs.jlink-version }}
               with:
                   script: |
                       core.summary.addHeading('Workflow inputs', '2');
-                      core.summary.addTable([['Ref', process.env.REF ? `<code>${process.env.REF}</code>` : `not set explicitly, using ref <code>${process.env.FALLBACK_REF}</code>`]]);
+                      core.summary.addTable([
+                          ['Ref', process.env.REF ? `<code>${process.env.REF}</code>` : `not set explicitly, using ref <code>${process.env.FALLBACK_REF}</code>`],
+                          ['Arch', `<code>${process.env.ARCH}</code>`],
+                          ['J-Link version', process.env.JLINK_VERSION ? `<code>${process.env.JLINK_VERSION}</code>` : `not set`],
+                      ]);
                       core.summary.write();
 
             - uses: actions/checkout@v4
@@ -56,6 +70,8 @@ jobs:
                   ref: ${{ inputs.ref }}
 
             - name: Build
+              env:
+                  OVERRIDE_JLINK_VERSION: ${{ inputs.jlink-version }}
               uses: ./.github/actions/build-action
 
             - name: Fetch certificate file
@@ -76,6 +92,7 @@ jobs:
                   APPLE_APP_SPECIFIC_PASSWORD:
                       ${{ secrets.WAYLAND_APPLE_APP_SPECIFIC_PASS }}
                   APPLE_TEAM_ID: ${{ secrets.WAYLAND_APPLE_TEAMID }}
+                  OVERRIDE_JLINK_VERSION: ${{ inputs.jlink-version }}
               run: npx electron-builder -p never --${{ inputs.arch }}
               if: github.event_name != 'pull_request'
 

--- a/.github/workflows/build_linux.yml
+++ b/.github/workflows/build_linux.yml
@@ -8,6 +8,12 @@ on:
                     Ref (Tag, branch, commit SHA) to build.
                     Defaults to the ref of the workflow.
                 type: string
+            jlink-version:
+                description:
+                    Which J-Link version is bundled with the launcher, e.g. v8.76.
+                    Only version available on files.nordicsemi.com can be used.
+                    Use this only for testing purposes.
+                type: string
             echo-inputs:
                 description: Print the workflow inputs.
                 type: boolean
@@ -16,6 +22,8 @@ on:
         inputs:
             ref:
                 description: Ref to build from
+                type: string
+            jlink-version:
                 type: string
             echo-inputs:
                 type: boolean
@@ -31,10 +39,14 @@ jobs:
               env:
                   REF: ${{ inputs.ref }}
                   FALLBACK_REF: ${{ github.ref_name }}
+                  JLINK_VERSION: ${{ inputs.jlink-version }}
               with:
                   script: |
                       core.summary.addHeading('Workflow inputs', '2');
-                      core.summary.addTable([['Ref', process.env.REF ? `<code>${process.env.REF}</code>` : `not set explicitly, using ref <code>${process.env.FALLBACK_REF}</code>`]]);
+                      core.summary.addTable([
+                          ['Ref', process.env.REF ? `<code>${process.env.REF}</code>` : `not set explicitly, using ref <code>${process.env.FALLBACK_REF}</code>`],
+                          ['J-Link version', process.env.JLINK_VERSION ? `<code>${process.env.JLINK_VERSION}</code>` : `not set`],
+                      ]);
                       core.summary.write();
 
             - uses: actions/checkout@v4
@@ -42,9 +54,13 @@ jobs:
                   ref: ${{ inputs.ref }}
 
             - name: Build
+              env:
+                  OVERRIDE_JLINK_VERSION: ${{ inputs.jlink-version }}
               uses: ./.github/actions/build-action
 
             - name: Run Electron Builder
+              env:
+                  OVERRIDE_JLINK_VERSION: ${{ inputs.jlink-version }}
               run: npx electron-builder -p never --x64
               if: github.event_name != 'pull_request'
 

--- a/.github/workflows/build_win.yml
+++ b/.github/workflows/build_win.yml
@@ -8,6 +8,12 @@ on:
                     Ref (Tag, branch, commit SHA) to build.
                     Defaults to the ref of the workflow.
                 type: string
+            jlink-version:
+                description:
+                    Which J-Link version is bundled with the launcher, e.g. v8.76.
+                    Only version available on files.nordicsemi.com can be used.
+                    Use this only for testing purposes.
+                type: string
             echo-inputs:
                 description: Print the workflow inputs.
                 type: boolean
@@ -16,6 +22,8 @@ on:
         inputs:
             ref:
                 description: Ref to build from
+                type: string
+            jlink-version:
                 type: string
             echo-inputs:
                 type: boolean
@@ -31,10 +39,14 @@ jobs:
               env:
                   REF: ${{ inputs.ref }}
                   FALLBACK_REF: ${{ github.ref_name }}
+                  JLINK_VERSION: ${{ inputs.jlink-version }}
               with:
                   script: |
                       core.summary.addHeading('Workflow inputs', '2');
-                      core.summary.addTable([['Ref', process.env.REF ? `<code>${process.env.REF}</code>` : `not set explicitly, using ref <code>${process.env.FALLBACK_REF}</code>`]]);
+                      core.summary.addTable([
+                          ['Ref', process.env.REF ? `<code>${process.env.REF}</code>` : `not set explicitly, using ref <code>${process.env.FALLBACK_REF}</code>`],
+                          ['J-Link version', process.env.JLINK_VERSION ? `<code>${process.env.JLINK_VERSION}</code>` : `not set`],
+                      ]);
                       core.summary.write();
 
             - uses: actions/checkout@v4
@@ -50,9 +62,13 @@ jobs:
               if: ${{ github.event_name != 'pull_request' }}
 
             - name: Build
+              env:
+                  OVERRIDE_JLINK_VERSION: ${{ inputs.jlink-version }}
               uses: ./.github/actions/build-action
 
             - name: Run Electron Builder
+              env:
+                  OVERRIDE_JLINK_VERSION: ${{ inputs.jlink-version }}
               run: |
                   npx electron-builder -p never --windows nsis:x64
               if: github.event_name != 'pull_request'

--- a/Changelog.minor.md
+++ b/Changelog.minor.md
@@ -52,6 +52,7 @@ release the new version.
 - #1223: Create log for messages from the renderer process in
   `nrfconnect/logs/renderer.log`.
 - #1235, #1236: Move some styling to use Tailwind.
+- #1265: For testing allow to specify a J-Link installer version to be bundled.
 
 ### Fixed
 

--- a/build/getJlink.js
+++ b/build/getJlink.js
@@ -5,13 +5,41 @@
  */
 
 const path = require('path');
+const os = require('os');
 
 const downloadJLink =
     require('@nordicsemiconductor/nrf-jlink-js').downloadAndSaveJLink;
 
 const bundledJLink = require('../src/main/bundledJlink');
+const downloadFile = require('../scripts/downloadFile');
 
-exports.default = () =>
+const downloadSpecificJLink = version => {
+    const platform = {
+        win32: 'Windows',
+        darwin: 'MacOSX',
+        linux: 'Linux',
+    }[os.platform()];
+    const arch = os.arch() === 'x64' ? 'x86_64' : os.arch();
+    const fileExtension = {
+        win32: 'exe',
+        darwin: 'pkg',
+        linux: 'deb',
+    }[os.platform()];
+
+    const filename = `JLink_${platform}_V${version.replace('.', '').replace(/^v/, '')}_${arch}.${fileExtension}`;
+
+    const url = `https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=true&repoKey=swtools&path=external/ncd/jlink/${filename}`;
+
+    return downloadFile(
+        url,
+        path.join('resources', 'prefetched', 'jlink', filename),
+    ).catch(error => {
+        console.error(`Failed to download J-Link from ${url}: `, error.message);
+        process.exit(-1);
+    });
+};
+
+const downloadLatestJLink = () =>
     downloadJLink(path.join('resources', 'prefetched', 'jlink'))
         .then(result => {
             if (bundledJLink.toLowerCase() !== result.version.toLowerCase()) {
@@ -20,8 +48,17 @@ exports.default = () =>
                 );
                 process.exit(-1);
             }
+
+            console.log(
+                `Downloaded J-Link version ${result.version} successfully.`,
+            );
         })
         .catch(error => {
             console.error('\n!!! EXCEPTION', error.message);
             process.exit(-1);
         });
+
+exports.default = () =>
+    process.env.OVERRIDE_JLINK_VERSION
+        ? downloadSpecificJLink(process.env.OVERRIDE_JLINK_VERSION)
+        : downloadLatestJLink();

--- a/build/getJlink.js
+++ b/build/getJlink.js
@@ -13,7 +13,19 @@ const downloadJLink =
 const bundledJLink = require('../src/main/bundledJlink');
 const downloadFile = require('../scripts/downloadFile');
 
+const assertValidVersion = version => {
+    const match = version.match(/^v(\d+\.\d+[a-z]?)$/i);
+
+    if (match == null) {
+        throw new Error(
+            'OVERRIDE_JLINK_VERSION must match v<major>.<minor><suffix>, for example v8.76, V9.24a, or v5.00.',
+        );
+    }
+};
+
 const downloadSpecificJLink = version => {
+    assertValidVersion(version);
+
     const platform = {
         win32: 'Windows',
         darwin: 'MacOSX',
@@ -26,7 +38,7 @@ const downloadSpecificJLink = version => {
         linux: 'deb',
     }[os.platform()];
 
-    const filename = `JLink_${platform}_V${version.replace('.', '').replace(/^v/, '')}_${arch}.${fileExtension}`;
+    const filename = `JLink_${platform}_V${version.replace('.', '').replace(/^v/i, '')}_${arch}.${fileExtension}`;
 
     const url = `https://files.nordicsemi.com/ui/api/v1/download?isNativeBrowsing=true&repoKey=swtools&path=external/ncd/jlink/${filename}`;
 

--- a/scripts/esbuild-renderer.ts
+++ b/scripts/esbuild-renderer.ts
@@ -23,6 +23,9 @@ build({
     define: {
         'process.env.PACKAGE_JSON': JSON.stringify(packageJson),
         'process.env.APPLICATIONINSIGHTS_CONFIGURATION_CONTENT': '"{}"', // Needed because of https://github.com/microsoft/ApplicationInsights-node.js/issues/1226
+        'process.env.OVERRIDE_JLINK_VERSION': JSON.stringify(
+            process.env.OVERRIDE_JLINK_VERSION ?? '',
+        ),
     },
 });
 

--- a/scripts/esbuild.ts
+++ b/scripts/esbuild.ts
@@ -29,6 +29,9 @@ const options = {
         }"`,
         'process.env.APPLICATIONINSIGHTS_CONFIGURATION_CONTENT': '"{}"', // Needed because of https://github.com/microsoft/ApplicationInsights-node.js/issues/1226
         'process.env.PACKAGE_JSON': JSON.stringify(packageJson),
+        'process.env.OVERRIDE_JLINK_VERSION': JSON.stringify(
+            process.env.OVERRIDE_JLINK_VERSION ?? '',
+        ),
     },
     minify: process.argv.includes('--prod'),
     target: [`node${nodeVersion}`],

--- a/src/main/bundledJlink.js
+++ b/src/main/bundledJlink.js
@@ -4,4 +4,6 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-module.exports = 'V9.24a';
+module.exports = process.env.OVERRIDE_JLINK_VERSION
+    ? process.env.OVERRIDE_JLINK_VERSION
+    : 'V9.24a';


### PR DESCRIPTION
For testing purposes, this allows building binaries with a different version of the J-Link installer than is defined in https://files.nordicsemi.com/ui/repos/tree/General/swtools/external/ncd/jlink/index.json.

To do this on the command line, define the env variable `OVERRIDE_JLINK_VERSION`, e.g. run 
```sh
OVERRIDE_JLINK_VERSION=v8.76 npm run pack
```

This can also be done in when running the build GitHub Actions, e.g. when running https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/actions/workflows/build.yml. An example of such a run, which bundles J-Link v8.76 is https://github.com/NordicSemiconductor/pc-nrfconnect-launcher/actions/runs/23501734025:

<img width="522" height="246" alt="image" src="https://github.com/user-attachments/assets/b679f182-cf14-419c-a9b1-4c0fd267c9c1" />

Only versions of J-Link found in https://files.nordicsemi.com/artifactory/swtools/external/ncd/jlink/ can be used.