### PR TITLE
[DNM] doc: add debian 12 to supported os list

### DIFF
--- a/doc/get_started/docs/os_support.md
+++ b/doc/get_started/docs/os_support.md
@@ -9,6 +9,7 @@ The following table lists operating systems supported by nRF Connect for Desktop
 | Linux - Ubuntu 24.04 LTS  | Not supported  | Tier 1        | Not supported |
 | Linux - Ubuntu 22.04 LTS  | Not supported  | Tier 2        | Not supported |
 | Linux - Ubuntu 20.04 LTS  | Not supported  | Not supported | Not supported |
+| Linux - Debian 12         | Not supported  | Not supported | Tier 1        |
 | macOS 26                  | Not applicable | Tier 3        | Tier 3        |
 | macOS 15                  | Not applicable | Tier 1        | Tier 1        |
 | macOS 14                  | Not applicable | Tier 3        | Tier 3        |

--- a/doc/launcher/docs/revision_history.yml
+++ b/doc/launcher/docs/revision_history.yml
@@ -2,6 +2,9 @@ tool:
 - name: nRF Connect for Desktop launcher
   link: true
 sections:
+- name: June 2026
+  entries:
+  - "Updated the [Supported operating systems](./os_support.md) page: added Linux - Debian 12 as Tier 1."
 - name: May 2026
   entries:
   - "Updated the [Supported operating systems](./os_support.md) page: Linux - Ubuntu 24.04 LTS is now Tier 1, Linux - Ubuntu 22.04 LTS is now Tier 2."


### PR DESCRIPTION
Added Debian 12 to the list of supported operating systems. Alignment with [NRFU-1824](https://nordicsemi.atlassian.net/browse/NRFU-1824).

----

- [ ] Bump tag to trigger doc update.