### PR TITLE
fix: wrap linux shortcut executable path in double quotes

### DIFF
--- a/src/main/apps/createDesktopShortcut.ts
+++ b/src/main/apps/createDesktopShortcut.ts
@@ -113,7 +113,7 @@ const createShortcutForLinux = (app: LaunchableApp) => {
         'Encoding=UTF-8',
         `Version=${app.currentVersion}`,
         `Name=${fileName}`,
-        `Exec=${getElectronExePath().replace(/ /g, '\\ ')} ${args}`,
+        `Exec="${getElectronExePath()}" ${args}`,
         'Terminal=false',
         `Icon=${icon}`,
         'Type=Application',


### PR DESCRIPTION
I'm a bit unsure if we want this in the changelog since it only really affects 24.04 and is such a minor thing?