### PR TITLE
Feat/deeplink app open

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,14 @@
     "build": {
         "appId": "com.nordicsemi.nrfconnect",
         "productName": "nRF Connect for Desktop",
+        "protocols": [
+            {
+                "name": "nRF Connect for Desktop",
+                "schemes": [
+                    "nrfconnectfordesktop"
+                ]
+            }
+        ],
         "asarUnpack": [
             "resources/nrfutil-sandboxes",
             "resources/prefetched/jlink"

--- a/src/ipc/openAppConfirmation.ts
+++ b/src/ipc/openAppConfirmation.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import * as mainToRenderer from '@nordicsemiconductor/pc-nrfconnect-shared/ipc/infrastructure/mainToRenderer';
+import * as rendererToMain from '@nordicsemiconductor/pc-nrfconnect-shared/ipc/infrastructure/rendererToMain';
+import { type SourceName } from '@nordicsemiconductor/pc-nrfconnect-shared/ipc/sources';
+
+const channel = {
+    request: 'open-app-confirmation:request',
+    response: 'open-app-confirmation:response',
+};
+
+type RequestOpenAppConfirmation = (
+    requestId: string,
+    name: string,
+    source: SourceName,
+) => void;
+
+const requestOpenAppConfirmation =
+    mainToRenderer.send<RequestOpenAppConfirmation>(channel.request);
+const registerRequestOpenAppConfirmation =
+    mainToRenderer.on<RequestOpenAppConfirmation>(channel.request);
+
+type AnswerOpenAppConfirmation = (
+    requestId: string,
+    confirmed: boolean,
+) => void;
+
+const answerOpenAppConfirmation =
+    rendererToMain.send<AnswerOpenAppConfirmation>(channel.response);
+const registerAnswerOpenAppConfirmation =
+    rendererToMain.on<AnswerOpenAppConfirmation>(channel.response);
+
+export const inRenderer = { requestOpenAppConfirmation };
+export const forRenderer = { registerAnswerOpenAppConfirmation };
+export const inMain = { answerOpenAppConfirmation };
+export const forMain = { registerRequestOpenAppConfirmation };

--- a/src/launcher/Root.tsx
+++ b/src/launcher/Root.tsx
@@ -16,6 +16,7 @@ import About from './features/about/About';
 import AppleSiliconAlert from './features/appleSilicon/AppleSiliconAlert';
 import AppleSiliconDialog from './features/appleSilicon/AppleSiliconDialog';
 import AppList from './features/apps/AppList';
+import OpenAppConfirmationDialog from './features/deepLink/OpenAppConfirmationDialog';
 import JLinkUpdateDialog from './features/jlinkUpdate/JLinkUpdateDialog';
 import JLinkUpdateProgressDialog from './features/jlinkUpdate/JLinkUpdateProgressDialog';
 import UpdateAvailableDialog from './features/launcherUpdate/UpdateAvailableDialog';
@@ -100,6 +101,7 @@ export default () => {
             <TelemetryDialog />
             <ProxyLoginDialog />
             <ProxyErrorDialog />
+            <OpenAppConfirmationDialog />
             <AppleSiliconDialog />
             <QuickStartDialog />
             <DeprecatedSourcesDialog />

--- a/src/launcher/features/deepLink/OpenAppConfirmationDialog.tsx
+++ b/src/launcher/features/deepLink/OpenAppConfirmationDialog.tsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import React, { useCallback } from 'react';
+import { ConfirmationDialog } from '@nordicsemiconductor/pc-nrfconnect-shared';
+
+import { inMain as openAppConfirmation } from '../../../ipc/openAppConfirmation';
+import { useLauncherDispatch, useLauncherSelector } from '../../util/hooks';
+import {
+    getOpenAppConfirmationRequest,
+    openAppConfirmationAnswered,
+} from './openAppConfirmationSlice';
+
+export default () => {
+    const dispatch = useLauncherDispatch();
+    const { isVisible, requestId, name, source } = useLauncherSelector(
+        getOpenAppConfirmationRequest,
+    );
+
+    const answer = useCallback(
+        (confirmed: boolean) => {
+            if (requestId == null) return;
+            openAppConfirmation.answerOpenAppConfirmation(requestId, confirmed);
+            dispatch(openAppConfirmationAnswered());
+        },
+        [dispatch, requestId],
+    );
+
+    return (
+        <ConfirmationDialog
+            isVisible={isVisible}
+            title="Open application"
+            confirmLabel="Open"
+            onConfirm={() => answer(true)}
+            onCancel={() => answer(false)}
+        >
+            <p>{`A link is requesting to open "${name}" from source "${source}".`}</p>
+        </ConfirmationDialog>
+    );
+};

--- a/src/launcher/features/deepLink/openAppConfirmationSlice.ts
+++ b/src/launcher/features/deepLink/openAppConfirmationSlice.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import { type SourceName } from '@nordicsemiconductor/pc-nrfconnect-shared/ipc/sources';
+import type { PayloadAction } from '@reduxjs/toolkit';
+import { createSlice } from '@reduxjs/toolkit';
+
+import type { RootState } from '../../store';
+
+export type State = {
+    requestId?: string;
+    name: string;
+    source?: SourceName;
+};
+
+const initialState: State = { name: '' };
+
+const slice = createSlice({
+    name: 'openAppConfirmation',
+    initialState,
+    reducers: {
+        openAppConfirmationRequested(
+            state,
+            {
+                payload: { requestId, name, source },
+            }: PayloadAction<{
+                requestId: string;
+                name: string;
+                source: SourceName;
+            }>,
+        ) {
+            state.requestId = requestId;
+            state.name = name;
+            state.source = source;
+        },
+        openAppConfirmationAnswered(state) {
+            state.requestId = undefined;
+        },
+    },
+});
+
+export default slice.reducer;
+
+export const { openAppConfirmationRequested, openAppConfirmationAnswered } =
+    slice.actions;
+
+export const getOpenAppConfirmationRequest = (state: RootState) => ({
+    ...state.openAppConfirmation,
+    isVisible: state.openAppConfirmation.requestId != null,
+});

--- a/src/launcher/store.ts
+++ b/src/launcher/store.ts
@@ -13,6 +13,7 @@ import { type ThunkAction } from 'redux-thunk';
 import appleSilicon from './features/appleSilicon/appleSiliconSlice';
 import appDialogs from './features/apps/appDialogsSlice';
 import apps from './features/apps/appsSlice';
+import openAppConfirmation from './features/deepLink/openAppConfirmationSlice';
 import filter from './features/filter/filterSlice';
 import jlinkUpdate from './features/jlinkUpdate/jlinkUpdateSlice';
 import launcherUpdate from './features/launcherUpdate/launcherUpdateSlice';
@@ -39,6 +40,7 @@ export const reducer = {
     settings,
     sources,
     telemetry,
+    openAppConfirmation,
 };
 
 const store = configureStore({

--- a/src/launcher/util/registerIpcHandler.ts
+++ b/src/launcher/util/registerIpcHandler.ts
@@ -9,6 +9,7 @@ import { ErrorDialogActions } from '@nordicsemiconductor/pc-nrfconnect-shared';
 import * as appInstallProgress from '../../ipc/appInstallProgress';
 import * as installJlink from '../../ipc/jlinkProgress';
 import * as launcherUpdateProgress from '../../ipc/launcherUpdateProgress';
+import * as openAppConfirmation from '../../ipc/openAppConfirmation';
 import * as proxyLogin from '../../ipc/proxyLogin';
 import * as showErrorDialog from '../../ipc/showErrorDialog';
 import {
@@ -17,6 +18,7 @@ import {
     resetAppInstallProgress,
     updateAppInstallProgress,
 } from '../features/apps/appsSlice';
+import { openAppConfirmationRequested } from '../features/deepLink/openAppConfirmationSlice';
 import { updateProgress as updateJLinkProgress } from '../features/jlinkUpdate/jlinkUpdateSlice';
 import {
     reset,
@@ -58,4 +60,10 @@ export default (dispatch: AppDispatch) => {
     installJlink.forMain.registerUpdateJLinkProgress(update => {
         dispatch(updateJLinkProgress(update));
     });
+
+    openAppConfirmation.forMain.registerRequestOpenAppConfirmation(
+        (requestId, name, source) => {
+            dispatch(openAppConfirmationRequested({ requestId, name, source }));
+        },
+    );
 };

--- a/src/main/deepLink/handlers/appsHandler.ts
+++ b/src/main/deepLink/handlers/appsHandler.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import {
+    OFFICIAL,
+    type SourceName,
+} from '@nordicsemiconductor/pc-nrfconnect-shared/ipc/sources';
+import { dialog } from 'electron';
+
+import { logger } from '../../log';
+import { openInstalledApp } from '../../windows';
+
+export const handleOpenAppDeepLink = async (url: URL) => {
+    const name = decodeURIComponent(
+        url.pathname.replace(/^\/open\//, '').split('/')[0],
+    );
+    if (!name) return logger.warn('Open-app deep link without app name');
+    const source = (url.searchParams.get('source') ?? OFFICIAL) as SourceName;
+    const args: string[] = [];
+    url.searchParams.forEach((v, k) => {
+        if (k !== 'source') args.push(`--${k}`, v);
+    });
+
+    const { response } = await dialog.showMessageBox({
+        type: 'question',
+        buttons: ['Cancel', 'Open'],
+        defaultId: 1, // Enter -> Open
+        cancelId: 0, // Esc -> Cancel
+        title: 'Open application',
+        message: `Open "${name}"?`,
+        detail: `A link is requesting to open "${name}" from source "${source}".`,
+    });
+
+    if (response !== 1) {
+        logger.info(`User declined deep-link open of "${name}"`);
+        return;
+    }
+
+    openInstalledApp(name, source, args);
+};

--- a/src/main/deepLink/handlers/appsHandler.ts
+++ b/src/main/deepLink/handlers/appsHandler.ts
@@ -8,10 +8,10 @@ import {
     OFFICIAL,
     type SourceName,
 } from '@nordicsemiconductor/pc-nrfconnect-shared/ipc/sources';
-import { dialog } from 'electron';
 
 import { logger } from '../../log';
-import { openInstalledApp } from '../../windows';
+import { openInstalledApp, openLauncherWindow } from '../../windows';
+import { requestOpenAppConfirmation } from '../openAppConfirmation';
 
 export const handleOpenAppDeepLink = async (url: URL) => {
     const name = decodeURIComponent(
@@ -24,17 +24,10 @@ export const handleOpenAppDeepLink = async (url: URL) => {
         if (k !== 'source') args.push(`--${k}`, v);
     });
 
-    const { response } = await dialog.showMessageBox({
-        type: 'question',
-        buttons: ['Cancel', 'Open'],
-        defaultId: 1, // Enter -> Open
-        cancelId: 0, // Esc -> Cancel
-        title: 'Open application',
-        message: `Open "${name}"?`,
-        detail: `A link is requesting to open "${name}" from source "${source}".`,
-    });
+    openLauncherWindow();
 
-    if (response !== 1) {
+    const confirmed = await requestOpenAppConfirmation(name, source);
+    if (!confirmed) {
         logger.info(`User declined deep-link open of "${name}"`);
         return;
     }

--- a/src/main/deepLink/handlers/appsHandler.ts
+++ b/src/main/deepLink/handlers/appsHandler.ts
@@ -24,7 +24,7 @@ export const handleOpenAppDeepLink = async (url: URL) => {
         if (k !== 'source') args.push(`--${k}`, v);
     });
 
-    openLauncherWindow();
+    await openLauncherWindow();
 
     const confirmed = await requestOpenAppConfirmation(name, source);
     if (!confirmed) {

--- a/src/main/deepLink/index.ts
+++ b/src/main/deepLink/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+export { registerProtocolClient, DEEPLINK_SCHEME } from './protocolClient';
+export { handleDeepLink, findDeepLink } from './router';

--- a/src/main/deepLink/index.ts
+++ b/src/main/deepLink/index.ts
@@ -4,9 +4,5 @@
  * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
  */
 
-export { registerProtocolClient, DEEPLINK_SCHEME } from './protocolClient';
-export {
-    containsDeepLink,
-    handleDeepLink,
-    handleDeepLinkFromArgv,
-} from './router';
+export { registerDeepLinkHandling } from './protocolClient';
+export { containsDeepLink, handleDeepLinkFromArgv } from './router';

--- a/src/main/deepLink/index.ts
+++ b/src/main/deepLink/index.ts
@@ -5,4 +5,8 @@
  */
 
 export { registerProtocolClient, DEEPLINK_SCHEME } from './protocolClient';
-export { handleDeepLink, findDeepLink } from './router';
+export {
+    containsDeepLink,
+    handleDeepLink,
+    handleDeepLinkFromArgv,
+} from './router';

--- a/src/main/deepLink/openAppConfirmation.ts
+++ b/src/main/deepLink/openAppConfirmation.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import { type SourceName } from '@nordicsemiconductor/pc-nrfconnect-shared/ipc/sources';
+import { uuid } from 'short-uuid';
+
+import { inRenderer as openAppConfirmation } from '../../ipc/openAppConfirmation';
+
+const pendingRequests = new Map<string, (confirmed: boolean) => void>();
+
+export const requestOpenAppConfirmation = (name: string, source: SourceName) =>
+    new Promise<boolean>(resolve => {
+        const requestId = uuid();
+        pendingRequests.set(requestId, resolve);
+        openAppConfirmation.requestOpenAppConfirmation(requestId, name, source);
+    });
+
+export const answerOpenAppConfirmation = (
+    requestId: string,
+    confirmed: boolean,
+) => {
+    const resolve = pendingRequests.get(requestId);
+    if (resolve == null) return;
+
+    resolve(confirmed);
+    pendingRequests.delete(requestId);
+};

--- a/src/main/deepLink/protocolClient.ts
+++ b/src/main/deepLink/protocolClient.ts
@@ -9,10 +9,9 @@ import path from 'path';
 
 import { logger } from '../log';
 import { registerLinuxAppImageProtocolClient } from './registerLinuxProtocolClient';
+import { DEEPLINK_SCHEME, handleDeepLink } from './router';
 
-export const DEEPLINK_SCHEME = 'nrfconnectfordesktop';
-
-export const registerProtocolClient = () => {
+export const registerDeepLinkHandling = () => {
     if (process.platform === 'linux') {
         // AppImage is not installed into the system, so there is no existing
         // .desktop file for setAsDefaultProtocolClient() to update.
@@ -32,4 +31,9 @@ export const registerProtocolClient = () => {
     } else {
         app.setAsDefaultProtocolClient(DEEPLINK_SCHEME);
     }
+
+    app.on('open-url', (event, url) => {
+        event.preventDefault();
+        handleDeepLink(url);
+    });
 };

--- a/src/main/deepLink/protocolClient.ts
+++ b/src/main/deepLink/protocolClient.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import { app } from 'electron';
+import path from 'path';
+
+export const DEEPLINK_SCHEME = 'nrfconnectfordesktop';
+
+export const registerProtocolClient = () => {
+    if (process.defaultApp) {
+        // dev / unpackaged
+        if (process.argv.length >= 2) {
+            app.setAsDefaultProtocolClient(DEEPLINK_SCHEME, process.execPath, [
+                path.resolve(process.argv[1]),
+            ]);
+        }
+    } else {
+        app.setAsDefaultProtocolClient(DEEPLINK_SCHEME);
+    }
+};

--- a/src/main/deepLink/protocolClient.ts
+++ b/src/main/deepLink/protocolClient.ts
@@ -7,9 +7,21 @@
 import { app } from 'electron';
 import path from 'path';
 
+import { logger } from '../log';
+import { registerLinuxAppImageProtocolClient } from './registerLinuxProtocolClient';
+
 export const DEEPLINK_SCHEME = 'nrfconnectfordesktop';
 
 export const registerProtocolClient = () => {
+    if (process.platform === 'linux') {
+        // AppImage is not installed into the system, so there is no existing
+        // .desktop file for setAsDefaultProtocolClient() to update.
+        registerLinuxAppImageProtocolClient(DEEPLINK_SCHEME).catch(error =>
+            logger.warn(`Failed to register deep link handler: ${error}`),
+        );
+        return;
+    }
+
     if (process.defaultApp) {
         // dev / unpackaged
         if (process.argv.length >= 2) {

--- a/src/main/deepLink/registerLinuxProtocolClient.ts
+++ b/src/main/deepLink/registerLinuxProtocolClient.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import { execFile } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+import { getNrfConnectForDesktopIcon } from '../icons';
+import { logger } from '../log';
+
+const desktopFileName = 'nrfconnect-deeplink.desktop';
+
+const applicationsDir = () =>
+    path.join(
+        process.env.XDG_DATA_HOME ?? path.join(os.homedir(), '.local/share'),
+        'applications',
+    );
+
+// The Exec key follows the quoting rules of the Desktop Entry Specification,
+// not shell quoting: https://specifications.freedesktop.org/desktop-entry-spec
+const escapeExecValue = (value: string) =>
+    value.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/%/g, '%%');
+
+const runCommand = (command: string, args: string[]) =>
+    new Promise<void>(resolve => {
+        execFile(command, args, error => {
+            if (error) {
+                logger.warn(`Failed to run ${command}: ${error.message}`);
+            }
+            resolve();
+        });
+    });
+
+/*
+ * AppImage does not install anything into the system, so Electron's
+ * app.setAsDefaultProtocolClient() has nothing to register on Linux (it only
+ * updates an already-installed .desktop file). We instead write and register
+ * our own .desktop file, pointing at the stable AppImage path (process.env.APPIMAGE),
+ * since process.execPath is an ephemeral squashfs mount that disappears once
+ * the app exits.
+ */
+export const registerLinuxAppImageProtocolClient = async (scheme: string) => {
+    const appImagePath = process.env.APPIMAGE;
+    if (!appImagePath) return;
+
+    const dir = applicationsDir();
+    fs.mkdirSync(dir, { recursive: true });
+
+    const desktopEntry = [
+        '[Desktop Entry]',
+        'Name=nRF Connect for Desktop',
+        // chrome-sandbox needs to be owned by root with the setuid bit set,
+        // which an unprivileged AppImage extraction/mount can never provide.
+        `Exec="${escapeExecValue(appImagePath)}" --no-sandbox %u`,
+        `Icon=${getNrfConnectForDesktopIcon()}`,
+        'Type=Application',
+        'Terminal=false',
+        `MimeType=x-scheme-handler/${scheme};`,
+        'Categories=Development;',
+        '',
+    ].join('\n');
+
+    fs.writeFileSync(path.join(dir, desktopFileName), desktopEntry);
+
+    await runCommand('update-desktop-database', [dir]);
+    await runCommand('xdg-mime', [
+        'default',
+        desktopFileName,
+        `x-scheme-handler/${scheme}`,
+    ]);
+};

--- a/src/main/deepLink/router.ts
+++ b/src/main/deepLink/router.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: LicenseRef-Nordic-4-Clause
+ */
+
+import { app } from 'electron';
+
+import { logger } from '../log';
+import { handleOpenAppDeepLink } from './handlers/appsHandler';
+import { DEEPLINK_SCHEME } from './protocolClient';
+
+// Define deep link routes here. Each route has a match function and a handle function.
+// The match function should return true if the URL matches the route, and the handle function should handle the URL.
+const routes: { match: (u: URL) => boolean; handle: (u: URL) => unknown }[] = [
+    {
+        match: u => u.host === 'apps' && u.pathname.startsWith('/open/'),
+        handle: handleOpenAppDeepLink,
+    },
+];
+
+const routeDeepLink = async (url: URL) => {
+    const route = routes.find(r => r.match(url));
+    if (!route)
+        return logger.warn(
+            `Unknown deep link route: ${url.host}${url.pathname}`,
+        );
+    await route.handle(url);
+};
+
+export const handleDeepLink = (rawUrl?: string) => {
+    if (!rawUrl) return;
+
+    let url: URL;
+    try {
+        url = new URL(rawUrl);
+    } catch {
+        logger.warn(`Invalid deep link URL: ${rawUrl}`);
+        return;
+    }
+
+    app.whenReady().then(() =>
+        routeDeepLink(url).catch(err =>
+            logger.error(`Deep link handling failed: ${err}`),
+        ),
+    );
+};
+
+export const findDeepLink = (args: string[]) =>
+    args.find(a => a.startsWith(`${DEEPLINK_SCHEME}://`));

--- a/src/main/deepLink/router.ts
+++ b/src/main/deepLink/router.ts
@@ -46,5 +46,11 @@ export const handleDeepLink = (rawUrl?: string) => {
     );
 };
 
-export const findDeepLink = (args: string[]) =>
+const findDeepLink = (args: string[]) =>
     args.find(a => a.startsWith(`${DEEPLINK_SCHEME}://`));
+
+export const containsDeepLink = (args: string[]) => findDeepLink(args) != null;
+
+export const handleDeepLinkFromArgv = (argv = process.argv) => {
+    handleDeepLink(findDeepLink(argv));
+};

--- a/src/main/deepLink/router.ts
+++ b/src/main/deepLink/router.ts
@@ -8,7 +8,8 @@ import { app } from 'electron';
 
 import { logger } from '../log';
 import { handleOpenAppDeepLink } from './handlers/appsHandler';
-import { DEEPLINK_SCHEME } from './protocolClient';
+
+export const DEEPLINK_SCHEME = 'nrfconnectfordesktop';
 
 // Define deep link routes here. Each route has a match function and a handle function.
 // The match function should return true if the URL matches the route, and the handle function should handle the URL.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -21,14 +21,19 @@ import storeExecutablePath from './storeExecutablePath';
 
 telemetry.enableTelemetry();
 
+// Initialise infrastructure
 registerDeepLinkHandling();
-handleDeepLinkFromArgv();
-
 initNrfUtilProxyEnv();
 singeInstanceLock();
 initializeElectronRemote();
+registerIpcHandler();
+
+// Run migrations
 migrateSourcesJson();
 migrateSourcesVersionedJson();
-registerIpcHandler();
+
+// Start app
+handleDeepLinkFromArgv();
 configureElectronApp();
+
 storeExecutablePath();

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -15,8 +15,8 @@ import { migrateSourcesJson } from './apps/dataMigration/migrateSourcesJson';
 import { migrateSourcesVersionedJson } from './apps/dataMigration/migrateSourcesVersionedJson';
 import configureElectronApp from './configureElectronApp';
 import {
-    findDeepLink,
     handleDeepLink,
+    handleDeepLinkFromArgv,
     registerProtocolClient,
 } from './deepLink';
 import initNrfUtilProxyEnv from './initNrfUtilProxyEnv';
@@ -35,7 +35,7 @@ app.on('open-url', (event, url) => {
 });
 
 // Windows / Linux cold start (URL is in argv)
-handleDeepLink(findDeepLink(process.argv));
+handleDeepLinkFromArgv();
 
 initNrfUtilProxyEnv();
 singeInstanceLock();

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -9,16 +9,11 @@ import './setUserDataDir';
 
 import { initialize as initializeElectronRemote } from '@electron/remote/main';
 import telemetry from '@nordicsemiconductor/pc-nrfconnect-shared/src/telemetry/telemetry';
-import { app } from 'electron';
 
 import { migrateSourcesJson } from './apps/dataMigration/migrateSourcesJson';
 import { migrateSourcesVersionedJson } from './apps/dataMigration/migrateSourcesVersionedJson';
 import configureElectronApp from './configureElectronApp';
-import {
-    handleDeepLink,
-    handleDeepLinkFromArgv,
-    registerProtocolClient,
-} from './deepLink';
+import { handleDeepLinkFromArgv, registerDeepLinkHandling } from './deepLink';
 import initNrfUtilProxyEnv from './initNrfUtilProxyEnv';
 import registerIpcHandler from './registerIpcHandler';
 import singeInstanceLock from './singeInstanceLock';
@@ -26,15 +21,7 @@ import storeExecutablePath from './storeExecutablePath';
 
 telemetry.enableTelemetry();
 
-registerProtocolClient();
-
-// macOS (cold + warm)
-app.on('open-url', (event, url) => {
-    event.preventDefault();
-    handleDeepLink(url);
-});
-
-// Windows / Linux cold start (URL is in argv)
+registerDeepLinkHandling();
 handleDeepLinkFromArgv();
 
 initNrfUtilProxyEnv();

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -9,16 +9,33 @@ import './setUserDataDir';
 
 import { initialize as initializeElectronRemote } from '@electron/remote/main';
 import telemetry from '@nordicsemiconductor/pc-nrfconnect-shared/src/telemetry/telemetry';
+import { app } from 'electron';
 
 import { migrateSourcesJson } from './apps/dataMigration/migrateSourcesJson';
 import { migrateSourcesVersionedJson } from './apps/dataMigration/migrateSourcesVersionedJson';
 import configureElectronApp from './configureElectronApp';
+import {
+    findDeepLink,
+    handleDeepLink,
+    registerProtocolClient,
+} from './deepLink';
 import initNrfUtilProxyEnv from './initNrfUtilProxyEnv';
 import registerIpcHandler from './registerIpcHandler';
 import singeInstanceLock from './singeInstanceLock';
 import storeExecutablePath from './storeExecutablePath';
 
 telemetry.enableTelemetry();
+
+registerProtocolClient();
+
+// macOS (cold + warm)
+app.on('open-url', (event, url) => {
+    event.preventDefault();
+    handleDeepLink(url);
+});
+
+// Windows / Linux cold start (URL is in argv)
+handleDeepLink(findDeepLink(process.argv));
 
 initNrfUtilProxyEnv();
 singeInstanceLock();

--- a/src/main/registerIpcHandler.ts
+++ b/src/main/registerIpcHandler.ts
@@ -27,6 +27,7 @@ import * as artifactoryToken from '../ipc/artifactoryToken';
 import * as desktopShortcut from '../ipc/createDesktopShortcut';
 import * as jlink from '../ipc/jlink';
 import * as launcherUpdate from '../ipc/launcherUpdate';
+import * as openAppConfirmation from '../ipc/openAppConfirmation';
 import * as proxyLogin from '../ipc/proxyLogin';
 import * as sources from '../ipc/sources';
 import {
@@ -44,6 +45,7 @@ import createDesktopShortcut from './apps/createDesktopShortcut';
 import { addSource, removeSource } from './apps/sources/sourceChanges';
 import { getAllSources } from './apps/sources/sources';
 import { getTokenInformation, removeToken, setToken } from './artifactoryToken';
+import { answerOpenAppConfirmation } from './deepLink/openAppConfirmation';
 import { getJLinkState, installJLink } from './jlink';
 import {
     cancelUpdate,
@@ -108,6 +110,10 @@ export default () => {
 
     proxyLogin.forRenderer.registerAnswerProxyLoginRequest(
         callRegisteredCallback,
+    );
+
+    openAppConfirmation.forRenderer.registerAnswerOpenAppConfirmation(
+        answerOpenAppConfirmation,
     );
 
     launcherUpdate.forRenderer.registerCheckForUpdate(checkForUpdate);

--- a/src/main/singeInstanceLock.ts
+++ b/src/main/singeInstanceLock.ts
@@ -8,7 +8,7 @@ import { app } from 'electron/main';
 
 import argv from './argv';
 import { openInitialWindow } from './configureElectronApp';
-import { findDeepLink, handleDeepLink } from './deepLink';
+import { containsDeepLink, handleDeepLinkFromArgv } from './deepLink';
 
 export default () => {
     if (argv['new-instance']) {
@@ -23,14 +23,14 @@ export default () => {
         app.on(
             'second-instance',
             (_event, argvFromSecondInstance, _wd, message) => {
-                const link = findDeepLink(argvFromSecondInstance);
-                if (link) {
-                    handleDeepLink(link);
-                    return; // Don't open a new window if the second instance was launched with a deep link, just handle the link.
+                if (containsDeepLink(argvFromSecondInstance)) {
+                    handleDeepLinkFromArgv(argvFromSecondInstance);
+                } else {
+                    const parsed = JSON.parse(
+                        (message as { argv: string }).argv,
+                    );
+                    openInitialWindow(parsed);
                 }
-
-                const parsed = JSON.parse((message as { argv: string }).argv);
-                openInitialWindow(parsed);
             },
         );
     } else {

--- a/src/main/singeInstanceLock.ts
+++ b/src/main/singeInstanceLock.ts
@@ -8,6 +8,7 @@ import { app } from 'electron/main';
 
 import argv from './argv';
 import { openInitialWindow } from './configureElectronApp';
+import { findDeepLink, handleDeepLink } from './deepLink';
 
 export default () => {
     if (argv['new-instance']) {
@@ -19,10 +20,19 @@ export default () => {
     });
 
     if (isFirstInstance) {
-        app.on('second-instance', (_event, _args, _wd, message) => {
-            const args = (message as { argv: string }).argv;
-            openInitialWindow(JSON.parse(args) as typeof argv);
-        });
+        app.on(
+            'second-instance',
+            (_event, argvFromSecondInstance, _wd, message) => {
+                const link = findDeepLink(argvFromSecondInstance);
+                if (link) {
+                    handleDeepLink(link);
+                    return; // Don't open a new window if the second instance was launched with a deep link, just handle the link.
+                }
+
+                const parsed = JSON.parse((message as { argv: string }).argv);
+                openInitialWindow(parsed);
+            },
+        );
     } else {
         console.log(
             'Other instance already running. Bringing that to the front.',

--- a/src/main/singeInstanceLock.ts
+++ b/src/main/singeInstanceLock.ts
@@ -15,21 +15,16 @@ export default () => {
         return;
     }
 
-    const isFirstInstance = app.requestSingleInstanceLock({
-        argv: JSON.stringify(argv),
-    });
+    const isFirstInstance = app.requestSingleInstanceLock(argv);
 
     if (isFirstInstance) {
         app.on(
             'second-instance',
-            (_event, argvFromSecondInstance, _wd, message) => {
+            (_event, argvFromSecondInstance, _wd, parsedArgv) => {
                 if (containsDeepLink(argvFromSecondInstance)) {
                     handleDeepLinkFromArgv(argvFromSecondInstance);
                 } else {
-                    const parsed = JSON.parse(
-                        (message as { argv: string }).argv,
-                    );
-                    openInitialWindow(parsed);
+                    openInitialWindow(parsedArgv as typeof argv);
                 }
             },
         );

--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -53,9 +53,15 @@ export const openLauncherWindow = () => {
         }
         launcherWindow.show();
         launcherWindow.focus();
-    } else {
-        launcherWindow = createLauncherWindow();
+        return Promise.resolve(launcherWindow);
     }
+
+    launcherWindow = createLauncherWindow();
+    return new Promise<BrowserWindow>(resolve => {
+        launcherWindow?.webContents.once('did-finish-load', () =>
+            resolve(launcherWindow as BrowserWindow),
+        );
+    });
 };
 
 const keepPositionWithinBounds = ({ x, y, height, width }: WindowState) => {

--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -48,7 +48,11 @@ const appWindows: {
 
 export const openLauncherWindow = () => {
     if (launcherWindow) {
+        if (launcherWindow.isMinimized()) {
+            launcherWindow.restore();
+        }
         launcherWindow.show();
+        launcherWindow.focus();
     } else {
         launcherWindow = createLauncherWindow();
     }

--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -24,7 +24,7 @@ import {
     windowSizeLauncherKey,
     type WindowState,
 } from '../common/persistedStore';
-import { LOCAL } from '../common/sources';
+import { LOCAL, type SourceName } from '../common/sources';
 import {
     type AppSpec,
     hasFixedSize,
@@ -38,6 +38,7 @@ import { createWindow } from './browser';
 import bundledJlinkVersion from './bundledJlink';
 import { getBundledResourcePath } from './config';
 import { getAppIcon, getNrfConnectForDesktopIcon } from './icons';
+import { logger } from './log';
 
 let launcherWindow: BrowserWindow | undefined;
 const appWindows: {
@@ -252,6 +253,24 @@ export const openApp = (app: AppSpec, openAppOptions?: OpenAppOptions) => {
     } else {
         openDownloadableAppWindow(app, args);
     }
+};
+
+export const openInstalledApp = (
+    name: string,
+    source: SourceName,
+    args: string[],
+) => {
+    openLauncherWindow();
+    if (source === LOCAL) {
+        const local = getLocalApps(false).find(a => a.name === name);
+        if (local) return openAppWindow(local, args);
+    } else {
+        const app = getDownloadableApps().apps.find(
+            a => a.name === name && a.source === source,
+        );
+        if (app && isInstalled(app)) return openAppWindow(app, args);
+    }
+    logger.warn(`App "${name}" from source "${source}" is not installed`);
 };
 
 export const openDownloadableAppWindow = (appSpec: AppSpec, args: string[]) => {


### PR DESCRIPTION
Adds deep link support, allowing external links to open a specific app, optionally from a specific source (if one is not specified, the main source is used by default). It includes a confirmation dialog before opening an app (via deep link), and a dedicated deep link registration flow for Linux.

<img width="1077" height="942" alt="image" src="https://github.com/user-attachments/assets/660da9c1-a1ac-4616-8900-0c6e093a087c" />
