### PR TITLE
doc: os support: linux tier updates

### DIFF
--- a/doc/get_started/docs/os_support.md
+++ b/doc/get_started/docs/os_support.md
@@ -6,8 +6,8 @@ The following table lists operating systems supported by nRF Connect for Desktop
 |---------------------------|----------------|---------------|---------------|
 | Windows 11                | Not applicable | Tier 1        | Not supported |
 | Windows 10                | Tier 3         | Tier 3        | Not supported |
-| Linux - Ubuntu 24.04 LTS  | Not supported  | Tier 2        | Not supported |
-| Linux - Ubuntu 22.04 LTS  | Not supported  | Tier 1        | Not supported |
+| Linux - Ubuntu 24.04 LTS  | Not supported  | Tier 1        | Not supported |
+| Linux - Ubuntu 22.04 LTS  | Not supported  | Tier 2        | Not supported |
 | Linux - Ubuntu 20.04 LTS  | Not supported  | Not supported | Not supported |
 | macOS 26                  | Not applicable | Tier 3        | Tier 3        |
 | macOS 15                  | Not applicable | Tier 1        | Tier 1        |

--- a/doc/launcher/docs/revision_history.yml
+++ b/doc/launcher/docs/revision_history.yml
@@ -2,6 +2,9 @@ tool:
 - name: nRF Connect for Desktop launcher
   link: true
 sections:
+- name: May 2026
+  entries:
+  - "Updated the [Supported operating systems](./os_support.md) page: Linux - Ubuntu 24.04 LTS is now Tier 1, Linux - Ubuntu 22.04 LTS is now Tier 2."
 - name: February 2026
   entries:
   - "Updated the [Requirements and installation](./download_cfd.md) page to list requirements in a table."


### PR DESCRIPTION
Updated Ubuntu 24.04 to Tier 1 and Ubuntu 22.04 to Tier 2. NCSDK-38777.