### PR TITLE
One-shot: Release launcher without GitHub

### DIFF
--- a/.github/workflows/continue-release-common.yml
+++ b/.github/workflows/continue-release-common.yml
@@ -55,20 +55,6 @@ jobs:
               run: |
                   gh release download "$TAG" --dir "$TAG" --repo nordicsemi/pc-nrfconnect-launcher
 
-            - name: Update the Windows checksum
-              env:
-                  GH_TOKEN: ${{ github.token }}
-              run: |
-                  export NEW_CHECKSUM="$(openssl dgst -sha512 -binary "$TAG"/nrfconnect-setup-*-x64.exe | openssl base64 -A)"
-                  yq '(.files[].sha512, .sha512) = strenv(NEW_CHECKSUM)' -i "$TAG/$CHANNEL.yml"
-                  gh release upload "$TAG" "$TAG/$CHANNEL.yml" --clobber --repo nordicsemi/pc-nrfconnect-launcher
-
-            - name: Publish GitHub Release
-              env:
-                  GH_TOKEN: ${{ github.token }}
-              run: |
-                  gh release edit "$TAG" --draft=false --repo nordicsemi/pc-nrfconnect-launcher
-
             - name: Generate top level yml files
               run: |
                   for yaml_file in */"$CHANNEL"*.yml; do

--- a/.github/workflows/continue-release-production.yml
+++ b/.github/workflows/continue-release-production.yml
@@ -25,12 +25,6 @@ jobs:
                       exit 1
                   fi
 
-                  # Check if GitHub release already exists
-                  if ! gh release view "$TAG" --repo nordicsemi/pc-nrfconnect-launcher >/dev/null 2>&1; then
-                      echo "::error::Not running because there is no GitHub release with the tag $TAG prepared yet"
-                      exit 1
-                  fi
-
                   # Check if Artifactory release already exists
                   ARTIFACTORY_URL="https://files.nordicsemi.com/artifactory/swtools/external/ncd/launcher/$TAG"
                   if curl --head --fail "$ARTIFACTORY_URL" >/dev/null 2>&1; then


### PR DESCRIPTION
We released 5.3.0 only to GitHub (because we did it manually) but not to Artifactory. As a consequence, the release also doesn't appear on https://www.nordicsemi.com/Products/Development-tools/nRF-Connect-for-Desktop/Download#infotabs.

This commit changes the “Continue production release” workflow so that it doesn't fail even though the release is already on GitHub and also doesn't try to publish to GitHub again but _does_ run the steps to publish to Artifactory.

This commit will not be merged to main. We will only run it manually once for 5.3.0.