### PR TITLE
Fix "Update all apps"

### DIFF
--- a/Changelog.minor.md
+++ b/Changelog.minor.md
@@ -9,6 +9,13 @@ release the new version.
 
 ## Unreleased
 
+### Fixed
+
+- #1276: Button "Update all apps" was not disabled and tried to update apps
+  which are already being updated or removed.
+
+## 5.3.0
+
 ### Added
 
 - #1162: Update bundled J-Link to V9.24a.

--- a/src/launcher/features/apps/appsSlice.ts
+++ b/src/launcher/features/apps/appsSlice.ts
@@ -312,12 +312,9 @@ export const getUpdateCheckStatus = (state: RootState) => ({
     lastUpdateCheckDate: state.apps.lastUpdateCheckDate,
 });
 
-export const getUpdatableVisibleApps = (
-    state: RootState,
-): InstalledDownloadableApp[] =>
+export const getUpdatableVisibleApps = (state: RootState) =>
     state.apps.downloadableApps
         .filter(getAppsFilter(state))
-        .map((app: App) => app) // Narrowing the type, so that the final type is just InstalledDownloadableApp[]
         .filter(isUpdatable);
 
 export const isInProgress = (

--- a/src/launcher/features/filter/UpdateAllApps.tsx
+++ b/src/launcher/features/filter/UpdateAllApps.tsx
@@ -9,21 +9,29 @@ import Button from 'react-bootstrap/Button';
 
 import { useLauncherDispatch, useLauncherSelector } from '../../util/hooks';
 import { updateDownloadableApp } from '../apps/appsEffects';
-import { getUpdatableVisibleApps } from '../apps/appsSlice';
+import { getUpdatableVisibleApps, isInProgress } from '../apps/appsSlice';
 
 export default () => {
     const dispatch = useLauncherDispatch();
     const updatableApps = useLauncherSelector(getUpdatableVisibleApps);
 
     const updateAllApps = () =>
-        updatableApps.forEach(app => {
-            dispatch(updateDownloadableApp(app));
-        });
+        updatableApps
+            .filter(app => !isInProgress(app))
+            .forEach(app => {
+                dispatch(updateDownloadableApp(app));
+            });
 
     if (updatableApps.length === 0) return null;
 
+    const areAllUpdatableAppsInProgress = updatableApps.every(isInProgress);
+
     return (
-        <Button variant="outline-secondary" onClick={updateAllApps}>
+        <Button
+            variant="outline-secondary"
+            disabled={areAllUpdatableAppsInProgress}
+            onClick={updateAllApps}
+        >
             Update all apps
         </Button>
     );


### PR DESCRIPTION
Previously the "Update all apps" button was never disabled. Now it is disabled after either clicking on it or if all visible apps with updates are already in progress (because they were one by one asked to be updated or removed).

Also: When clicking on "Update all apps", only those apps are updated, which are not yet in progress.

Especially on Windows, where more strict file locking is in place, it seemed to be problematic, if an update was triggered multiple times (and potentially also while its removal was in progress).

Fixes [NCD-1641](https://nordicsemi.atlassian.net/browse/NCD-1641).