### PR TITLE
Let renovate bot create PRs for GitHub Actions

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,8 +4,20 @@
     "labels": ["doc not required", "ui not required"],
     "packageRules": [
         {
-            "enabled": false,
-            "matchPackageNames": ["!@nordicsemiconductor/pc-nrfconnect-shared"]
+            "matchManagers": ["npm"],
+            "matchPackageNames": ["!@nordicsemiconductor/pc-nrfconnect-shared"],
+            "enabled": false
+        },
+        {
+            "matchManagers": ["github-actions"],
+            "enabled": true,
+            "pinDigests": true,
+            "groupName": "GitHub Actions"
+        },
+        {
+            "matchManagers": ["github-actions"],
+            "matchPackageNames": ["nordicsemi/pc-nrfconnect-shared"],
+            "enabled": false
         }
     ]
 }


### PR DESCRIPTION
With this:
- Renovate bot will create PRs for GitHub Actions.
- For security reasons, it will use digest pinning.
- It will ignore the actions from shared, because we currently always use main for convenience.
- It will group all updates to GitHub Actions in a single PR.