### PR TITLE
Fix: Error during network initialization

### DIFF
--- a/src/main/net.ts
+++ b/src/main/net.ts
@@ -164,10 +164,10 @@ const doNetworkRequestToCheckForProxyAuthentication = () =>
                 /* do nothing, handler is only needed to consume all data */
             });
             res.on('end', () => resolve());
-            res.on('error', () => reject());
+            res.on('error', () => reject(new Error('We seem to be offline')));
         });
         req.on('login', handleLoginRequest);
-        req.on('error', () => reject());
+        req.on('error', () => reject(new Error('We seem to be offline')));
 
         req.end();
     });


### PR DESCRIPTION
If the network initialization fails while in an IPC handler, the promise was rejected without a reason. Electron's IPC implementation does not handle this well, so we now reject with an error.