### PR TITLE
docs: fix link to documentation in About page

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,9 @@
+## 5.3.2 - Unreleased
+
+### Fixed
+
+- Broken link for the **Open Documentation** button.
+
 ## 5.3.1 - 2026-05-05
 
 ### Fixed

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ### Fixed
 
-- Broken link for the **Open Documentation** button.
+- Several broken documentation links in different areas of the app.
 
 ## 5.3.1 - 2026-05-05
 

--- a/src/launcher/features/about/About.tsx
+++ b/src/launcher/features/about/About.tsx
@@ -20,7 +20,7 @@ export default () => (
         </Card>
         <Card title="Documentation">
             <Button
-                href="https://docs.nordicsemi.com/bundle/swtools_docs/page/index.html"
+                href="https://docs.nordicsemi.com/r/bundle/nrf-connect-for-desktop/page/index.html"
                 target="_blank"
                 variant="outline-primary"
             >


### PR DESCRIPTION
Fixed the broken link to documentation for the Open Documentation button. Reported by Slava.