### PR TITLE
Update documentation links

### DIFF
--- a/Changelog.minor.md
+++ b/Changelog.minor.md
@@ -13,6 +13,7 @@ release the new version.
 
 - #1276: Button "Update all apps" was not disabled and tried to update apps
   which are already being updated or removed.
+- #1284: Links to outdated documentation bundle.
 
 ## 5.3.0
 

--- a/src/launcher/features/about/About.tsx
+++ b/src/launcher/features/about/About.tsx
@@ -20,7 +20,7 @@ export default () => (
         </Card>
         <Card title="Documentation">
             <Button
-                href="https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/index.html"
+                href="https://docs.nordicsemi.com/bundle/swtools_docs/page/index.html"
                 target="_blank"
                 variant="outline-primary"
             >

--- a/src/launcher/features/settings/AddArtifactoryTokenDialog.tsx
+++ b/src/launcher/features/settings/AddArtifactoryTokenDialog.tsx
@@ -62,7 +62,7 @@ export default () => {
                 />
                 . Read{' '}
                 <ExternalLink
-                    href="https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/working_with_authentications_tokens.html"
+                    href="https://docs.nordicsemi.com/bundle/swtools_docs/page/app/pc-nrfconnect-launcher/working_with_authentications_tokens.html"
                     label="Working with identity tokens"
                 />{' '}
                 for detailed steps.

--- a/src/launcher/features/settings/Cards/Authentication.tsx
+++ b/src/launcher/features/settings/Cards/Authentication.tsx
@@ -60,7 +60,7 @@ export default () => {
                         Semiconductor, you need an identity token. Generating a
                         token is described in{' '}
                         <ExternalLink
-                            href="https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/working_with_authentications_tokens.html#generating-a-new-token"
+                            href="https://docs.nordicsemi.com/bundle/swtools_docs/page/app/pc-nrfconnect-launcher/working_with_authentications_tokens.html#generating-a-new-token"
                             label="Working with identity tokens"
                         />
                         .

--- a/src/launcher/features/settings/__snapshots__/Settings.test.tsx.snap
+++ b/src/launcher/features/settings/__snapshots__/Settings.test.tsx.snap
@@ -137,10 +137,10 @@ exports[`SettingsView should render check for updates completed, with everything
                  
                 <a
                   class="tw-preflight tw-text-nordicBlue hover:tw-underline"
-                  href="https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/working_with_authentications_tokens.html#generating-a-new-token"
+                  href="https://docs.nordicsemi.com/bundle/swtools_docs/page/app/pc-nrfconnect-launcher/working_with_authentications_tokens.html#generating-a-new-token"
                   rel="noreferrer noopener"
                   target="_blank"
-                  title="https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/working_with_authentications_tokens.html#generating-a-new-token"
+                  title="https://docs.nordicsemi.com/bundle/swtools_docs/page/app/pc-nrfconnect-launcher/working_with_authentications_tokens.html#generating-a-new-token"
                 >
                   Working with identity tokens
                 </a>
@@ -454,10 +454,10 @@ exports[`SettingsView should render check for updates completed, with updates av
                  
                 <a
                   class="tw-preflight tw-text-nordicBlue hover:tw-underline"
-                  href="https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/working_with_authentications_tokens.html#generating-a-new-token"
+                  href="https://docs.nordicsemi.com/bundle/swtools_docs/page/app/pc-nrfconnect-launcher/working_with_authentications_tokens.html#generating-a-new-token"
                   rel="noreferrer noopener"
                   target="_blank"
-                  title="https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/working_with_authentications_tokens.html#generating-a-new-token"
+                  title="https://docs.nordicsemi.com/bundle/swtools_docs/page/app/pc-nrfconnect-launcher/working_with_authentications_tokens.html#generating-a-new-token"
                 >
                   Working with identity tokens
                 </a>
@@ -1043,10 +1043,10 @@ exports[`SettingsView should render when checking for updates 1`] = `
                  
                 <a
                   class="tw-preflight tw-text-nordicBlue hover:tw-underline"
-                  href="https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/working_with_authentications_tokens.html#generating-a-new-token"
+                  href="https://docs.nordicsemi.com/bundle/swtools_docs/page/app/pc-nrfconnect-launcher/working_with_authentications_tokens.html#generating-a-new-token"
                   rel="noreferrer noopener"
                   target="_blank"
-                  title="https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/working_with_authentications_tokens.html#generating-a-new-token"
+                  title="https://docs.nordicsemi.com/bundle/swtools_docs/page/app/pc-nrfconnect-launcher/working_with_authentications_tokens.html#generating-a-new-token"
                 >
                   Working with identity tokens
                 </a>
@@ -1309,10 +1309,10 @@ exports[`SettingsView should render with check for updates disabled 1`] = `
                  
                 <a
                   class="tw-preflight tw-text-nordicBlue hover:tw-underline"
-                  href="https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/working_with_authentications_tokens.html#generating-a-new-token"
+                  href="https://docs.nordicsemi.com/bundle/swtools_docs/page/app/pc-nrfconnect-launcher/working_with_authentications_tokens.html#generating-a-new-token"
                   rel="noreferrer noopener"
                   target="_blank"
-                  title="https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/working_with_authentications_tokens.html#generating-a-new-token"
+                  title="https://docs.nordicsemi.com/bundle/swtools_docs/page/app/pc-nrfconnect-launcher/working_with_authentications_tokens.html#generating-a-new-token"
                 >
                   Working with identity tokens
                 </a>
@@ -1575,10 +1575,10 @@ exports[`SettingsView should render with check for updates enabled 1`] = `
                  
                 <a
                   class="tw-preflight tw-text-nordicBlue hover:tw-underline"
-                  href="https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/working_with_authentications_tokens.html#generating-a-new-token"
+                  href="https://docs.nordicsemi.com/bundle/swtools_docs/page/app/pc-nrfconnect-launcher/working_with_authentications_tokens.html#generating-a-new-token"
                   rel="noreferrer noopener"
                   target="_blank"
-                  title="https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/working_with_authentications_tokens.html#generating-a-new-token"
+                  title="https://docs.nordicsemi.com/bundle/swtools_docs/page/app/pc-nrfconnect-launcher/working_with_authentications_tokens.html#generating-a-new-token"
                 >
                   Working with identity tokens
                 </a>
@@ -1845,10 +1845,10 @@ exports[`SettingsView should render with last update check date 1`] = `
                  
                 <a
                   class="tw-preflight tw-text-nordicBlue hover:tw-underline"
-                  href="https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/working_with_authentications_tokens.html#generating-a-new-token"
+                  href="https://docs.nordicsemi.com/bundle/swtools_docs/page/app/pc-nrfconnect-launcher/working_with_authentications_tokens.html#generating-a-new-token"
                   rel="noreferrer noopener"
                   target="_blank"
-                  title="https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/working_with_authentications_tokens.html#generating-a-new-token"
+                  title="https://docs.nordicsemi.com/bundle/swtools_docs/page/app/pc-nrfconnect-launcher/working_with_authentications_tokens.html#generating-a-new-token"
                 >
                   Working with identity tokens
                 </a>

--- a/src/launcher/features/sources/MissingTokenWarning.tsx
+++ b/src/launcher/features/sources/MissingTokenWarning.tsx
@@ -121,7 +121,7 @@ export default () => {
                 />
                 . Read{' '}
                 <ExternalLink
-                    href="https://docs.nordicsemi.com/bundle/nrf-connect-desktop/page/working_with_authentications_tokens.html#generating-a-new-token"
+                    href="https://docs.nordicsemi.com/bundle/swtools_docs/page/app/pc-nrfconnect-launcher/working_with_authentications_tokens.html#generating-a-new-token"
                     label="Working with identity tokens"
                 />{' '}
                 for detailed steps.


### PR DESCRIPTION
https://docs.nordicsemi.com/bundle/nrf-connect-desktop is the outdated bundle which is not updated anymore. Correct is now to link to https://docs.nordicsemi.com/bundle/swtools_docs.